### PR TITLE
Darwin: fix initial window style

### DIFF
--- a/window_cocoa.odin
+++ b/window_cocoa.odin
@@ -101,6 +101,9 @@ cocoa_init :: proc(
 	s.window->setAcceptsMouseMovedEvents(true)
 	s.window->makeKeyAndOrderFront(nil)
 	s.window_handle = s.window
+
+	// for init onlny, ensure window_mode differs so set_window_mode actually applies the style
+	s.window_mode = .Borderless_Fullscreen if init_options.window_mode != .Borderless_Fullscreen else .Windowed
 	cocoa_set_window_mode(init_options.window_mode)
 
 	// Activate the application


### PR DESCRIPTION
Found a little bug: because Odin's enum zero value of `Window_Mode` is `.Windowed`, we weren't running the `cocoa_set_window_mode` because of the early exit. But it's nice to have that early exit while we're running, to prevent messing up the previous `windowed_rect`.

Meta question: How do you want to deal with little bugs like these? Quickly make PRs for them? Or fold this into the gamepad PR (which will take longer)?   Up to you.