### PR TITLE
Mac Handle Cmd-Q Terminate Message Gracefully

### DIFF
--- a/platform_mac.odin
+++ b/platform_mac.odin
@@ -145,6 +145,18 @@ mac_init :: proc(
 		}),
 	)
 
+	application_delegate := NS.application_delegate_register_and_alloc(
+		NS.ApplicationDelegateTemplate{
+			applicationShouldTerminate = proc(_: ^NS.Application) -> NS.ApplicationTerminateReply {
+				append(&s.events, Event_Close_Window_Requested{})
+				return .TerminateCancel
+			},
+		},
+		"Karl2DApplicationDelegate",
+		context,
+	)
+
+	s.app->setDelegate(application_delegate)
 
 	// Setup delegates for events not handled in mac_process_events
 	window_delegates := NS.window_delegate_register_and_alloc(


### PR DESCRIPTION
Fixes #56

Catches the terminate message on NSApplication and replies with cancel so the application can handle its own shutdown manually.