### PR TITLE
Fix for mac_set_screen_size

### DIFF
--- a/platform_bindings/mac/cocoa_extras/cocoa_extras.odin
+++ b/platform_bindings/mac/cocoa_extras/cocoa_extras.odin
@@ -17,3 +17,8 @@ Application_setPresentationOptions :: proc "c" (self: ^NS.Application, options: 
 Application_presentationOptions :: proc "c" (self: ^NS.Application) -> NS.ApplicationPresentationOptions {
 	return msgSend(NS.ApplicationPresentationOptions, self, "presentationOptions")
 }
+
+// NSWindow content size (sets the size of the content area, excluding decorations)
+Window_setContentSize :: proc "c" (self: ^NS.Window, size: NS.Size) {
+	msgSend(nil, self, "setContentSize:", size)
+}

--- a/platform_mac.odin
+++ b/platform_mac.odin
@@ -340,14 +340,7 @@ mac_set_window_position :: proc(x: int, y: int) {
 }
 
 mac_set_screen_size :: proc(w, h: int) {
-	frame := NS.Window_frame(s.window)
-	// Keep the top-left corner in place when resizing
-	new_y := frame.origin.y + frame.size.height - NS.Float(h)
-	new_frame := NS.Rect{
-		origin = {frame.origin.x, new_y},
-		size = {NS.Float(w), NS.Float(h)},
-	}
-	s.window->setFrame(new_frame, true)
+	ce.Window_setContentSize(s.window, {NS.Float(w), NS.Float(h)})
 }
 
 mac_get_window_scale :: proc() -> f32 {


### PR DESCRIPTION
#### Summary

- For mac we should be setting the content size (which doesn't include the decorations), not changing the frame size (which does include the decorations).
- For example, if you called `k2.set_screen_size(500, 400)`, you would actually only get (500, 378) or so.