### PR TITLE
Fix incorrect input format for OpenGL shaders when passing layout_formats

### DIFF
--- a/render_backend_gl.odin
+++ b/render_backend_gl.odin
@@ -611,8 +611,7 @@ gl_load_shader :: proc(vs_source: []byte, fs_source: []byte, desc_allocator := f
 				type = type,
 			}
 
-			input_format := get_shader_input_format(name, type)
-			format_size := pixel_format_size(input_format)
+			format_size := pixel_format_size(format)
 
 			stride += format_size
 		}


### PR DESCRIPTION
When calculating the stride the OpenGL renderer ignores the layout_formats passed by the user.