### PR TITLE
Fix override shader input index (OpenGL)

### DIFF
--- a/karl2d.odin
+++ b/karl2d.odin
@@ -2242,7 +2242,6 @@ batch_vertex :: proc(v: Vec2, uv: Vec2, color: Color) {
 	override_offset: int
 	for &input in shd.inputs {
 		o := &shd.input_overrides[input.register]
-		input := &shd.inputs[idx]
 		sz := pixel_format_size(input.format)
 
 		if o.used != 0 {


### PR DESCRIPTION
When using `override_shader_input` with OpenGL the register order is not guaranteed to match the attributes order, and it may even differ between PC. For example in my pc I need to call `override_shader_input(shader, 2, color)` to override the `from_color` while on my notebook it does not work, and I need to call with `override_shader_input(shader, 1, color)`.

This fix makes sure to always use the register value, meaning calling `override_shader_input(shader, 3, color)` would work the same for both computers (and other renderers)

<img width="1213" height="165" alt="image" src="https://github.com/user-attachments/assets/b0aee23f-63fb-4e23-9eb7-78dad05165a6" />

shader.inputs with OpenGL (my PC)

| i | Name | Register |
| - | --------- | ---- | 
| 0 | texcoord | 1 |
| 1 | color | 2 |
| 2 | from_color | 3 |
| 3 | to_color | 4 |
| 4 | position | 0 |

<img width="855" height="170" alt="image" src="https://github.com/user-attachments/assets/1ec7901f-c9cf-47b9-b711-299ac093ec4b" />


shader.inputs with Open GL (my Notebook)
| i | Name | Register |
| - | --------- | ---- | 
| 0 | color | 2 |
| 1 | from_color | 3 |
| 2 | position | 0 |
| 3 | texcoord | 1 |
| 4 | to_color | 4 |

<img width="685" height="210" alt="image" src="https://github.com/user-attachments/assets/f257f1eb-ebd7-417a-936a-fbf1c6f3c87c" />


For D33D11 it seems that it will always match:

shader.inputs with D3D11 (my PC)
| i | Name | Register |
| - | --------- | ---- | 
| 0 | position | 0 |
| 1 | texcoord | 1 |
| 2 | color | 2 |
| 3 | from_color | 3 |
| 4 | to_color | 4 |

shader.inputs with D3D11 (my Notebook)
| i | Name | Register |
| - | --------- | ---- | 
| 0 | position | 0 |
| 1 | texcoord | 1 |
| 2 | color | 2 |
| 3 | from_color | 3 |
| 4 | to_color | 4 |