### PR TITLE
Disallow 180 degree moves in snake example

### DIFF
--- a/examples/snake/snake.odin
+++ b/examples/snake/snake.odin
@@ -98,19 +98,19 @@ step :: proc() -> bool {
 		return false
 	}
 
-	if k2.key_is_held(.Up) || k2.gamepad_button_is_held(0, .Left_Face_Up) {
+	if (k2.key_is_held(.Up) || k2.gamepad_button_is_held(0, .Left_Face_Up)) && move_direction != {0, 1} {
 		move_direction = {0, -1}
 	}
 
-	if k2.key_is_held(.Down) || k2.gamepad_button_is_held(0, .Left_Face_Down) {
+	if (k2.key_is_held(.Down) || k2.gamepad_button_is_held(0, .Left_Face_Down)) && move_direction != {0, -1} {
 		move_direction = {0, 1}
 	}
 
-	if k2.key_is_held(.Left) || k2.gamepad_button_is_held(0, .Left_Face_Left) {
+	if (k2.key_is_held(.Left) || k2.gamepad_button_is_held(0, .Left_Face_Left)) && move_direction != {1, 0} {
 		move_direction = {-1, 0}
 	}
 
-	if k2.key_is_held(.Right) || k2.gamepad_button_is_held(0, .Left_Face_Right) {
+	if (k2.key_is_held(.Right) || k2.gamepad_button_is_held(0, .Left_Face_Right)) && move_direction != {-1, 0} {
 		move_direction = {1, 0}
 	}
 


### PR DESCRIPTION
Example: If you are moving left, no longer allow changing direction to right. (And for all other directions.)