### PR TITLE
Implement CoreAudio audio backend for macOS

### DIFF
--- a/audio_backend_chooser.odin
+++ b/audio_backend_chooser.odin
@@ -5,6 +5,9 @@ CONFIG_AUDIO_BACKEND_NAME :: #config(KARL2D_AUDIO_BACKEND, "")
 when ODIN_OS == .Windows {
 	DEFAULT_AUDIO_BACKEND_NAME :: "waveout"
 	AVAILABLE_AUDIO_BACKENDS :: "waveout, nil"
+} else when ODIN_OS == .Darwin {
+	DEFAULT_AUDIO_BACKEND_NAME :: "coreaudio"
+	AVAILABLE_AUDIO_BACKENDS :: "coreaudio, nil"
 } else when ODIN_OS == .JS {
 	DEFAULT_AUDIO_BACKEND_NAME :: "web_audio"
 	AVAILABLE_AUDIO_BACKENDS :: "web_audio, nil"
@@ -24,6 +27,8 @@ when CONFIG_AUDIO_BACKEND_NAME == "" {
 
 when AUDIO_BACKEND_NAME == "waveout" {
 	AUDIO_BACKEND :: AUDIO_BACKEND_WAVEOUT
+} else when AUDIO_BACKEND_NAME == "coreaudio" {
+	AUDIO_BACKEND :: AUDIO_BACKEND_COREAUDIO
 } else when AUDIO_BACKEND_NAME == "web_audio" {
 	AUDIO_BACKEND :: AUDIO_BACKEND_WEB_AUDIO
 } else when AUDIO_BACKEND_NAME == "alsa" {

--- a/audio_backend_coreaudio.odin
+++ b/audio_backend_coreaudio.odin
@@ -1,0 +1,154 @@
+#+build darwin
+#+vet explicit-allocators
+#+private file
+package karl2d
+
+@(private = "package")
+AUDIO_BACKEND_COREAUDIO :: Audio_Backend_Interface {
+	state_size         = coreaudio_state_size,
+	init               = coreaudio_init,
+	shutdown           = coreaudio_shutdown,
+	set_internal_state = coreaudio_set_internal_state,
+	feed               = coreaudio_feed,
+	remaining_samples  = coreaudio_remaining_samples,
+}
+
+import "base:runtime"
+import "core:time"
+import "log"
+import aq "platform_bindings/mac/audiotoolbox"
+
+NUM_BUFFERS :: 8
+
+CoreAudio_State :: struct {
+	queue:             aq.AudioQueueRef,
+	timeline:          aq.AudioQueueTimelineRef,
+	buffers:           [NUM_BUFFERS]aq.AudioQueueBufferRef,
+	buffer_busy:       [NUM_BUFFERS]bool,
+	cur_buffer:        int,
+	submitted_samples: int,
+}
+
+coreaudio_state_size :: proc() -> int {
+	return size_of(CoreAudio_State)
+}
+
+cs: ^CoreAudio_State
+
+coreaudio_init :: proc(state: rawptr, allocator: runtime.Allocator) {
+	cs = (^CoreAudio_State)(state)
+	log.debug("[coreaudio] Init audio backend coreaudio")
+
+	format := make_pcm_format(sample_rate = 44100.0, channels = 2, bits_per_channel = 32)
+
+	status := aq.AudioQueueNewOutput(&format, audio_queue_callback, cs, nil, nil, 0, &cs.queue)
+	if status != .NoErr {
+		log.errorf("[coreaudio] Failed to create audio queue. Error code: %v", status)
+		return
+	}
+
+	status = aq.AudioQueueCreateTimeline(cs.queue, &cs.timeline)
+	if status != .NoErr {
+		log.warnf("[coreaudio] Failed to create audio queue timeline. Error code: %v", status)
+		cs.timeline = nil
+	}
+
+	buffer_size := u32(AUDIO_MIX_CHUNK_SIZE * size_of(Audio_Sample))
+	for i in 0 ..< NUM_BUFFERS {
+		aq.AudioQueueAllocateBuffer(cs.queue, buffer_size, &cs.buffers[i])
+	}
+
+	if aq.AudioQueueStart(cs.queue, nil) != .NoErr {
+		log.errorf("[coreaudio] Failed to start audio queue. Error code: %v", status)
+		return
+	}
+}
+
+coreaudio_feed :: proc(samples: []Audio_Sample) {
+	if cs == nil || cs.queue == nil {
+		return
+	}
+
+	// sync wait
+	for cs.buffer_busy[cs.cur_buffer] {
+		time.sleep(1 * time.Millisecond)
+	}
+
+	buffer := cs.buffers[cs.cur_buffer]
+	copy_len := min(len(samples), AUDIO_MIX_CHUNK_SIZE)
+	byte_size := copy_len * size_of(Audio_Sample)
+
+	runtime.mem_copy(buffer.mAudioData, raw_data(samples), byte_size)
+	buffer.mAudioDataByteSize = u32(byte_size)
+	cs.buffer_busy[cs.cur_buffer] = true
+
+	if aq.AudioQueueEnqueueBuffer(cs.queue, buffer, 0, nil) == .NoErr {
+		cs.submitted_samples += copy_len
+		cs.cur_buffer = (cs.cur_buffer + 1) % NUM_BUFFERS
+	}
+}
+
+coreaudio_remaining_samples :: proc() -> int {
+	if cs == nil || cs.queue == nil {
+		return 0
+	}
+	timestamp: aq.AudioTimeStamp
+	discontinuity: bool
+
+	status := aq.AudioQueueGetCurrentTime(cs.queue, cs.timeline, &timestamp, &discontinuity)
+	if status == .NoErr && .Sample_Time_Valid in timestamp.mFlags {
+		return max(cs.submitted_samples - int(timestamp.mSampleTime), 0)
+	}
+
+	return 0
+}
+
+coreaudio_shutdown :: proc() {
+	if cs != nil && cs.queue != nil {
+		if cs.timeline != nil {
+			aq.AudioQueueDisposeTimeline(cs.queue, cs.timeline)
+			cs.timeline = nil
+		}
+		aq.AudioQueueStop(cs.queue, true)
+		aq.AudioQueueDispose(cs.queue, true)
+		cs.queue = nil
+	}
+}
+
+coreaudio_set_internal_state :: proc(state: rawptr) {
+	assert(state != nil)
+	cs = (^CoreAudio_State)(state)
+}
+
+audio_queue_callback :: proc "c" (
+	user_data: rawptr,
+	queue: aq.AudioQueueRef,
+	buffer: aq.AudioQueueBufferRef,
+) {
+	s := (^CoreAudio_State)(user_data)
+	for b, i in s.buffers {
+		if b == buffer {
+			s.buffer_busy[i] = false
+			return
+		}
+	}
+}
+
+make_pcm_format :: proc(
+	sample_rate: f64,
+	channels: u32,
+	bits_per_channel: u32,
+) -> aq.AudioStreamBasicDescription {
+	bytes_per_sample := bits_per_channel / 8
+	return aq.AudioStreamBasicDescription {
+		mSampleRate = sample_rate,
+		mFormatID = .Linear_PCM,
+		mFormatFlags = {.Is_Float, .Is_Packed},
+		mBytesPerPacket = bytes_per_sample * channels,
+		mFramesPerPacket = 1,
+		mBytesPerFrame = bytes_per_sample * channels,
+		mChannelsPerFrame = channels,
+		mBitsPerChannel = bits_per_channel,
+		mReserved = 0,
+	}
+}

--- a/platform_bindings/mac/audiotoolbox/audiotoolbox.odin
+++ b/platform_bindings/mac/audiotoolbox/audiotoolbox.odin
@@ -1,0 +1,134 @@
+#+build darwin
+
+package karl2d_darwin_audiotoolbox
+
+foreign import AudioToolbox "system:AudioToolbox.framework"
+
+OSStatus :: distinct i32
+
+Audio_Queue_Error :: enum i32 {
+	NoErr                  = 0,
+	Invalid_Buffer         = -66687,
+	Buffer_Empty           = -66686,
+	Disposal_Pending       = -66685,
+	Invalid_Property       = -66684,
+	Invalid_Property_Size  = -66683,
+	Invalid_Parameter      = -66682,
+	Cannot_Start           = -66681,
+	Invalid_Device         = -66680,
+	Buffer_In_Queue        = -66679,
+	Invalid_Run_State      = -66678,
+	Invalid_Queue_Type     = -66677,
+	Permissions            = -66676,
+	Invalid_Property_Value = -66675,
+	Prime_Timed_Out        = -66674,
+	Codec_Not_Found        = -66673,
+	Invalid_Codec_Access   = -66672,
+	Queue_Invalidated      = -66671,
+	Too_Many_Taps          = -66670,
+	Invalid_Tap_Context    = -66669,
+	Record_Underrun        = -66668,
+	Invalid_Tap_Type       = -66667,
+	Buffer_Enqueued_Twice  = -66666,
+	Enqueue_During_Reset   = -66632,
+	Invalid_Offline_Mode   = -66626,
+}
+
+Audio_Format_ID :: enum u32 {
+	Linear_PCM = 0x6C70636D, // 'lpcm'
+}
+
+PCM_Flag :: enum u32 {
+	Is_Float           = 0,
+	Is_Big_Endian      = 1,
+	Is_Signed_Integer  = 2,
+	Is_Packed          = 3,
+	Is_Aligned_High    = 4,
+	Is_Non_Interleaved = 5,
+	Is_Non_Mixable     = 6,
+}
+PCM_Flags :: bit_set[PCM_Flag;u32]
+
+Audio_Timestamp_Flag :: enum u32 {
+	Sample_Time_Valid     = 0,
+	Host_Time_Valid       = 1,
+	Rate_Scalar_Valid     = 2,
+	Word_Clock_Time_Valid = 3,
+	SMPTE_Time_Valid      = 4,
+}
+Audio_Timestamp_Flags :: bit_set[Audio_Timestamp_Flag;u32]
+
+Audio_Queue_Property :: enum u32 {
+	Is_Running = 0x6171726E, // 'aqrn'
+}
+
+AudioStreamBasicDescription :: struct {
+	mSampleRate:       f64,
+	mFormatID:         Audio_Format_ID,
+	mFormatFlags:      PCM_Flags,
+	mBytesPerPacket:   u32,
+	mFramesPerPacket:  u32,
+	mBytesPerFrame:    u32,
+	mChannelsPerFrame: u32,
+	mBitsPerChannel:   u32,
+	mReserved:         u32,
+}
+
+AudioQueueRef :: distinct rawptr
+
+AudioQueueBuffer :: struct {
+	mAudioDataBytesCapacity:            u32,
+	mAudioData:                         rawptr,
+	mAudioDataByteSize:                 u32,
+	mUserData:                          rawptr,
+	mPacketDescriptionCapacity:         u32,
+	mPacketDescriptions:                rawptr,
+	mPacketDescriptionCount:            u32,
+	mReserved1, mReserved2, mReserved3: u32,
+}
+
+AudioQueueBufferRef :: ^AudioQueueBuffer
+
+AudioQueueOutputCallback :: #type proc "c" (
+	inUserData: rawptr,
+	inAQ: AudioQueueRef,
+	inBuffer: AudioQueueBufferRef,
+)
+
+AudioQueueTimelineRef :: distinct rawptr
+
+SMPTETime :: struct {
+	mSubframes:                          i16,
+	mSubframeDivisor:                    i16,
+	mCounter:                            u32,
+	mType:                               u32,
+	mFlags:                              u32,
+	mHours, mMinutes, mSeconds, mFrames: i16,
+}
+
+AudioTimeStamp :: struct {
+	mSampleTime:    f64,
+	mHostTime:      u64,
+	mRateScalar:    f64,
+	mWordClockTime: u64,
+	mSMPTETime:     SMPTETime,
+	mFlags:         Audio_Timestamp_Flags,
+	mReserved:      u32,
+}
+
+@(default_calling_convention = "c")
+foreign AudioToolbox {
+	AudioQueueNewOutput :: proc(inFormat: ^AudioStreamBasicDescription, inCallbackProc: AudioQueueOutputCallback, inUserData: rawptr, inCallbackRunLoop: rawptr, inCallbackRunLoopMode: rawptr, inFlags: u32, outAQ: ^AudioQueueRef) -> Audio_Queue_Error ---
+	AudioQueueDispose :: proc(inAQ: AudioQueueRef, inImmediate: bool) -> Audio_Queue_Error ---
+	AudioQueueAllocateBuffer :: proc(inAQ: AudioQueueRef, inBufferByteSize: u32, outBuffer: ^AudioQueueBufferRef) -> Audio_Queue_Error ---
+	AudioQueueFreeBuffer :: proc(inAQ: AudioQueueRef, inBuffer: AudioQueueBufferRef) -> Audio_Queue_Error ---
+	AudioQueueEnqueueBuffer :: proc(inAQ: AudioQueueRef, inBuffer: AudioQueueBufferRef, inNumPacketDescs: u32, inPacketDescs: rawptr) -> Audio_Queue_Error ---
+	AudioQueueStart :: proc(inAQ: AudioQueueRef, inStartTime: ^AudioTimeStamp) -> Audio_Queue_Error ---
+	AudioQueueStop :: proc(inAQ: AudioQueueRef, inImmediate: bool) -> Audio_Queue_Error ---
+	AudioQueuePause :: proc(inAQ: AudioQueueRef) -> Audio_Queue_Error ---
+	AudioQueueGetProperty :: proc(inAQ: AudioQueueRef, inID: Audio_Queue_Property, outData: rawptr, ioDataSize: ^u32) -> Audio_Queue_Error ---
+	AudioQueueSetProperty :: proc(inAQ: AudioQueueRef, inID: Audio_Queue_Property, inData: rawptr, inDataSize: u32) -> Audio_Queue_Error ---
+	AudioQueueCreateTimeline :: proc(inAQ: AudioQueueRef, outTimeline: ^AudioQueueTimelineRef) -> Audio_Queue_Error ---
+	AudioQueueDisposeTimeline :: proc(inAQ: AudioQueueRef, inTimeline: AudioQueueTimelineRef) -> Audio_Queue_Error ---
+	AudioQueueGetCurrentTime :: proc(inAQ: AudioQueueRef, inTimeline: AudioQueueTimelineRef, outTimeStamp: ^AudioTimeStamp, outTimelineDiscontinuity: ^bool) -> Audio_Queue_Error ---
+}


### PR DESCRIPTION
Implement CoreAudio audio backend for macOS using the AudioToolbox framework.

I'm new to this so wouldn't want to merge unless someone with experience had reviewed it.