### PR TITLE
Clone strings used in shader.texture_lookup

### DIFF
--- a/karl2d.odin
+++ b/karl2d.odin
@@ -3017,7 +3017,7 @@ load_shader_from_bytes :: proc(
 	}
 
 	for tbp, tbp_idx in desc.texture_bindpoints {
-		shd.texture_lookup[tbp.name] = tbp_idx
+		shd.texture_lookup[strings.clone(tbp.name, s.allocator)] = tbp_idx
 
 		if tbp.name == "tex" {
 			shd.default_texture_index = tbp_idx
@@ -3052,7 +3052,12 @@ destroy_shader :: proc(shader: Shader) {
 
 	delete(shader.constants_data, a)
 	delete(shader.constants, a)
+
+	for k, _ in shader.texture_lookup {
+		delete(k, a)
+	}
 	delete(shader.texture_lookup)
+
 	delete(shader.texture_bindpoints, a)
 
 	for k, _ in shader.constant_lookup {


### PR DESCRIPTION
When loading shaders, make sure that we clone strings used in the `texture_lookup` keys, similar to what is done with `constant_lookup`.

Noticed this because when I started using `texture_lookup` it crashed when doing hotreload.

---

## Rules Checklist

You can always submit a draft pull request. But when you make your Pull Request "ready for review", then please make sure these rules are followed (put an x between each [ ]):
- [x] Make sure that the code you submit is working and tested.
- [x] Do not submit "basic" or "rudimentary" code that needs further work to actually be finished. Finish the code to the best of your abilities.
- [x] Do not modify any code that is unrelated to your changes. That just makes reviewing your code harder: I'll have a hard time seeing what you actually did. Do not use auto formatters such as odinfmt.
- [x] If you used an LLM to generate any code, then make that you understand every single line. In other words: No form of "vibe coded" PRs are allowed.
- [x] If you commit changes that were unintended, just do additional commits that undo them. Don't worry about polluting the commit history: I will do a "squash merge" of your Pull Request. Just make sure that the diff in the "Files changed" tab looks tidy.
- [x] If the GitHub testing action complain about the `karl2d.doc.odin` file being out-of-date, then please regenerate it by running `odin run tools/api_doc_builder`. This way you'll have an easier time seeing if you've made changes to the user-facing API.
- [x] Make sure that the code follows the same style as in `karl2d.odin`:
	- Please look through that file and pay attention to how characters such as `:` `=`, `(` `{` etc are placed.
	- Use tabs, not spaces.
	- Lines cannot be longer than 100 characters. See the `init` proc in `karl2d.odin` for an example of how to split up procedure signatures that are too long. That proc also shows how to write API comments. Use a ruler in your editor to make it easy to spot long lines.