### PR TITLE
Skip gamepad events with REPEAT flag.

### DIFF
--- a/platform_windows.odin
+++ b/platform_windows.odin
@@ -132,6 +132,10 @@ windows_get_events :: proc(events: ^[dynamic]Event) {
 		for win32.XInputGetKeystroke(win32.XUSER(gamepad), 0, &gp_event) == .SUCCESS {
 			button: Maybe(Gamepad_Button)
 
+			if .REPEAT in gp_event.Flags {
+				continue
+			}
+
 			#partial switch gp_event.VirtualKey {
 			case .DPAD_UP:    button = .Left_Face_Up
 			case .DPAD_DOWN:  button = .Left_Face_Down


### PR DESCRIPTION
When holding a single button,  the pressed event was being triggered repeatedly. This fixes the issue.

This seems to be what RGFW does too (at least the 1.7 version) https://github.com/ColleagueRiley/RGFW/blob/bca4c86e6ac19ae7f82b78303830c1484f41c4f2/RGFW.h#L6817

---

## Rules Checklist

You can always submit a draft pull request. But when you make your Pull Request "ready for review", then please make sure these rules are followed (put an x between each [ ]):
- [X] Make sure that the code you submit is working and tested.
- [X] Do not submit "basic" or "rudimentary" code that needs further work to actually be finished. Finish the code to the best of your abilities.
- [X] Do not modify any code that is unrelated to your changes. That just makes reviewing your code harder: I'll have a hard time seeing what you actually did. Do not use auto formatters such as odinfmt.
- [X] If you used an LLM to generate any code, then make that you understand every single line. In other words: No form of "vibe coded" PRs are allowed.
- [X] If you commit changes that were unintended, just do additional commits that undo them. Don't worry about polluting the commit history: I will do a "squash merge" of your Pull Request. Just make sure that the diff in the "Files changed" tab looks tidy.
- [X] If the GitHub testing action complain about the `karl2d.doc.odin` file being out-of-date, then please regenerate it by running `odin run tools/api_doc_builder`. This way you'll have an easier time seeing if you've made changes to the user-facing API.
- [X] Make sure that the code follows the same style as in `karl2d.odin`:
	- Please look through that file and pay attention to how characters such as `:` `=`, `(` `{` etc are placed.
	- Use tabs, not spaces.
	- Lines cannot be longer than 100 characters. See the `init` proc in `karl2d.odin` for an example of how to split up procedure signatures that are too long. That proc also shows how to write API comments. Use a ruler in your editor to make it easy to spot long lines.
