### PR TITLE
draw_texture_XXX API finalization pass + draw_text rotation

### DIFF
--- a/examples/audio/audio.odin
+++ b/examples/audio/audio.odin
@@ -161,9 +161,10 @@ step :: proc() -> bool {
 		),
 		{20, 20},
 		40,
+		k2.BLACK,
 	)
-	k2.draw_text("Press Space to play a familiar sound.", {20, 200}, 40)
-	k2.draw_text("Press Enter to also play a 1 second 440 hz sine wave.", {20, 240}, 40)
+	k2.draw_text("Press Space to play a familiar sound.", {20, 200}, 40, k2.BLACK)
+	k2.draw_text("Press Enter to also play a 1 second 440 hz sine wave.", {20, 240}, 40, k2.BLACK)
 	k2.present()
 	free_all(context.temp_allocator)
 

--- a/examples/basics/basics.odin
+++ b/examples/basics/basics.odin
@@ -82,10 +82,10 @@ step :: proc() -> bool {
 
 	// k2.color_alpha takes a pre-defined color and replaces the alpha (transparency).
 	k2.draw_rect({4, 95, msg2_width+20, 162}, k2.color_alpha(k2.DARK_GRAY, 192))
-	k2.draw_text("Hellöpe!", {15, 105}, 48, color = k2.LIGHT_RED)
+	k2.draw_text("Hellöpe!", {15, 105}, 48, k2.LIGHT_RED)
 
-	k2.draw_text(msg1, {15, 153}, 48, color = k2.ORANGE)
-	k2.draw_text(msg2, {15, 201}, 48, color = k2.LIGHT_PURPLE)
+	k2.draw_text(msg1, {15, 153}, 48, k2.ORANGE)
+	k2.draw_text(msg2, {15, 201}, 48, k2.LIGHT_PURPLE)
 
 	k2.draw_text("Move the red dot using arrow keys!", {10, f32(k2.get_screen_height()) - 50}, 40)
 

--- a/examples/basics/basics.odin
+++ b/examples/basics/basics.odin
@@ -83,10 +83,10 @@ step :: proc() -> bool {
 
 	// k2.color_alpha takes a pre-defined color and replaces the alpha (transparency).
 	k2.draw_rect({4, 95, msg2_width+20, 162}, k2.color_alpha(k2.DARK_GRAY, 192))
-	k2.draw_text("Hellöpe!", {15, 105}, 48, color = k2.LIGHT_RED)
+	k2.draw_text("Hellöpe!", {15, 105}, 48, k2.LIGHT_RED)
 
-	k2.draw_text(msg1, {15, 153}, 48, color = k2.ORANGE)
-	k2.draw_text(msg2, {15, 201}, 48, color = k2.LIGHT_PURPLE)
+	k2.draw_text(msg1, {15, 153}, 48, k2.ORANGE)
+	k2.draw_text(msg2, {15, 201}, 48, k2.LIGHT_PURPLE)
 
 	k2.draw_text(
 		"Move the red dot using arrow keys!",

--- a/examples/basics/basics.odin
+++ b/examples/basics/basics.odin
@@ -53,19 +53,17 @@ step :: proc() -> bool {
 	t := k2.get_time()
 	pos_x := f32(math.sin(t)*200)
 	rot := f32(t*1.5)
-	tex_source_rect := k2.get_texture_rect(tex)
-	tex_into_rect := k2.Rect{
-		pos_x + 600, 450,
-		tex_source_rect.w*3, tex_source_rect.h*3,
-	}
 
+	tex_fit_into := k2.Rect{
+		pos_x + 600, 450,
+		f32(tex.width*3), f32(tex.height*3),
+	}
 
 	k2.draw_texture_fit(
 		tex,
-		tex_into_rect,
-		tex_source_rect,
-		{tex_into_rect.w/2, tex_into_rect.h/2},
-		rot,
+		tex_fit_into,
+		origin = {tex_fit_into.w/2, tex_fit_into.h/2},
+		rotation = rot,
 	)
 
 	k2.draw_rect({10, 10, 60, 60}, k2.GREEN)

--- a/examples/basics/basics.odin
+++ b/examples/basics/basics.odin
@@ -53,14 +53,18 @@ step :: proc() -> bool {
 	t := k2.get_time()
 	pos_x := f32(math.sin(t)*200)
 	rot := f32(t*1.5)
-	tex_rect := k2.get_texture_rect(tex)
-	tex_rect_dst := k2.Rect{pos_x + 600, 450, tex_rect.w*3, tex_rect.h*3}
+	tex_source_rect := k2.get_texture_rect(tex)
+	tex_into_rect := k2.Rect{
+		pos_x + 600, 450,
+		tex_source_rect.w*3, tex_source_rect.h*3,
+	}
 
-	k2.draw_texture_ex(
+
+	k2.draw_texture_fit(
 		tex,
-		tex_rect,
-		tex_rect_dst,
-		{tex_rect_dst.w/2, tex_rect_dst.h/2},
+		tex_into_rect,
+		tex_source_rect,
+		{tex_into_rect.w/2, tex_into_rect.h/2},
 		rot,
 	)
 
@@ -78,10 +82,10 @@ step :: proc() -> bool {
 
 	// k2.color_alpha takes a pre-defined color and replaces the alpha (transparency).
 	k2.draw_rect({4, 95, msg2_width+20, 162}, k2.color_alpha(k2.DARK_GRAY, 192))
-	k2.draw_text("Hellöpe!", {15, 105}, 48, k2.LIGHT_RED)
+	k2.draw_text("Hellöpe!", {15, 105}, 48, color = k2.LIGHT_RED)
 
-	k2.draw_text(msg1, {15, 153}, 48, k2.ORANGE)
-	k2.draw_text(msg2, {15, 201}, 48, k2.LIGHT_PURPLE)
+	k2.draw_text(msg1, {15, 153}, 48, color = k2.ORANGE)
+	k2.draw_text(msg2, {15, 201}, 48, color = k2.LIGHT_PURPLE)
 
 	k2.draw_text("Move the red dot using arrow keys!", {10, f32(k2.get_screen_height()) - 50}, 40)
 

--- a/examples/basics/basics.odin
+++ b/examples/basics/basics.odin
@@ -54,15 +54,18 @@ step :: proc() -> bool {
 	pos_x := f32(math.sin(t)*200)
 	rot := f32(t*1.5)
 
-	tex_fit_into := k2.Rect{
+	tex_src := k2.get_texture_rect(tex)
+
+	tex_dest := k2.Rect{
 		pos_x + 600, 450,
-		f32(tex.width*3), f32(tex.height*3),
+		tex_src.w*3, tex_src.h*3,
 	}
 
 	k2.draw_texture_fit(
 		tex,
-		tex_fit_into,
-		origin = {tex_fit_into.w/2, tex_fit_into.h/2},
+		tex_src,
+		tex_dest,
+		origin = {tex_dest.w/2, tex_dest.h/2},
 		rotation = rot,
 	)
 
@@ -85,7 +88,12 @@ step :: proc() -> bool {
 	k2.draw_text(msg1, {15, 153}, 48, color = k2.ORANGE)
 	k2.draw_text(msg2, {15, 201}, 48, color = k2.LIGHT_PURPLE)
 
-	k2.draw_text("Move the red dot using arrow keys!", {10, f32(k2.get_screen_height()) - 50}, 40)
+	k2.draw_text(
+		"Move the red dot using arrow keys!",
+		{10, f32(k2.get_screen_height()) - 50},
+		40,
+		k2.BLACK,
+	)
 
 	k2.present()
 

--- a/examples/basics/basics.odin
+++ b/examples/basics/basics.odin
@@ -80,10 +80,10 @@ step :: proc() -> bool {
 
 	// k2.color_alpha takes a pre-defined color and replaces the alpha (transparency).
 	k2.draw_rect({4, 95, msg2_width+20, 162}, k2.color_alpha(k2.DARK_GRAY, 192))
-	k2.draw_text("Hellöpe!", {15, 105}, 48, k2.LIGHT_RED)
+	k2.draw_text("Hellöpe!", {15, 105}, 48, color = k2.LIGHT_RED)
 
-	k2.draw_text(msg1, {15, 153}, 48, k2.ORANGE)
-	k2.draw_text(msg2, {15, 201}, 48, k2.LIGHT_PURPLE)
+	k2.draw_text(msg1, {15, 153}, 48, color = k2.ORANGE)
+	k2.draw_text(msg2, {15, 201}, 48, color = k2.LIGHT_PURPLE)
 
 	k2.draw_text("Move the red dot using arrow keys!", {10, f32(k2.get_screen_height()) - 50}, 40)
 

--- a/examples/box2d/karl2d_box2d.odin
+++ b/examples/box2d/karl2d_box2d.odin
@@ -121,7 +121,7 @@ step :: proc() -> bool {
 		r := b2.Body_GetRotation(b)
 		rot := math.atan2(r.s, r.c)
 		// Y position is flipped because raylib has Y down and box2d has Y up.
-		k2.draw_rect_ex({position.x, -position.y, 40, 40}, {20, 20}, rot, k2.BROWN)
+		k2.draw_rect({position.x, -position.y, 40, 40}, k2.BROWN, {20, 20}, rot)
 	}
 
 	k2.draw_circle(pos, 40, k2.RED)

--- a/examples/custom_frame_update/custom_frame_update.odin
+++ b/examples/custom_frame_update/custom_frame_update.odin
@@ -33,7 +33,7 @@ main :: proc() {
 
 		// Draw things
 		k2.clear(k2.BLUE)
-		k2.draw_text(fmt.tprintf("Hellope! Time: %.3f s", k2.get_time()), {10, 10}, 50)
+		k2.draw_text(fmt.tprintf("Hellope! Time: %.3f s", k2.get_time()), {10, 10}, 50, k2.BLACK)
 
 		// Present what we drew to the user.
 		k2.present()

--- a/examples/dual_grid_tilemap/dual_grid_tilemap.odin
+++ b/examples/dual_grid_tilemap/dual_grid_tilemap.odin
@@ -132,31 +132,27 @@ step :: proc() -> bool {
 		tx := txty.x
 		ty := txty.y
 
-		src := k2.Rect {
+		crop := k2.Rect {
 			x = f32(tx) * TILE_SIZE,
 			y = f32(ty) * TILE_SIZE,
 			w = TILE_SIZE,
 			h = TILE_SIZE,
 		}
 
-		dst := k2.Rect {
-			// Note the half-tile offset here: This is what "undoes" the half-tile offset that dual
-			// tile grids need.
-			x = f32(x) * TILE_SIZE - TILE_SIZE/2,
-			y = f32(y) * TILE_SIZE - TILE_SIZE/2,
-			w = TILE_SIZE,
-			h = TILE_SIZE,
+		// Note the half-tile offset here: This is what "undoes" the half-tile offset that dual
+		// tile grids need.
+		pos := k2.Vec2 {
+			f32(x) * TILE_SIZE - TILE_SIZE/2,
+			f32(y) * TILE_SIZE - TILE_SIZE/2,
 		}
 
 		// Always draw "grass" below the tile, as they have transparent pixels.
-		k2.draw_rect(dst, k2.LIGHT_GREEN)
+		k2.draw_rect(k2.rect_from_pos_size(pos, {TILE_SIZE, TILE_SIZE}), k2.LIGHT_GREEN)
 
-		k2.draw_texture_ex(
+		k2.draw_texture(
 			tileset_path_texture,
-			src,
-			dst,
-			{},
-			0,
+			pos,
+			crop,
 		)
 	}
 

--- a/examples/dual_grid_tilemap/dual_grid_tilemap.odin
+++ b/examples/dual_grid_tilemap/dual_grid_tilemap.odin
@@ -132,7 +132,7 @@ step :: proc() -> bool {
 		tx := txty.x
 		ty := txty.y
 
-		crop := k2.Rect {
+		tile_rect := k2.Rect {
 			x = f32(tx) * TILE_SIZE,
 			y = f32(ty) * TILE_SIZE,
 			w = TILE_SIZE,
@@ -149,10 +149,10 @@ step :: proc() -> bool {
 		// Always draw "grass" below the tile, as they have transparent pixels.
 		k2.draw_rect(k2.rect_from_pos_size(pos, {TILE_SIZE, TILE_SIZE}), k2.LIGHT_GREEN)
 
-		k2.draw_texture(
+		k2.draw_texture_section(
 			tileset_path_texture,
+			tile_rect,
 			pos,
-			crop,
 		)
 	}
 

--- a/examples/events/events.odin
+++ b/examples/events/events.odin
@@ -39,12 +39,12 @@ main :: proc() {
 		}
 
 		k2.clear(k2.LIGHT_BLUE)
-		k2.draw_text(fmt.tprintf("Left mouse button pressed %v times", num_mouse_clicks), {10, 10}, 50)
-		k2.draw_text(fmt.tprintf("%v latest events:", MAX_HISTORY), {10, 100}, 40)
+		k2.draw_text(fmt.tprintf("Left mouse button pressed %v times", num_mouse_clicks), {10, 10}, 50, k2.BLACK)
+		k2.draw_text(fmt.tprintf("%v latest events:", MAX_HISTORY), {10, 100}, 40, k2.BLACK)
 		y_pos := f32(145)
 
 		#reverse for te in event_history {
-			k2.draw_text(fmt.tprint(te), {10, y_pos}, 30)
+			k2.draw_text(fmt.tprint(te), {10, y_pos}, 30, k2.BLACK)
 			y_pos += 35
 		}
 

--- a/examples/fonts/fonts.odin
+++ b/examples/fonts/fonts.odin
@@ -23,16 +23,16 @@ step :: proc() -> bool {
 	
 	k2.clear(k2.BLUE)
 
-	font := k2.get_default_font() 
+	font := k2.FONT_DEFAULT
 
 	if k2.key_is_held(.K) {
 		font = cat_and_onion_font
 	}
 
 	msg := "Hellöpe! Hold K to swap font.\nLine breaks work too!"
-	k2.draw_text_ex(font, msg, {20, 20}, 64, k2.WHITE)
+	k2.draw_text(msg, {20, 20}, 64, k2.WHITE, font)
 
-	size := k2.measure_text_ex(font, msg, 64)
+	size := k2.measure_text(msg, 64, font)
 	size_msg := fmt.tprintf("The text above uses %.1f x %.1f pixels of space", size.x, size.y)
 
 	k2.draw_text(size_msg, {20, 200}, 32)

--- a/examples/fonts/fonts.odin
+++ b/examples/fonts/fonts.odin
@@ -30,7 +30,7 @@ step :: proc() -> bool {
 	}
 
 	msg := "Hellöpe! Hold K to swap font.\nLine breaks work too!"
-	k2.draw_text(msg, {20, 20}, 64, k2.WHITE, font)
+	k2.draw_text(msg, {20, 20}, 64, font, k2.WHITE)
 
 	size := k2.measure_text(msg, 64, font)
 	size_msg := fmt.tprintf("The text above uses %.1f x %.1f pixels of space", size.x, size.y)

--- a/examples/fonts/fonts.odin
+++ b/examples/fonts/fonts.odin
@@ -30,12 +30,26 @@ step :: proc() -> bool {
 	}
 
 	msg := "Hellöpe! Hold K to swap font.\nLine breaks work too!"
-	k2.draw_text(msg, {20, 20}, 64, font, k2.WHITE)
+	k2.draw_text(msg, {20, 20}, 64, k2.WHITE, font)
 
 	size := k2.measure_text(msg, 64, font)
 	size_msg := fmt.tprintf("The text above uses %.1f x %.1f pixels of space", size.x, size.y)
 
-	k2.draw_text(size_msg, {20, 200}, 32)
+	k2.draw_text(size_msg, {20, 200}, 32, k2.BLACK)
+
+	ROTATING_TEXT :: "rotating text!"
+	ROTATING_TEXT_SIZE :: 50
+
+	rotating_text_origin := k2.measure_text(ROTATING_TEXT, ROTATING_TEXT_SIZE, font) * 0.5
+	k2.draw_text(
+		ROTATING_TEXT,
+		{400, 400},
+		ROTATING_TEXT_SIZE,
+		k2.YELLOW,
+		font,
+		rotating_text_origin,
+		f32(k2.get_time()),
+	)
 
 	k2.present()
 	free_all(context.temp_allocator)

--- a/examples/gamepad/gamepad.odin
+++ b/examples/gamepad/gamepad.odin
@@ -36,8 +36,8 @@ gamepad_demo :: proc(gamepad: k2.Gamepad_Index, offset: k2.Vec2) {
 	k2.draw_circle(o + {300+50, 140}, 10, button_color(g, .Right_Face_Left))
 	k2.draw_circle(o + {340+50, 140}, 10, button_color(g, .Right_Face_Right))
 
-	k2.draw_rect_vec(o + {250 - 30, 140}, {20, 10}, button_color(g, .Middle_Face_Left))
-	k2.draw_rect_vec(o + {250 + 10, 140}, {20, 10}, button_color(g, .Middle_Face_Right))
+	k2.draw_rect(k2.rect_from_pos_size(o + {250 - 30, 140}, {20, 10}), button_color(g, .Middle_Face_Left))
+	k2.draw_rect(k2.rect_from_pos_size(o + {250 + 10, 140}, {20, 10}), button_color(g, .Middle_Face_Right))
 
 	left_stick := k2.Vec2 {
 		k2.get_gamepad_axis(gamepad, .Left_Stick_X),
@@ -54,11 +54,11 @@ gamepad_demo :: proc(gamepad: k2.Gamepad_Index, offset: k2.Vec2) {
 
 	k2.set_gamepad_vibration(gamepad, left_trigger, right_trigger)
 
-	k2.draw_rect_vec(o + {80, 50}, {20, 10}, button_color(g, .Left_Shoulder))
-	k2.draw_rect_vec(o + {50, 50} + {0, left_trigger * 20}, {20, 10}, button_color(g, .Left_Trigger, k2.WHITE, k2.GRAY))
+	k2.draw_rect(k2.rect_from_pos_size(o + {80, 50}, {20, 10}), button_color(g, .Left_Shoulder))
+	k2.draw_rect(k2.rect_from_pos_size(o + {50, 50} + {0, left_trigger * 20}, {20, 10}), button_color(g, .Left_Trigger, k2.WHITE, k2.GRAY))
 
-	k2.draw_rect_vec(o + {420, 50}, {20, 10}, button_color(g, .Right_Shoulder))
-	k2.draw_rect_vec(o + {450, 50} + {0, right_trigger * 20}, {20, 10}, button_color(g, .Right_Trigger, k2.WHITE, k2.GRAY))
+	k2.draw_rect(k2.rect_from_pos_size(o + {420, 50}, {20, 10}), button_color(g, .Right_Shoulder))
+	k2.draw_rect(k2.rect_from_pos_size(o + {450, 50} + {0, right_trigger * 20}, {20, 10}), button_color(g, .Right_Trigger, k2.WHITE, k2.GRAY))
 	k2.draw_circle(o + {200, 200} + 20 * left_stick, 20, button_color(g, .Left_Stick_Press, k2.WHITE, k2.GRAY))
 	k2.draw_circle(o + {300, 200} + 20 * right_stick, 20, button_color(g, .Right_Stick_Press, k2.WHITE, k2.GRAY))
 }

--- a/examples/gamepad/gamepad.odin
+++ b/examples/gamepad/gamepad.odin
@@ -7,13 +7,13 @@ gamepad_demo :: proc(gamepad: k2.Gamepad_Index, offset: k2.Vec2) {
 	if !k2.is_gamepad_active(gamepad) {
 		title := fmt.tprintf("Gamepad %v (not connected)", gamepad + 1)
 		ts := k2.measure_text(title, 30)
-		k2.draw_text(title, offset + {250, 60} - {ts.x/2, 0}, 30, k2.WHITE)
+		k2.draw_text(title, offset + {250, 60} - {ts.x/2, 0}, 30, color = k2.WHITE)
 		return
 	}
 
 	title := fmt.tprintf("Gamepad %v", gamepad + 1)
 	ts := k2.measure_text(title, 30)
-	k2.draw_text(title, offset + {250, 60} - {ts.x/2, 0}, 30, k2.WHITE)
+	k2.draw_text(title, offset + {250, 60} - {ts.x/2, 0}, 30, color = k2.WHITE)
 
 	button_color :: proc(
 		gamepad: k2.Gamepad_Index,
@@ -36,8 +36,8 @@ gamepad_demo :: proc(gamepad: k2.Gamepad_Index, offset: k2.Vec2) {
 	k2.draw_circle(o + {300+50, 140}, 10, button_color(g, .Right_Face_Left))
 	k2.draw_circle(o + {340+50, 140}, 10, button_color(g, .Right_Face_Right))
 
-	k2.draw_rect(k2.rect_from_pos_size(o + {250 - 30, 140}, {20, 10}), button_color(g, .Middle_Face_Left))
-	k2.draw_rect(k2.rect_from_pos_size(o + {250 + 10, 140}, {20, 10}), button_color(g, .Middle_Face_Right))
+	k2.draw_rect_vec(o + {250 - 30, 140}, {20, 10}, button_color(g, .Middle_Face_Left))
+	k2.draw_rect_vec(o + {250 + 10, 140}, {20, 10}, button_color(g, .Middle_Face_Right))
 
 	left_stick := k2.Vec2 {
 		k2.get_gamepad_axis(gamepad, .Left_Stick_X),
@@ -54,11 +54,11 @@ gamepad_demo :: proc(gamepad: k2.Gamepad_Index, offset: k2.Vec2) {
 
 	k2.set_gamepad_vibration(gamepad, left_trigger, right_trigger)
 
-	k2.draw_rect(k2.rect_from_pos_size(o + {80, 50}, {20, 10}), button_color(g, .Left_Shoulder))
-	k2.draw_rect(k2.rect_from_pos_size(o + {50, 50} + {0, left_trigger * 20}, {20, 10}), button_color(g, .Left_Trigger, k2.WHITE, k2.GRAY))
+	k2.draw_rect_vec(o + {80, 50}, {20, 10}, button_color(g, .Left_Shoulder))
+	k2.draw_rect_vec(o + {50, 50} + {0, left_trigger * 20}, {20, 10}, button_color(g, .Left_Trigger, k2.WHITE, k2.GRAY))
 
-	k2.draw_rect(k2.rect_from_pos_size(o + {420, 50}, {20, 10}), button_color(g, .Right_Shoulder))
-	k2.draw_rect(k2.rect_from_pos_size(o + {450, 50} + {0, right_trigger * 20}, {20, 10}), button_color(g, .Right_Trigger, k2.WHITE, k2.GRAY))
+	k2.draw_rect_vec(o + {420, 50}, {20, 10}, button_color(g, .Right_Shoulder))
+	k2.draw_rect_vec(o + {450, 50} + {0, right_trigger * 20}, {20, 10}, button_color(g, .Right_Trigger, k2.WHITE, k2.GRAY))
 	k2.draw_circle(o + {200, 200} + 20 * left_stick, 20, button_color(g, .Left_Stick_Press, k2.WHITE, k2.GRAY))
 	k2.draw_circle(o + {300, 200} + 20 * right_stick, 20, button_color(g, .Right_Stick_Press, k2.WHITE, k2.GRAY))
 }

--- a/examples/measure_text/measure_text.odin
+++ b/examples/measure_text/measure_text.odin
@@ -64,7 +64,7 @@ step :: proc() -> bool {
 
 			if i == current_font_idx {
 				size := k2.measure_text(text, UI_FONT_SIZE)
-				k2.draw_rect(k2.rect_from_pos_size(pos, size), k2.LIGHT_YELLOW)
+				k2.draw_rect_vec(pos, size, k2.LIGHT_YELLOW)
 			}
 
 			k2.draw_text(text, pos, UI_FONT_SIZE)
@@ -96,7 +96,7 @@ step :: proc() -> bool {
 		for char in ' '..='~' {
 			text := string([]u8 { u8(char) })
 			size := k2.measure_text(text, current_font_size, font)
-			k2.draw_rect(k2.rect_from_pos_size(pos, size), k2.LIGHT_RED)
+			k2.draw_rect_vec(pos, size, k2.LIGHT_RED)
 			k2.draw_text(text, pos, current_font_size, font = font)
 
 			pos.x += current_font_size
@@ -114,14 +114,14 @@ step :: proc() -> bool {
 		}) {
 			pos1 := Vec2 { LEFT, pos.y + f32(i+2)*current_font_size }
 			size := k2.measure_text(text, current_font_size, font)
-			k2.draw_rect(k2.rect_from_pos_size(pos1, size), k2.LIGHT_RED)
+			k2.draw_rect_vec(pos1, size, k2.LIGHT_RED)
 			k2.draw_text(text, pos1, current_font_size, font = font)
 		}
 
 		pos = { LEFT+400, pos.y + 2*current_font_size }
 		text := "/*\nHellöpe Karl2D!\nNext line goes here\nAnd one more\n*/"
 		size := k2.measure_text(text, current_font_size, font)
-		k2.draw_rect(k2.rect_from_pos_size(pos, size), k2.LIGHT_RED)
+		k2.draw_rect_vec(pos, size, k2.LIGHT_RED)
 		k2.draw_text(text, pos, current_font_size, font = font)
 	}
 

--- a/examples/measure_text/measure_text.odin
+++ b/examples/measure_text/measure_text.odin
@@ -35,7 +35,7 @@ init :: proc() {
 	for &f in fonts {
 		f.font = f.bytes != nil\
 			? k2.load_font_from_bytes(f.bytes)\
-			: k2.get_default_font()
+			: k2.FONT_DEFAULT
 	}
 }
 
@@ -64,7 +64,7 @@ step :: proc() -> bool {
 
 			if i == current_font_idx {
 				size := k2.measure_text(text, UI_FONT_SIZE)
-				k2.draw_rect_vec(pos, size, k2.LIGHT_YELLOW)
+				k2.draw_rect(k2.rect_from_pos_size(pos, size), k2.LIGHT_YELLOW)
 			}
 
 			k2.draw_text(text, pos, UI_FONT_SIZE)
@@ -95,9 +95,9 @@ step :: proc() -> bool {
 		pos := Vec2 { LEFT, TOP }
 		for char in ' '..='~' {
 			text := string([]u8 { u8(char) })
-			size := k2.measure_text_ex(font, text, current_font_size)
-			k2.draw_rect_vec(pos, size, k2.LIGHT_RED)
-			k2.draw_text_ex(font, text, pos, current_font_size)
+			size := k2.measure_text(text, current_font_size, font)
+			k2.draw_rect(k2.rect_from_pos_size(pos, size), k2.LIGHT_RED)
+			k2.draw_text(text, pos, current_font_size, font = font)
 
 			pos.x += current_font_size
 			if pos.x+current_font_size > screen_size.x-40 {
@@ -113,16 +113,16 @@ step :: proc() -> bool {
 			"    000,4,000    ",
 		}) {
 			pos1 := Vec2 { LEFT, pos.y + f32(i+2)*current_font_size }
-			size := k2.measure_text_ex(font, text, current_font_size)
-			k2.draw_rect_vec(pos1, size, k2.LIGHT_RED)
-			k2.draw_text_ex(font, text, pos1, current_font_size)
+			size := k2.measure_text(text, current_font_size, font)
+			k2.draw_rect(k2.rect_from_pos_size(pos1, size), k2.LIGHT_RED)
+			k2.draw_text(text, pos1, current_font_size, font = font)
 		}
 
 		pos = { LEFT+400, pos.y + 2*current_font_size }
 		text := "/*\nHellöpe Karl2D!\nNext line goes here\nAnd one more\n*/"
-		size := k2.measure_text_ex(font, text, current_font_size)
-		k2.draw_rect_vec(pos, size, k2.LIGHT_RED)
-		k2.draw_text_ex(font, text, pos, current_font_size)
+		size := k2.measure_text(text, current_font_size, font)
+		k2.draw_rect(k2.rect_from_pos_size(pos, size), k2.LIGHT_RED)
+		k2.draw_text(text, pos, current_font_size, font = font)
 	}
 
 	// HINTS

--- a/examples/measure_text/measure_text.odin
+++ b/examples/measure_text/measure_text.odin
@@ -67,7 +67,7 @@ step :: proc() -> bool {
 				k2.draw_rect_vec(pos, size, k2.LIGHT_YELLOW)
 			}
 
-			k2.draw_text(text, pos, UI_FONT_SIZE)
+			k2.draw_text(text, pos, UI_FONT_SIZE, k2.BLACK)
 		}
 	}
 
@@ -84,7 +84,7 @@ step :: proc() -> bool {
 
 		text := fmt.tprintf("[+/-] Font size: %.1f", current_font_size)
 		pos := Vec2 { 40, 30 + (len(fonts)+1)*UI_FONT_SIZE }
-		k2.draw_text(text, pos, UI_FONT_SIZE)
+		k2.draw_text(text, pos, UI_FONT_SIZE, k2.BLACK)
 	}
 
 	// CURRENT FONT FACE
@@ -97,7 +97,7 @@ step :: proc() -> bool {
 			text := string([]u8 { u8(char) })
 			size := k2.measure_text(text, current_font_size, font)
 			k2.draw_rect_vec(pos, size, k2.LIGHT_RED)
-			k2.draw_text(text, pos, current_font_size, font = font)
+			k2.draw_text(text, pos, current_font_size, k2.BLACK, font)
 
 			pos.x += current_font_size
 			if pos.x+current_font_size > screen_size.x-40 {
@@ -115,21 +115,21 @@ step :: proc() -> bool {
 			pos1 := Vec2 { LEFT, pos.y + f32(i+2)*current_font_size }
 			size := k2.measure_text(text, current_font_size, font)
 			k2.draw_rect_vec(pos1, size, k2.LIGHT_RED)
-			k2.draw_text(text, pos1, current_font_size, font = font)
+			k2.draw_text(text, pos1, current_font_size, k2.BLACK, font)
 		}
 
 		pos = { LEFT+400, pos.y + 2*current_font_size }
 		text := "/*\nHellöpe Karl2D!\nNext line goes here\nAnd one more\n*/"
 		size := k2.measure_text(text, current_font_size, font)
 		k2.draw_rect_vec(pos, size, k2.LIGHT_RED)
-		k2.draw_text(text, pos, current_font_size, font = font)
+		k2.draw_text(text, pos, current_font_size, k2.BLACK, font)
 	}
 
 	// HINTS
 	{
 		hits_text := fmt.tprintf("Press 1..%i to change font\nPress +/- to change size", len(fonts))
 		hits_pos := Vec2 { 40, screen_size.y-30-2*UI_FONT_SIZE }
-		k2.draw_text(hits_text, hits_pos, UI_FONT_SIZE)
+		k2.draw_text(hits_text, hits_pos, UI_FONT_SIZE, k2.BLACK)
 	}
 
 	k2.present()

--- a/examples/multitexture/multitexture.odin
+++ b/examples/multitexture/multitexture.odin
@@ -47,7 +47,7 @@ step :: proc() -> bool {
 	k2.draw_circle({120, 40}, 30, k2.BLACK)
 	k2.draw_circle({120, 40}, 20, k2.GREEN)
 	k2.draw_text("Hellöpe!", {10, 100}, 64, k2.WHITE)
-	k2.draw_texture_fit(tex1, {10, 200, 900, 500})
+	k2.draw_texture_fit(tex1, k2.get_texture_rect(tex1), {10, 200, 900, 500})
 
 	k2.present()
 	free_all(context.temp_allocator)

--- a/examples/multitexture/multitexture.odin
+++ b/examples/multitexture/multitexture.odin
@@ -47,7 +47,7 @@ step :: proc() -> bool {
 	k2.draw_circle({120, 40}, 30, k2.BLACK)
 	k2.draw_circle({120, 40}, 20, k2.GREEN)
 	k2.draw_text("Hellöpe!", {10, 100}, 64, k2.WHITE)
-	k2.draw_texture_ex(tex1, {0, 0, f32(tex1.width), f32(tex1.height)}, {10, 200, 900, 500}, {}, 0)
+	k2.draw_texture_fit(tex1, {10, 200, 900, 500})
 
 	k2.present()
 	free_all(context.temp_allocator)

--- a/examples/premultiplied_alpha/premultiplied_alpha.odin
+++ b/examples/premultiplied_alpha/premultiplied_alpha.odin
@@ -15,9 +15,8 @@ main :: proc() {
 	for k2.update() {
 		k2.clear(k2.BLUE)
 
-		src := k2.get_texture_rect(tex)
-		dst := k2.Rect { 20, 100, src.w*20, src.h*20}
-		k2.draw_texture_ex(tex, src, dst, {}, 0)
+		tex_fit_into := k2.Rect { 20, 100, f32(tex.width*20), f32(tex.height*20) }
+		k2.draw_texture_fit(tex, tex_fit_into)
 
 		k2.present()
 		free_all(context.temp_allocator)

--- a/examples/premultiplied_alpha/premultiplied_alpha.odin
+++ b/examples/premultiplied_alpha/premultiplied_alpha.odin
@@ -15,8 +15,9 @@ main :: proc() {
 	for k2.update() {
 		k2.clear(k2.BLUE)
 
-		tex_fit_into := k2.Rect { 20, 100, f32(tex.width*20), f32(tex.height*20) }
-		k2.draw_texture_fit(tex, tex_fit_into)
+		tex_src := k2.get_texture_rect(tex)
+		tex_dest := k2.Rect { 20, 100, tex_src.w*20, tex_src.h*20 }
+		k2.draw_texture_fit(tex, tex_src, tex_dest)
 
 		k2.present()
 		free_all(context.temp_allocator)

--- a/examples/render_texture/render_texture.odin
+++ b/examples/render_texture/render_texture.odin
@@ -48,11 +48,12 @@ step :: proc() -> bool {
 
 	rt_rect := k2.get_texture_rect(render_texture.texture)
 
-	k2.draw_texture_fit(render_texture.texture, {0, 0, rt_rect.w * 5, rt_rect.h * 5})
+	k2.draw_texture_fit(render_texture.texture, rt_rect, {0, 0, rt_rect.w * 5, rt_rect.h * 5})
 	k2.draw_texture(render_texture.texture, {400, 20})
 	k2.draw_texture_fit(
 		render_texture.texture,
-		into = {512, 512, rt_rect.w * 5, rt_rect.h * 5},
+		rt_rect,
+		{512, 512, rt_rect.w * 5, rt_rect.h * 5},
 		origin = {rt_rect.w * 2.5, rt_rect.h * 2.5}, // half the dst rect size
 		rotation = rot2,
 	)

--- a/examples/render_texture/render_texture.odin
+++ b/examples/render_texture/render_texture.odin
@@ -39,24 +39,22 @@ step :: proc() -> bool {
 		rot -= 2*math.PI
 	}
 
-	k2.draw_rect_ex({12, 12, 12, 12}, {6, 6}, rot, k2.BLACK)
+	k2.draw_rect({12, 12, 12, 12}, k2.BLACK, {6, 6}, rot)
 	k2.draw_text("Hellöpe!", {f32(math.sin(k2.get_time() * 10))*5 + 7, 20}, 20, k2.BLACK)
 	
 	k2.set_render_texture(nil)
 
 	k2.clear(k2.BLACK)
 
-	rt_size := k2.get_texture_rect(render_texture.texture)
+	rt_rect := k2.get_texture_rect(render_texture.texture)
 
-	k2.draw_texture_ex(render_texture.texture, rt_size, {0, 0, rt_size.w * 5, rt_size.h * 5}, {}, 0)
+	k2.draw_texture_fit(render_texture.texture, {0, 0, rt_rect.w * 5, rt_rect.h * 5})
 	k2.draw_texture(render_texture.texture, {400, 20})
-	k2.draw_texture_ex(
+	k2.draw_texture_fit(
 		render_texture.texture,
-		rt_size,
-		{512, 512, rt_size.w * 5, rt_size.h * 5}, // dst rect
-		{rt_size.w * 2.5, rt_size.h * 2.5}, // half the dst rect size
-		rot2,
-		k2.WHITE,
+		into = {512, 512, rt_rect.w * 5, rt_rect.h * 5},
+		origin = {rt_rect.w * 2.5, rt_rect.h * 2.5}, // half the dst rect size
+		rotation = rot2,
 	)
 
 	k2.present()

--- a/examples/snake/snake.odin
+++ b/examples/snake/snake.odin
@@ -164,7 +164,12 @@ step :: proc() -> bool {
 	food_sprite.width = CELL_SIZE
 	food_sprite.height = CELL_SIZE
 
-	k2.draw_texture(food_sprite, {f32(food_pos.x), f32(food_pos.y)}*CELL_SIZE)
+	food_pos := k2.Vec2 {
+		f32(food_pos.x),
+		f32(food_pos.y),
+	}*CELL_SIZE
+
+	k2.draw_texture(food_sprite, food_pos)
 
 	for i in 0..<snake_length {
 		part_sprite := body_sprite
@@ -187,14 +192,12 @@ step :: proc() -> bool {
 			f32(part_sprite.width), f32(part_sprite.height),
 		}
 
-		dest := k2.Rect {
+		part_pos := k2.Vec2 {
 			f32(snake[i].x)*CELL_SIZE + 0.5*CELL_SIZE,
 			f32(snake[i].y)*CELL_SIZE + 0.5*CELL_SIZE,
-			CELL_SIZE,
-			CELL_SIZE,
 		}
 
-		k2.draw_texture_ex(part_sprite, source, dest, {CELL_SIZE, CELL_SIZE}*0.5, rot)
+		k2.draw_texture(part_sprite, part_pos, source, {CELL_SIZE, CELL_SIZE}*0.5, rot)
 	}
 
 	if game_over {

--- a/examples/snake/snake.odin
+++ b/examples/snake/snake.odin
@@ -161,14 +161,7 @@ step :: proc() -> bool {
 	}
 	
 	k2.set_camera(camera)
-	food_sprite.width = CELL_SIZE
-	food_sprite.height = CELL_SIZE
-
-	food_pos := k2.Vec2 {
-		f32(food_pos.x),
-		f32(food_pos.y),
-	}*CELL_SIZE
-
+	food_pos := k2.Vec2 { f32(food_pos.x), f32(food_pos.y) } * CELL_SIZE
 	k2.draw_texture(food_sprite, food_pos)
 
 	for i in 0..<snake_length {
@@ -185,19 +178,20 @@ step :: proc() -> bool {
 			dir = snake[i - 1] - snake[i]
 		}
 
-		rot := math.atan2(f32(dir.y), f32(dir.x))
-
-		source := k2.Rect {
-			0, 0,
-			f32(part_sprite.width), f32(part_sprite.height),
-		}
+		origin := k2.rect_middle(k2.get_texture_rect(part_sprite))
+		rotation := math.atan2(f32(dir.y), f32(dir.x))
 
 		part_pos := k2.Vec2 {
-			f32(snake[i].x)*CELL_SIZE + 0.5*CELL_SIZE,
-			f32(snake[i].y)*CELL_SIZE + 0.5*CELL_SIZE,
+			f32(snake[i].x)*CELL_SIZE + origin.x,
+			f32(snake[i].y)*CELL_SIZE + origin.y,
 		}
 
-		k2.draw_texture(part_sprite, part_pos, source, {CELL_SIZE, CELL_SIZE}*0.5, rot)
+		k2.draw_texture(
+			part_sprite,
+			part_pos,
+			origin = origin,
+			rotation = rotation,
+		)
 	}
 
 	if game_over {

--- a/examples/snake/snake.odin
+++ b/examples/snake/snake.odin
@@ -161,6 +161,7 @@ step :: proc() -> bool {
 	}
 	
 	k2.set_camera(camera)
+	
 	food_pos := k2.Vec2 { f32(food_pos.x), f32(food_pos.y) } * CELL_SIZE
 	k2.draw_texture(food_sprite, food_pos)
 

--- a/examples/ui/ui.odin
+++ b/examples/ui/ui.odin
@@ -24,14 +24,19 @@ main :: proc() {
 			append(&random_numbers, rand.int_max(int(math.pow(f32(10), f32(sz)))))
 		}
 
-		k2.draw_text(fmt.tprintf("Button has been clicked %v times", button_click_count), {300, 15}, 30)
+		k2.draw_text(
+			fmt.tprintf("Button has been clicked %v times", button_click_count),
+			{300, 15},
+			30,
+			k2.BLACK,
+		)
 
 		numbers_bg_rect := Rect { 10, 100, 500, f32(len(random_numbers) * 30 + 10)}
 		k2.draw_rect(numbers_bg_rect, k2.LIGHT_GREEN)
 		k2.draw_rect_outline(numbers_bg_rect, 1, k2.BLACK)
 
 		for n, idx in random_numbers {
-			k2.draw_text(fmt.tprint(n), {15, 105 + f32(idx) * 30}, 30)
+			k2.draw_text(fmt.tprint(n), {15, 105 + f32(idx) * 30}, 30, k2.BLACK)
 		}
 
 		k2.present()
@@ -59,7 +64,7 @@ button :: proc(r: Rect, text: string) -> bool {
 
 	textr := inset_rect(r, 5, 5)
 	text_width := k2.measure_text(text, textr.h).x
-	k2.draw_text(text, {textr.x + textr.w/2 - text_width/2, textr.y}, textr.h)
+	k2.draw_text(text, {textr.x + textr.w/2 - text_width/2, textr.y}, textr.h, k2.BLACK)
 
 	if in_rect && k2.mouse_button_went_down(.Left) {
 		return true

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -347,17 +347,21 @@ draw_texture_fit :: proc(
 // The return value contains the width and height of the text.
 measure_text :: proc(text: string, font_size: f32, font: Font = FONT_DEFAULT) -> Vec2
 
-// Draw text at a position with a size.
+// Draw text at a position, with a size and color. The position is the top-left position of the
+// text.
 //
 // Optional parameters:
-// - color: The color of the text.
 // - font: The font to use, uses a default font if none is specified.
+// - origin: The origin relative top the top-left position of the text. Used when rotating the text.
+// - rotation: Rotating to apply to the text, measured in radians.
 draw_text :: proc(
 	text: string,
-	pos: Vec2,
+	position: Vec2,
 	font_size: f32,
+	color: Color,
 	font := FONT_DEFAULT,
-	color := BLACK,
+	origin: Vec2 = {},
+	rotation: f32 = 0,
 )
 
 //--------------------//

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -332,16 +332,17 @@ draw_texture_fit :: proc(
 // The return value contains the width and height of the text.
 measure_text :: proc(text: string, font_size: f32, font: Font = FONT_DEFAULT) -> Vec2
 
-// Draw text at a position with a size, using a custom font. `pos` will be equal to the  top-left
-// position of the text.
-// Draw text at a position with a size. This uses the default font. `pos` will be equal to the 
-// top-left position of the text.
+// Draw text at a position with a size.
+//
+// Optional parameters:
+// - color: The color of the text.
+// - font: The font to use, uses a default font if none is specified.
 draw_text :: proc(
 	text: string,
 	pos: Vec2,
 	font_size: f32,
-	color := BLACK,
 	font := FONT_DEFAULT,
+	color := BLACK,
 )
 
 //--------------------//

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -322,7 +322,7 @@ draw_texture :: proc(
 )
 
 // Draw a section of a texture at a position. The section is chosen using the `source` parameter,
-// which is a rectangle that uses pixel cooridnates.
+// which is a rectangle that uses pixel coordinates.
 //
 // Optional parameters:
 // - origin: An offset for the position, and also the point to rotate around.
@@ -354,10 +354,8 @@ draw_texture_fit :: proc(
 	tint := WHITE,
 )
 
-// Tells you how much space some text of a certain size will use on the screen. The font used is the
-// default font. The return value contains the width and height of the text.
-// Tells you how much space some text of a certain size will use on the screen, using a custom font.
-// The return value contains the width and height of the text.
+// Measures how much space some text of a certain size will use on the screen. Will use the default
+// font unless you specify a custom font.
 measure_text :: proc(text: string, font_size: f32, font: Font = FONT_DEFAULT) -> Vec2
 
 // Draw text at a position, with a size and color. The position is the top-left position of the

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -304,9 +304,13 @@ draw_triangle :: proc(vertices: [3]Vec2, c: Color)
 
 // Draw a texture a specific position.
 //
+// The top-left corner of the texture will end up at the position. If you use the `crop` parameter
+// to crop out a part of the texture, then the top-left corner of the cropped-out part will be at
+// the position. Also, any non-zero origin will offset the position as well.
+//
 // Optional parameters:
 // - crop: A rectangle that describes which part of `texture` to display. Note that it is a Maybe
-//   type, which means that `nil` means "no cropping".
+//   type, which means that `nil` means "no cropping". Uses pixel coordinates.
 // - origin: The point which `rotation` rotates around. Effectively an offset of `position`.
 // - rotation: Rotation around `origin`, measured in radians.
 // - tint: A color to apply to the texture, in a multiplicative way. WHITE means no tinting.
@@ -314,7 +318,7 @@ draw_triangle :: proc(vertices: [3]Vec2, c: Color)
 // If you want to rotate around the middle of the texture, then try this:
 // 
 //// middle := k2.rect_middle(k2.get_texture_rect(tex))
-//// draw_texture(tex, pos + middle, origin = middle, rot)
+//// draw_texture(tex, pos + middle, origin = middle, rotation = rot)
 draw_texture :: proc(
 	texture: Texture,
 	position: Vec2,

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -261,19 +261,13 @@ set_gamepad_vibration :: proc(gamepad: Gamepad_Index, left: f32, right: f32)
 
 // Draw a colored rectangle. The rectangles have their (x, y) position in the top-left corner of the
 // rectangle.
-draw_rect :: proc(r: Rect, c: Color)
-
-// Creates a rectangle from a position and a size and draws it.
-draw_rect_vec :: proc(pos: Vec2, size: Vec2, c: Color)
-
-// Draw a rectangle with a custom origin and rotation.
 //
-// The origin says which point the rotation rotates around. If the origin is `(0, 0)`, then the
-// rectangle rotates around the top-left corner of the rectangle. If it is `(rect.w/2, rect.h/2)`
-// then the rectangle rotates around its center.
-//
-// Rotation unit: Radians.
-draw_rect_ex :: proc(r: Rect, origin: Vec2, rot: f32, c: Color)
+// Optional parameters:
+// - origin: The point to rotate around, also offsets the position of the rect. If the origin is
+//   `(0, 0)`, then the rectangle rotates around the top-left corner of the rectangle. If it is
+//   `(rect.w/2, rect.h/2)` then the rectangle rotates around its center.
+// - rotation: The rotation to apply, in radians
+draw_rect :: proc(rect: Rect, c: Color, origin: Vec2 = {}, rotation: f32 = 0)
 
 // Draw the outline of a rectangle with a specific thickness. The outline is drawn using four
 // rectangles.
@@ -858,13 +852,6 @@ Mat4 :: matrix[4,4]f32
 Rect :: struct {
 	x, y: f32,
 	w, h: f32,
-}
-
-RECT_EMPTY :: Rect{}
-
-WHOLE_TEXTURE :: Rect {
-	w = max(f32),
-	h = max(f32),
 }
 
 // An RGBA (Red, Green, Blue, Alpha) color. Each channel can have a value between 0 and 255.

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -293,29 +293,40 @@ draw_line :: proc(start: Vec2, end: Vec2, thickness: f32, color: Color)
 // counter-clockwise triangles will give the same result.
 draw_triangle :: proc(vertices: [3]Vec2, c: Color)
 
-// Draw a section of a texture at a specific position. `rect` is a rectangle measured in pixels. It
-// tells the procedure which part of the texture to display. The texture will be drawn with its
-// top-left corner at position `pos`.
+// Draw a texture a specific position.
+//
+// Optional parameters:
+// - crop: A rectangle that describes which part of `texture` to display. Note that it is a Maybe
+//   type, which means that `nil` means "no cropping".
+// - origin: The point which `rotation` rotates around. Effectively an offset of `position`.
+// - rotation: Rotation around `origin`, measured in radians.
+// - tint: A color to apply to the texture, in a multiplicative way. WHITE means no tinting.
+//
+// If you want to rotate around the middle of the texture, then try this:
+// 
+//// middle := k2.rect_middle(k2.get_texture_rect(tex))
+//// draw_texture(tex, pos + middle, origin = middle, rot)
 draw_texture :: proc(
 	texture: Texture,
 	position: Vec2,
-	texture_src: Rect = RECT_EMPTY,
+	crop: Maybe(Rect) = nil,
 	origin: Vec2 = {},
 	rotation: f32 = 0,
 	tint := WHITE
 )
 
-// Draw a texture by taking a section of the texture specified by `src` and draw it into the area of
-// the screen specified by `dst`. You can also rotate the texture around an origin point of your
-// choice.
+// Draw a texture by fitting it into a rectangle.
 //
-// Tip: Use `k2.get_texture_rect(tex)` for `src` if you want to draw the whole texture.
-//
-// Rotation unit: Radians.
+// Optional parameters:
+// - crop: A rectangle that describes which part of `texture` to display. Note that it is a Maybe
+//   type, which means that `nil` means "no cropping".
+// - origin: An offset of the `into` rectangle and also the point which `rotation` rotates around.
+// - rotation: Rotation around `origin`, measured in radians.
+// - tint: A color to apply to the texture, in a multiplicative way. WHITE means no tinting.
 draw_texture_fit :: proc(
 	texture: Texture,
 	into: Rect,
-	texture_src: Rect = RECT_EMPTY,
+	crop: Maybe(Rect) = nil,
 	origin: Vec2 = {},
 	rotation: f32 = 0,
 	tint := WHITE,
@@ -850,6 +861,11 @@ Rect :: struct {
 }
 
 RECT_EMPTY :: Rect{}
+
+WHOLE_TEXTURE :: Rect {
+	w = max(f32),
+	h = max(f32),
+}
 
 // An RGBA (Red, Green, Blue, Alpha) color. Each channel can have a value between 0 and 255.
 Color :: [4]u8

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -1120,6 +1120,9 @@ Font :: distinct int
 DEFAULT_FONT_DATA :: #load("default_fonts/roboto.ttf")
 
 FONT_NONE :: Font(0)
+
+// The default font. It's a font called "roboto". It is loaded from `DEFAULT_FONT_DATA` on Karl2D is
+// initialized.
 FONT_DEFAULT :: Font(1)
 
 TEXTURE_NONE :: Texture_Handle {}

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -293,16 +293,17 @@ draw_line :: proc(start: Vec2, end: Vec2, thickness: f32, color: Color)
 // counter-clockwise triangles will give the same result.
 draw_triangle :: proc(vertices: [3]Vec2, c: Color)
 
-// Draw a texture at a specific position. The texture will be drawn with its top-left corner at
-// position `pos`.
-//
-// Load textures using `load_texture_from_file` or `load_texture_from_bytes`.
-draw_texture :: proc(tex: Texture, pos: Vec2, tint := WHITE)
-
 // Draw a section of a texture at a specific position. `rect` is a rectangle measured in pixels. It
 // tells the procedure which part of the texture to display. The texture will be drawn with its
 // top-left corner at position `pos`.
-draw_texture_rect :: proc(tex: Texture, rect: Rect, pos: Vec2, tint := WHITE)
+draw_texture :: proc(
+	texture: Texture,
+	position: Vec2,
+	texture_src: Rect = RECT_EMPTY,
+	origin: Vec2 = {},
+	rotation: f32 = 0,
+	tint := WHITE
+)
 
 // Draw a texture by taking a section of the texture specified by `src` and draw it into the area of
 // the screen specified by `dst`. You can also rotate the texture around an origin point of your
@@ -311,23 +312,32 @@ draw_texture_rect :: proc(tex: Texture, rect: Rect, pos: Vec2, tint := WHITE)
 // Tip: Use `k2.get_texture_rect(tex)` for `src` if you want to draw the whole texture.
 //
 // Rotation unit: Radians.
-draw_texture_ex :: proc(tex: Texture, src: Rect, dst: Rect, origin: Vec2, rotation: f32, tint := WHITE)
+draw_texture_fit :: proc(
+	texture: Texture,
+	into: Rect,
+	texture_src: Rect = RECT_EMPTY,
+	origin: Vec2 = {},
+	rotation: f32 = 0,
+	tint := WHITE,
+)
 
 // Tells you how much space some text of a certain size will use on the screen. The font used is the
 // default font. The return value contains the width and height of the text.
-measure_text :: proc(text: string, font_size: f32) -> Vec2
-
 // Tells you how much space some text of a certain size will use on the screen, using a custom font.
 // The return value contains the width and height of the text.
-measure_text_ex :: proc(font_handle: Font, text: string, font_size: f32) -> Vec2
-
-// Draw text at a position with a size. This uses the default font. `pos` will be equal to the 
-// top-left position of the text.
-draw_text :: proc(text: string, pos: Vec2, font_size: f32, color := BLACK)
+measure_text :: proc(text: string, font_size: f32, font: Font = FONT_DEFAULT) -> Vec2
 
 // Draw text at a position with a size, using a custom font. `pos` will be equal to the  top-left
 // position of the text.
-draw_text_ex :: proc(font_handle: Font, text: string, pos: Vec2, font_size: f32, color := BLACK)
+// Draw text at a position with a size. This uses the default font. `pos` will be equal to the 
+// top-left position of the text.
+draw_text :: proc(
+	text: string,
+	pos: Vec2,
+	font_size: f32,
+	color := BLACK,
+	font := FONT_DEFAULT,
+)
 
 //--------------------//
 // TEXTURE MANAGEMENT //
@@ -694,9 +704,6 @@ load_font_from_bytes :: proc(data: []u8, options: Font_Options = {}) -> Font
 // Destroy a font previously loaded using `load_font_from_file` or `load_font_from_bytes`.
 destroy_font :: proc(font: Font)
 
-// Returns the built-in font of Karl2D (the font is known as "roboto")
-get_default_font :: proc() -> Font
-
 //---------//
 // SHADERS //
 //---------//
@@ -841,6 +848,8 @@ Rect :: struct {
 	x, y: f32,
 	w, h: f32,
 }
+
+RECT_EMPTY :: Rect{}
 
 // An RGBA (Red, Green, Blue, Alpha) color. Each channel can have a value between 0 and 255.
 Color :: [4]u8
@@ -1091,7 +1100,9 @@ Render_Target_Handle :: distinct Handle
 Font :: distinct int
 DEFAULT_FONT_DATA :: #load("default_fonts/roboto.ttf")
 
-FONT_NONE :: Font {}
+FONT_NONE :: Font(0)
+FONT_DEFAULT :: Font(1)
+
 TEXTURE_NONE :: Texture_Handle {}
 RENDER_TARGET_NONE :: Render_Target_Handle {}
 
@@ -1282,7 +1293,7 @@ State :: struct {
 	gamepad_button_went_up: [MAX_GAMEPADS]#sparse [Gamepad_Button]bool,
 	gamepad_button_is_held: [MAX_GAMEPADS]#sparse [Gamepad_Button]bool,
 
-	default_font: Font,
+	// Also see FONT_NONE and FONT_DEFAULT
 	fonts: [dynamic]Font_Data,
 	shape_drawing_texture: Texture_Handle,
 	batch_font: Font,

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -267,7 +267,22 @@ set_gamepad_vibration :: proc(gamepad: Gamepad_Index, left: f32, right: f32)
 //   `(0, 0)`, then the rectangle rotates around the top-left corner of the rectangle. If it is
 //   `(rect.w/2, rect.h/2)` then the rectangle rotates around its center.
 // - rotation: The rotation to apply, in radians
-draw_rect :: proc(rect: Rect, c: Color, origin: Vec2 = {}, rotation: f32 = 0)
+draw_rect :: proc(rect: Rect, color: Color, origin: Vec2 = {}, rotation: f32 = 0)
+
+// Creates a rectangle from a position and a size and draws it using the specified color.
+//
+// Optional parameters:
+// - origin: The point to rotate around, also offsets the position of the rect. If the origin is
+//   `(0, 0)`, then the rectangle rotates around the top-left corner of the rectangle. If it is
+//   `(rect.w/2, rect.h/2)` then the rectangle rotates around its center.
+// - rotation: The rotation to apply, in radians
+draw_rect_vec :: proc(
+	position: Vec2,
+	size: Vec2,
+	color: Color,
+	origin: Vec2 = {},
+	rotation: f32 = 0
+)
 
 // Draw the outline of a rectangle with a specific thickness. The outline is drawn using four
 // rectangles.

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -332,8 +332,9 @@ draw_texture :: proc(
 //
 // Optional parameters:
 // - crop: A rectangle that describes which part of `texture` to display. Note that it is a Maybe
-//   type, which means that `nil` means "no cropping".
-// - origin: An offset of the `into` rectangle and also the point which `rotation` rotates around.
+//   type, which means that `nil` means "no cropping". Uses pixel coordinates.
+// - origin: The point within `into` to rotate around, measured from the top-left corner. Also
+//   offsets the position of `into`.
 // - rotation: Rotation around `origin`, measured in radians.
 // - tint: A color to apply to the texture, in a multiplicative way. WHITE means no tinting.
 draw_texture_fit :: proc(

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -302,45 +302,53 @@ draw_line :: proc(start: Vec2, end: Vec2, thickness: f32, color: Color)
 // counter-clockwise triangles will give the same result.
 draw_triangle :: proc(vertices: [3]Vec2, c: Color)
 
-// Draw a texture a specific position.
-//
-// The top-left corner of the texture will end up at the position. If you use the `crop` parameter
-// to crop out a part of the texture, then the top-left corner of the cropped-out part will be at
-// the position. Also, any non-zero origin will offset the position as well.
+// Draw a texture at a position. The top-left corner of the texture will end up at the position.
 //
 // Optional parameters:
-// - crop: A rectangle that describes which part of `texture` to display. Note that it is a Maybe
-//   type, which means that `nil` means "no cropping". Uses pixel coordinates.
-// - origin: The point which `rotation` rotates around. Effectively an offset of `position`.
-// - rotation: Rotation around `origin`, measured in radians.
+// - origin: An offset for the position, and also the point to rotate around.
+// - rotation: Measured in radians. Rotates around the top-left corner, plus any `origin` shift.
 // - tint: A color to apply to the texture, in a multiplicative way. WHITE means no tinting.
 //
 // If you want to rotate around the middle of the texture, then try this:
 // 
 //// middle := k2.rect_middle(k2.get_texture_rect(tex))
-//// draw_texture(tex, pos + middle, origin = middle, rotation = rot)
+//// draw_texture(tex, pos + middle, middle, rot)
 draw_texture :: proc(
 	texture: Texture,
 	position: Vec2,
-	crop: Maybe(Rect) = nil,
 	origin: Vec2 = {},
 	rotation: f32 = 0,
-	tint := WHITE
+	tint := WHITE,
 )
 
-// Draw a texture by fitting it into a rectangle.
+// Draw a section of a texture at a position. The section is chosen using the `source` parameter,
+// which is a rectangle that uses pixel cooridnates.
 //
 // Optional parameters:
-// - crop: A rectangle that describes which part of `texture` to display. Note that it is a Maybe
-//   type, which means that `nil` means "no cropping". Uses pixel coordinates.
-// - origin: The point within `into` to rotate around, measured from the top-left corner. Also
-//   offsets the position of `into`.
-// - rotation: Rotation around `origin`, measured in radians.
+// - origin: An offset for the position, and also the point to rotate around.
+// - rotation: Measured in radians. Rotates around the top-left corner, plus any `origin` shift.
+// - tint: A color to apply to the texture, in a multiplicative way. WHITE means no tinting.
+draw_texture_section :: proc(
+	texture: Texture,
+	source: Rect,
+	position: Vec2,
+	origin: Vec2 = {},
+	rotation: f32 = 0,
+	tint := WHITE,
+)
+
+// Draw a section of a texture by fitting it into a rectangle. The section is chosen using the
+// rectangle parameter `source`, measured in pixels. The `dest` parameter is the rectangle on the
+// screen (or in the world) that we want to fit the texture section into.
+//
+// Optional parameters:
+// - origin: An offset for the dest rectangle, and also the point to rotate around.
+// - rotation: Measured in radians. Rotates around the top-left corner, plus any `origin` shift.
 // - tint: A color to apply to the texture, in a multiplicative way. WHITE means no tinting.
 draw_texture_fit :: proc(
 	texture: Texture,
-	into: Rect,
-	crop: Maybe(Rect) = nil,
+	source: Rect,
+	dest: Rect,
 	origin: Vec2 = {},
 	rotation: f32 = 0,
 	tint := WHITE,

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -3475,6 +3475,7 @@ Rect :: struct {
 }
 
 RECT_EMPTY :: Rect{}
+WHOLE_TEXTURE :: Rect{}
 
 // An RGBA (Red, Green, Blue, Alpha) color. Each channel can have a value between 0 and 255.
 Color :: [4]u8

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -861,9 +861,13 @@ draw_triangle :: proc(vertices: [3]Vec2, c: Color) {
 
 // Draw a texture a specific position.
 //
+// The top-left corner of the texture will end up at the position. If you use the `crop` parameter
+// to crop out a part of the texture, then the top-left corner of the cropped-out part will be at
+// the position. Also, any non-zero origin will offset the position as well.
+//
 // Optional parameters:
 // - crop: A rectangle that describes which part of `texture` to display. Note that it is a Maybe
-//   type, which means that `nil` means "no cropping".
+//   type, which means that `nil` means "no cropping". Uses pixel coordinates.
 // - origin: The point which `rotation` rotates around. Effectively an offset of `position`.
 // - rotation: Rotation around `origin`, measured in radians.
 // - tint: A color to apply to the texture, in a multiplicative way. WHITE means no tinting.
@@ -871,7 +875,7 @@ draw_triangle :: proc(vertices: [3]Vec2, c: Color) {
 // If you want to rotate around the middle of the texture, then try this:
 // 
 //// middle := k2.rect_middle(k2.get_texture_rect(tex))
-//// draw_texture(tex, pos + middle, origin = middle, rot)
+//// draw_texture(tex, pos + middle, origin = middle, rotation = rot)
 draw_texture :: proc(
 	texture: Texture,
 	position: Vec2,

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1049,6 +1049,11 @@ draw_texture_fit :: proc(
 	batch_vertex(bl, uv5, c)
 }
 
+@(deprecated="Use draw_texture instead. Pass the `rect` into its `crop` argument")
+draw_texture_rect :: proc(tex: Texture, rect: Rect, pos: Vec2, tint := WHITE) {
+	draw_texture(tex, pos, crop = rect, tint = tint)
+}
+
 // Tells you how much space some text of a certain size will use on the screen. The font used is the
 // default font. The return value contains the width and height of the text.
 // Tells you how much space some text of a certain size will use on the screen, using a custom font.

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -124,8 +124,9 @@ init :: proc(
 	// Dummy element so font with index 0 means 'no font'.
 	append_nothing(&s.fonts)
 
-	s.default_font = load_font_from_bytes(DEFAULT_FONT_DATA)
-	_set_font(s.default_font)
+	default_font := load_font_from_bytes(DEFAULT_FONT_DATA)
+	log.assertf(default_font == FONT_DEFAULT, "Default font must be at index %i", FONT_DEFAULT)
+	_set_font(FONT_DEFAULT)
 
 	// Audio
 	{
@@ -211,7 +212,7 @@ shutdown :: proc() {
 	}
 
 	delete(s.events)
-	destroy_font(s.default_font)
+	destroy_font(FONT_DEFAULT)
 	rb.destroy_texture(s.shape_drawing_texture)
 	destroy_shader(s.default_shader)
 	rb.shutdown()
@@ -861,32 +862,41 @@ draw_triangle :: proc(vertices: [3]Vec2, c: Color) {
 	batch_vertex(vertices[2], {0, 1}, c)
 }
 
-
-// Draw a texture at a specific position. The texture will be drawn with its top-left corner at
-// position `pos`.
-//
-// Load textures using `load_texture_from_file` or `load_texture_from_bytes`.
-draw_texture :: proc(tex: Texture, pos: Vec2, tint := WHITE) {
-	draw_texture_ex(
-		tex,
-		{0, 0, f32(tex.width), f32(tex.height)},
-		{pos.x, pos.y, f32(tex.width), f32(tex.height)},
-		{},
-		0,
-		tint,
-	)
-}
-
 // Draw a section of a texture at a specific position. `rect` is a rectangle measured in pixels. It
 // tells the procedure which part of the texture to display. The texture will be drawn with its
 // top-left corner at position `pos`.
-draw_texture_rect :: proc(tex: Texture, rect: Rect, pos: Vec2, tint := WHITE) {
-	draw_texture_ex(
-		tex,
-		rect,
-		{pos.x, pos.y, rect.w, rect.h},
-		{},
-		0,
+draw_texture :: proc(
+	texture: Texture,
+	position: Vec2,
+	texture_src: Rect = RECT_EMPTY,
+	origin: Vec2 = {},
+	rotation: f32 = 0,
+	tint := WHITE
+) {
+	if texture.handle == TEXTURE_NONE || texture.width == 0 || texture.height == 0 {
+		return
+	}
+
+	dst: Rect
+
+	if texture_src != RECT_EMPTY {
+		dst = {
+			position.x, position.y,
+			texture_src.w, texture_src.h,
+		}
+	} else {
+		dst = {
+			position.x, position.y,
+			f32(texture.width), f32(texture.height),
+		}
+	}
+
+	draw_texture_fit(
+		texture,
+		dst,
+		texture_src,
+		origin,
+		rotation,
 		tint,
 	)
 }
@@ -898,8 +908,15 @@ draw_texture_rect :: proc(tex: Texture, rect: Rect, pos: Vec2, tint := WHITE) {
 // Tip: Use `k2.get_texture_rect(tex)` for `src` if you want to draw the whole texture.
 //
 // Rotation unit: Radians.
-draw_texture_ex :: proc(tex: Texture, src: Rect, dst: Rect, origin: Vec2, rotation: f32, tint := WHITE) {
-	if tex.width == 0 || tex.height == 0 {
+draw_texture_fit :: proc(
+	texture: Texture,
+	into: Rect,
+	texture_src: Rect = RECT_EMPTY,
+	origin: Vec2 = {},
+	rotation: f32 = 0,
+	tint := WHITE,
+) {
+	if texture.handle == TEXTURE_NONE || texture.width == 0 || texture.height == 0 {
 		return
 	}
 
@@ -907,15 +924,20 @@ draw_texture_ex :: proc(tex: Texture, src: Rect, dst: Rect, origin: Vec2, rotati
 		draw_current_batch()
 	}
 
-	if s.batch_texture != tex.handle {
+	if s.batch_texture != texture.handle {
 		draw_current_batch()
 	}
 	
-	s.batch_texture = tex.handle
+	s.batch_texture = texture.handle
 
 	flip_x, flip_y: bool
-	src := src
-	dst := dst
+	src := texture_src
+
+	if src == RECT_EMPTY {
+		src = get_texture_rect(texture)
+	}
+
+	dst := into
 
 	if src.w < 0 {
 		flip_x = true
@@ -974,7 +996,7 @@ draw_texture_ex :: proc(tex: Texture, src: Rect, dst: Rect, origin: Vec2, rotati
 		}
 	}
 	
-	ts := Vec2{f32(tex.width), f32(tex.height)}
+	ts := Vec2{f32(texture.width), f32(texture.height)}
 
 	up := Vec2{src.x, src.y} / ts
 	us := Vec2{src.w, src.h} / ts
@@ -1002,7 +1024,7 @@ draw_texture_ex :: proc(tex: Texture, src: Rect, dst: Rect, origin: Vec2, rotati
 	//
 	// Could we do something with the projection matrix while drawing into those render textures
 	// instead? I tried that, but couldn't get it to work.
-	if rb.texture_needs_vertical_flip(tex.handle) {
+	if rb.texture_needs_vertical_flip(texture.handle) {
 		flip_y = !flip_y
 	}
 
@@ -1025,21 +1047,17 @@ draw_texture_ex :: proc(tex: Texture, src: Rect, dst: Rect, origin: Vec2, rotati
 
 // Tells you how much space some text of a certain size will use on the screen. The font used is the
 // default font. The return value contains the width and height of the text.
-measure_text :: proc(text: string, font_size: f32) -> Vec2 {
-	return measure_text_ex(s.default_font, text, font_size)
-}
-
 // Tells you how much space some text of a certain size will use on the screen, using a custom font.
 // The return value contains the width and height of the text.
-measure_text_ex :: proc(font_handle: Font, text: string, font_size: f32) -> Vec2 {
-	if font_handle < 0 || int(font_handle) >= len(s.fonts) {
+measure_text :: proc(text: string, font_size: f32, font: Font = FONT_DEFAULT) -> Vec2 {
+	if font < 0 || int(font) >= len(s.fonts) {
 		return {}
 	}
 
-	font := s.fonts[font_handle]
+	font_object := s.fonts[font]
 
 	// Temporary until I rewrite the font caching system.
-	_set_font(font_handle)
+	_set_font(font)
 
 	// TextBounds from fontstash, but fixed and simplified for my purposes.
 	// The version in there is broken.
@@ -1088,24 +1106,26 @@ measure_text_ex :: proc(font_handle: Font, text: string, font_size: f32) -> Vec2
 		return { max_x, f32(lines)*size }
 	}
 
-	return TextBounds(&s.fs, font.fontstash_handle, font_size, text)
-}
-
-// Draw text at a position with a size. This uses the default font. `pos` will be equal to the 
-// top-left position of the text.
-draw_text :: proc(text: string, pos: Vec2, font_size: f32, color := BLACK) {
-	draw_text_ex(s.default_font, text, pos, font_size, color)
+	return TextBounds(&s.fs, font_object.fontstash_handle, font_size, text)
 }
 
 // Draw text at a position with a size, using a custom font. `pos` will be equal to the  top-left
 // position of the text.
-draw_text_ex :: proc(font_handle: Font, text: string, pos: Vec2, font_size: f32, color := BLACK) {
-	if int(font_handle) >= len(s.fonts) {
+// Draw text at a position with a size. This uses the default font. `pos` will be equal to the 
+// top-left position of the text.
+draw_text :: proc(
+	text: string,
+	pos: Vec2,
+	font_size: f32,
+	color := BLACK,
+	font := FONT_DEFAULT,
+) {
+	if int(font) >= len(s.fonts) {
 		return
 	}
 
-	_set_font(font_handle)
-	font := &s.fonts[font_handle]
+	_set_font(font)
+	font_object := &s.fonts[font]
 	fs.SetSize(&s.fs, font_size)
 	iter := fs.TextIterInit(&s.fs, pos.x, pos.y, text)
 
@@ -1141,7 +1161,7 @@ draw_text_ex :: proc(font_handle: Font, text: string, pos: Vec2, font_size: f32,
 			q.x1 - q.x0, q.y1 - q.y0,
 		}
 
-		draw_texture_ex(font.atlas, src, dst, {}, 0, color)
+		draw_texture_fit(font_object.atlas, dst, src, {}, 0, color)
 	}
 }
 
@@ -3022,11 +3042,6 @@ destroy_font :: proc(font: Font) {
 	s.fs.fonts[f.fontstash_handle].glyphs = {}
 }
 
-// Returns the built-in font of Karl2D (the font is known as "roboto")
-get_default_font :: proc() -> Font {
-	return s.default_font
-}
-
 
 //---------//
 // SHADERS //
@@ -3459,6 +3474,8 @@ Rect :: struct {
 	w, h: f32,
 }
 
+RECT_EMPTY :: Rect{}
+
 // An RGBA (Red, Green, Blue, Alpha) color. Each channel can have a value between 0 and 255.
 Color :: [4]u8
 
@@ -3710,7 +3727,9 @@ Render_Target_Handle :: distinct Handle
 Font :: distinct int
 DEFAULT_FONT_DATA :: #load("default_fonts/roboto.ttf")
 
-FONT_NONE :: Font {}
+FONT_NONE :: Font(0)
+FONT_DEFAULT :: Font(1) // There is always a default font at index 1, loaded in `init`
+
 TEXTURE_NONE :: Texture_Handle {}
 RENDER_TARGET_NONE :: Render_Target_Handle {}
 
@@ -3901,7 +3920,7 @@ State :: struct {
 	gamepad_button_went_up: [MAX_GAMEPADS]#sparse [Gamepad_Button]bool,
 	gamepad_button_is_held: [MAX_GAMEPADS]#sparse [Gamepad_Button]bool,
 
-	default_font: Font,
+	// Also see FONT_NONE and FONT_DEFAULT
 	fonts: [dynamic]Font_Data,
 	shape_drawing_texture: Texture_Handle,
 	batch_font: Font,
@@ -4413,7 +4432,7 @@ _set_font :: proc(fh: Font) {
 	}
 
 	if fh == 0 {
-		fh = s.default_font
+		fh = FONT_DEFAULT
 	}
 
 	font := &s.fonts[fh]

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -669,7 +669,7 @@ set_gamepad_vibration :: proc(gamepad: Gamepad_Index, left: f32, right: f32) {
 //   `(0, 0)`, then the rectangle rotates around the top-left corner of the rectangle. If it is
 //   `(rect.w/2, rect.h/2)` then the rectangle rotates around its center.
 // - rotation: The rotation to apply, in radians
-draw_rect :: proc(rect: Rect, c: Color, origin: Vec2 = {}, rotation: f32 = 0) {
+draw_rect :: proc(rect: Rect, color: Color, origin: Vec2 = {}, rotation: f32 = 0) {
 	if s.vertex_buffer_cpu_used + s.batch_shader.vertex_size * 6 > len(s.vertex_buffer_cpu) {
 		draw_current_batch()
 	}
@@ -718,12 +718,29 @@ draw_rect :: proc(rect: Rect, c: Color, origin: Vec2 = {}, rotation: f32 = 0) {
 		}
 	}
 
-	batch_vertex(tl, {0, 0}, c)
-	batch_vertex(tr, {1, 0}, c)
-	batch_vertex(br, {1, 1}, c)
-	batch_vertex(tl, {0, 0}, c)
-	batch_vertex(br, {1, 1}, c)
-	batch_vertex(bl, {0, 1}, c)
+	batch_vertex(tl, {0, 0}, color)
+	batch_vertex(tr, {1, 0}, color)
+	batch_vertex(br, {1, 1}, color)
+	batch_vertex(tl, {0, 0}, color)
+	batch_vertex(br, {1, 1}, color)
+	batch_vertex(bl, {0, 1}, color)
+}
+
+// Creates a rectangle from a position and a size and draws it using the specified color.
+//
+// Optional parameters:
+// - origin: The point to rotate around, also offsets the position of the rect. If the origin is
+//   `(0, 0)`, then the rectangle rotates around the top-left corner of the rectangle. If it is
+//   `(rect.w/2, rect.h/2)` then the rectangle rotates around its center.
+// - rotation: The rotation to apply, in radians
+draw_rect_vec :: proc(
+	position: Vec2,
+	size: Vec2,
+	color: Color,
+	origin: Vec2 = {},
+	rotation: f32 = 0
+) {
+	draw_rect(rect_from_pos_size(position, size), color, origin, rotation)
 }
 
 // Draw the outline of a rectangle with a specific thickness. The outline is drawn using four

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -743,6 +743,11 @@ draw_rect_vec :: proc(
 	draw_rect(rect_from_pos_size(position, size), color, origin, rotation)
 }
 
+@(deprecated="Use draw_rect instead")
+draw_rect_ex :: proc(r: Rect, origin: Vec2, rot: f32, c: Color) {
+	draw_rect(r, c, origin, rot)
+}
+
 // Draw the outline of a rectangle with a specific thickness. The outline is drawn using four
 // rectangles.
 draw_rect_outline :: proc(r: Rect, thickness: f32, color: Color) {

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -899,7 +899,7 @@ draw_texture :: proc(
 }
 
 // Draw a section of a texture at a position. The section is chosen using the `source` parameter,
-// which is a rectangle that uses pixel cooridnates.
+// which is a rectangle that uses pixel coordinates.
 //
 // Optional parameters:
 // - origin: An offset for the position, and also the point to rotate around.
@@ -1078,10 +1078,8 @@ draw_texture_ex :: proc(tex: Texture, src: Rect, dst: Rect, origin: Vec2, rotati
 	draw_texture_fit(tex, src, dst, origin, rotation, tint)
 }
 
-// Tells you how much space some text of a certain size will use on the screen. The font used is the
-// default font. The return value contains the width and height of the text.
-// Tells you how much space some text of a certain size will use on the screen, using a custom font.
-// The return value contains the width and height of the text.
+// Measures how much space some text of a certain size will use on the screen. Will use the default
+// font unless you specify a custom font.
 measure_text :: proc(text: string, font_size: f32, font: Font = FONT_DEFAULT) -> Vec2 {
 	if font < 0 || int(font) >= len(s.fonts) {
 		return {}

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -916,8 +916,9 @@ draw_texture :: proc(
 //
 // Optional parameters:
 // - crop: A rectangle that describes which part of `texture` to display. Note that it is a Maybe
-//   type, which means that `nil` means "no cropping".
-// - origin: An offset of the `into` rectangle and also the point which `rotation` rotates around.
+//   type, which means that `nil` means "no cropping". Uses pixel coordinates.
+// - origin: The point within `into` to rotate around, measured from the top-left corner. Also
+//   offsets the position of `into`.
 // - rotation: Rotation around `origin`, measured in radians.
 // - tint: A color to apply to the texture, in a multiplicative way. WHITE means no tinting.
 draw_texture_fit :: proc(

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1059,6 +1059,11 @@ draw_texture_rect :: proc(tex: Texture, rect: Rect, pos: Vec2, tint := WHITE) {
 	draw_texture(tex, pos, crop = rect, tint = tint)
 }
 
+@(deprecated="Use draw_texture_fit instead. Note that `dst` is equivalent to `into` and `src` is equivalent to `crop`, which have switched positions in the parameter list.")
+draw_texture_ex :: proc(tex: Texture, src: Rect, dst: Rect, origin: Vec2, rotation: f32, tint := WHITE) {
+	draw_texture_fit(tex, dst, src, origin, rotation, tint)
+}
+
 // Tells you how much space some text of a certain size will use on the screen. The font used is the
 // default font. The return value contains the width and height of the text.
 // Tells you how much space some text of a certain size will use on the screen, using a custom font.

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1180,6 +1180,11 @@ draw_text :: proc(
 	}
 }
 
+@(deprecated="Use draw_text instead")
+draw_text_ex :: proc(font_handle: Font, text: string, pos: Vec2, font_size: f32, color := BLACK) {
+	draw_text(text, pos, font_size, font_handle, color)
+}
+
 //--------------------//
 // TEXTURE MANAGEMENT //
 //--------------------//

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -862,13 +862,23 @@ draw_triangle :: proc(vertices: [3]Vec2, c: Color) {
 	batch_vertex(vertices[2], {0, 1}, c)
 }
 
-// Draw a section of a texture at a specific position. `rect` is a rectangle measured in pixels. It
-// tells the procedure which part of the texture to display. The texture will be drawn with its
-// top-left corner at position `pos`.
+// Draw a texture a specific position.
+//
+// Optional parameters:
+// - crop: A rectangle that describes which part of `texture` to display. Note that it is a Maybe
+//   type, which means that `nil` means "no cropping".
+// - origin: The point which `rotation` rotates around. Effectively an offset of `position`.
+// - rotation: Rotation around `origin`, measured in radians.
+// - tint: A color to apply to the texture, in a multiplicative way. WHITE means no tinting.
+//
+// If you want to rotate around the middle of the texture, then try this:
+// 
+//// middle := k2.rect_middle(k2.get_texture_rect(tex))
+//// draw_texture(tex, pos + middle, origin = middle, rot)
 draw_texture :: proc(
 	texture: Texture,
 	position: Vec2,
-	texture_src: Rect = RECT_EMPTY,
+	crop: Maybe(Rect) = nil,
 	origin: Vec2 = {},
 	rotation: f32 = 0,
 	tint := WHITE
@@ -877,15 +887,15 @@ draw_texture :: proc(
 		return
 	}
 
-	dst: Rect
+	fit_into: Rect
 
-	if texture_src != RECT_EMPTY {
-		dst = {
+	if crop_val, has_crop := crop.?; has_crop {
+		fit_into = {
 			position.x, position.y,
-			texture_src.w, texture_src.h,
+			crop_val.w, crop_val.h,
 		}
 	} else {
-		dst = {
+		fit_into = {
 			position.x, position.y,
 			f32(texture.width), f32(texture.height),
 		}
@@ -893,25 +903,26 @@ draw_texture :: proc(
 
 	draw_texture_fit(
 		texture,
-		dst,
-		texture_src,
+		fit_into,
+		crop,
 		origin,
 		rotation,
 		tint,
 	)
 }
 
-// Draw a texture by taking a section of the texture specified by `src` and draw it into the area of
-// the screen specified by `dst`. You can also rotate the texture around an origin point of your
-// choice.
+// Draw a texture by fitting it into a rectangle.
 //
-// Tip: Use `k2.get_texture_rect(tex)` for `src` if you want to draw the whole texture.
-//
-// Rotation unit: Radians.
+// Optional parameters:
+// - crop: A rectangle that describes which part of `texture` to display. Note that it is a Maybe
+//   type, which means that `nil` means "no cropping".
+// - origin: An offset of the `into` rectangle and also the point which `rotation` rotates around.
+// - rotation: Rotation around `origin`, measured in radians.
+// - tint: A color to apply to the texture, in a multiplicative way. WHITE means no tinting.
 draw_texture_fit :: proc(
 	texture: Texture,
 	into: Rect,
-	texture_src: Rect = RECT_EMPTY,
+	crop: Maybe(Rect) = nil,
 	origin: Vec2 = {},
 	rotation: f32 = 0,
 	tint := WHITE,
@@ -931,12 +942,8 @@ draw_texture_fit :: proc(
 	s.batch_texture = texture.handle
 
 	flip_x, flip_y: bool
-	src := texture_src
 
-	if src == RECT_EMPTY {
-		src = get_texture_rect(texture)
-	}
-
+	src := crop.? or_else get_texture_rect(texture)
 	dst := into
 
 	if src.w < 0 {
@@ -3473,9 +3480,6 @@ Rect :: struct {
 	x, y: f32,
 	w, h: f32,
 }
-
-RECT_EMPTY :: Rect{}
-WHOLE_TEXTURE :: Rect{}
 
 // An RGBA (Red, Green, Blue, Alpha) color. Each channel can have a value between 0 and 255.
 Color :: [4]u8

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1123,17 +1123,21 @@ measure_text_ex :: proc(font_handle: Font, text: string, font_size: f32) -> Vec2
 	return measure_text(text, font_size, font_handle)
 }
 
-// Draw text at a position with a size.
+// Draw text at a position, with a size and color. The position is the top-left position of the
+// text.
 //
 // Optional parameters:
-// - color: The color of the text.
 // - font: The font to use, uses a default font if none is specified.
+// - origin: The origin relative top the top-left position of the text. Used when rotating the text.
+// - rotation: Rotating to apply to the text, measured in radians.
 draw_text :: proc(
 	text: string,
-	pos: Vec2,
+	position: Vec2,
 	font_size: f32,
+	color: Color,
 	font := FONT_DEFAULT,
-	color := BLACK,
+	origin: Vec2 = {},
+	rotation: f32 = 0,
 ) {
 	if int(font) >= len(s.fonts) {
 		return
@@ -1142,13 +1146,13 @@ draw_text :: proc(
 	_set_font(font)
 	font_object := &s.fonts[font]
 	fs.SetSize(&s.fs, font_size)
-	iter := fs.TextIterInit(&s.fs, pos.x, pos.y, text)
+	iter := fs.TextIterInit(&s.fs, position.x, position.y, text)
 
 	q: fs.Quad
 	for fs.TextIterNext(&s.fs, &iter, &q) {
 		if iter.codepoint == '\n' {
 			iter.nexty += font_size
-			iter.nextx = pos.x
+			iter.nextx = position.x
 			continue
 		}
 
@@ -1172,17 +1176,18 @@ draw_text :: proc(
 		src.h *= h
 
 		dst := Rect {
-			q.x0, q.y0,
+			position.x, position.y,
 			q.x1 - q.x0, q.y1 - q.y0,
 		}
 
-		draw_texture_fit(font_object.atlas, dst, src, {}, 0, color)
+		char_origin := origin + {position.x - q.x0, position.y - q.y0}
+		draw_texture_fit(font_object.atlas, dst, src, char_origin, rotation, color)
 	}
 }
 
 @(deprecated="Use draw_text instead")
 draw_text_ex :: proc(font_handle: Font, text: string, pos: Vec2, font_size: f32, color := BLACK) {
-	draw_text(text, pos, font_size, font_handle, color)
+	draw_text(text, pos, font_size, color, font_handle)
 }
 
 //--------------------//

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -859,72 +859,87 @@ draw_triangle :: proc(vertices: [3]Vec2, c: Color) {
 	batch_vertex(vertices[2], {0, 1}, c)
 }
 
-// Draw a texture a specific position.
-//
-// The top-left corner of the texture will end up at the position. If you use the `crop` parameter
-// to crop out a part of the texture, then the top-left corner of the cropped-out part will be at
-// the position. Also, any non-zero origin will offset the position as well.
+// Draw a texture at a position. The top-left corner of the texture will end up at the position.
 //
 // Optional parameters:
-// - crop: A rectangle that describes which part of `texture` to display. Note that it is a Maybe
-//   type, which means that `nil` means "no cropping". Uses pixel coordinates.
-// - origin: The point which `rotation` rotates around. Effectively an offset of `position`.
-// - rotation: Rotation around `origin`, measured in radians.
+// - origin: An offset for the position, and also the point to rotate around.
+// - rotation: Measured in radians. Rotates around the top-left corner, plus any `origin` shift.
 // - tint: A color to apply to the texture, in a multiplicative way. WHITE means no tinting.
 //
 // If you want to rotate around the middle of the texture, then try this:
 // 
 //// middle := k2.rect_middle(k2.get_texture_rect(tex))
-//// draw_texture(tex, pos + middle, origin = middle, rotation = rot)
+//// draw_texture(tex, pos + middle, middle, rot)
 draw_texture :: proc(
 	texture: Texture,
 	position: Vec2,
-	crop: Maybe(Rect) = nil,
 	origin: Vec2 = {},
 	rotation: f32 = 0,
-	tint := WHITE
+	tint := WHITE,
 ) {
 	if texture.handle == TEXTURE_NONE || texture.width == 0 || texture.height == 0 {
 		return
 	}
 
-	fit_into: Rect
+	source := get_texture_rect(texture)
 
-	if crop_val, has_crop := crop.?; has_crop {
-		fit_into = {
-			position.x, position.y,
-			crop_val.w, crop_val.h,
-		}
-	} else {
-		fit_into = {
-			position.x, position.y,
-			f32(texture.width), f32(texture.height),
-		}
+	dest := Rect {
+		position.x, position.y,
+		source.w, source.h,
 	}
 
 	draw_texture_fit(
 		texture,
-		fit_into,
-		crop,
+		source,
+		dest,
 		origin,
 		rotation,
 		tint,
 	)
 }
 
-// Draw a texture by fitting it into a rectangle.
+// Draw a section of a texture at a position. The section is chosen using the `source` parameter,
+// which is a rectangle that uses pixel cooridnates.
 //
 // Optional parameters:
-// - crop: A rectangle that describes which part of `texture` to display. Note that it is a Maybe
-//   type, which means that `nil` means "no cropping". Uses pixel coordinates.
-// - origin: The point within `into` to rotate around, measured from the top-left corner. Also
-//   offsets the position of `into`.
-// - rotation: Rotation around `origin`, measured in radians.
+// - origin: An offset for the position, and also the point to rotate around.
+// - rotation: Measured in radians. Rotates around the top-left corner, plus any `origin` shift.
+// - tint: A color to apply to the texture, in a multiplicative way. WHITE means no tinting.
+draw_texture_section :: proc(
+	texture: Texture,
+	source: Rect,
+	position: Vec2,
+	origin: Vec2 = {},
+	rotation: f32 = 0,
+	tint := WHITE,
+) {
+	dest := Rect {
+		position.x, position.y,
+		source.w, source.h,
+	}
+
+	draw_texture_fit(
+		texture,
+		source,
+		dest,
+		origin,
+		rotation,
+		tint,
+	)
+}
+
+// Draw a section of a texture by fitting it into a rectangle. The section is chosen using the
+// rectangle parameter `source`, measured in pixels. The `dest` parameter is the rectangle on the
+// screen (or in the world) that we want to fit the texture section into.
+//
+// Optional parameters:
+// - origin: An offset for the dest rectangle, and also the point to rotate around.
+// - rotation: Measured in radians. Rotates around the top-left corner, plus any `origin` shift.
 // - tint: A color to apply to the texture, in a multiplicative way. WHITE means no tinting.
 draw_texture_fit :: proc(
 	texture: Texture,
-	into: Rect,
-	crop: Maybe(Rect) = nil,
+	source: Rect,
+	dest: Rect,
 	origin: Vec2 = {},
 	rotation: f32 = 0,
 	tint := WHITE,
@@ -944,43 +959,42 @@ draw_texture_fit :: proc(
 	s.batch_texture = texture.handle
 
 	flip_x, flip_y: bool
+	source := source
+	dest := dest
 
-	src := crop.? or_else get_texture_rect(texture)
-	dst := into
-
-	if src.w < 0 {
+	if source.w < 0 {
 		flip_x = true
-		src.w = -src.w
+		source.w = -source.w
 	}
 
-	if src.h < 0 {
+	if source.h < 0 {
 		flip_y = true
-		src.h = -src.h
+		source.h = -source.h
 	}
 
-	if dst.w < 0 {
-		dst.w *= -1
+	if dest.w < 0 {
+		dest.w *= -1
 	}
 
-	if dst.h < 0 {
-		dst.h *= -1
+	if dest.h < 0 {
+		dest.h *= -1
 	}
 
 	tl, tr, bl, br: Vec2
 
 	// Rotation adapted from Raylib's "DrawTexturePro"
 	if rotation == 0 {
-		x := dst.x - origin.x
-		y := dst.y - origin.y
+		x := dest.x - origin.x
+		y := dest.y - origin.y
 		tl = { x,         y }
-		tr = { x + dst.w, y }
-		bl = { x,         y + dst.h }
-		br = { x + dst.w, y + dst.h }
+		tr = { x + dest.w, y }
+		bl = { x,         y + dest.h }
+		br = { x + dest.w, y + dest.h }
 	} else {
 		sin_rot := math.sin(rotation)
 		cos_rot := math.cos(rotation)
-		x := dst.x
-		y := dst.y
+		x := dest.x
+		y := dest.y
 		dx := -origin.x
 		dy := -origin.y
 
@@ -990,25 +1004,25 @@ draw_texture_fit :: proc(
 		}
 
 		tr = {
-			x + (dx + dst.w) * cos_rot - dy * sin_rot,
-			y + (dx + dst.w) * sin_rot + dy * cos_rot,
+			x + (dx + dest.w) * cos_rot - dy * sin_rot,
+			y + (dx + dest.w) * sin_rot + dy * cos_rot,
 		}
 
 		bl = {
-			x + dx * cos_rot - (dy + dst.h) * sin_rot,
-			y + dx * sin_rot + (dy + dst.h) * cos_rot,
+			x + dx * cos_rot - (dy + dest.h) * sin_rot,
+			y + dx * sin_rot + (dy + dest.h) * cos_rot,
 		}
 
 		br = {
-			x + (dx + dst.w) * cos_rot - (dy + dst.h) * sin_rot,
-			y + (dx + dst.w) * sin_rot + (dy + dst.h) * cos_rot,
+			x + (dx + dest.w) * cos_rot - (dy + dest.h) * sin_rot,
+			y + (dx + dest.w) * sin_rot + (dy + dest.h) * cos_rot,
 		}
 	}
 	
 	ts := Vec2{f32(texture.width), f32(texture.height)}
 
-	up := Vec2{src.x, src.y} / ts
-	us := Vec2{src.w, src.h} / ts
+	up := Vec2{source.x, source.y} / ts
+	us := Vec2{source.w, source.h} / ts
 	
 	c := tint
 
@@ -1054,14 +1068,14 @@ draw_texture_fit :: proc(
 	batch_vertex(bl, uv5, c)
 }
 
-@(deprecated="Use draw_texture instead. Pass the `rect` into its `crop` argument")
+@(deprecated="Use draw_texture_section instead")
 draw_texture_rect :: proc(tex: Texture, rect: Rect, pos: Vec2, tint := WHITE) {
-	draw_texture(tex, pos, crop = rect, tint = tint)
+	draw_texture_section(tex, rect, pos, tint = tint)
 }
 
-@(deprecated="Use draw_texture_fit instead. Note that `dst` is equivalent to `into` and `src` is equivalent to `crop`, which have switched positions in the parameter list.")
+@(deprecated="Use draw_texture_fit instead")
 draw_texture_ex :: proc(tex: Texture, src: Rect, dst: Rect, origin: Vec2, rotation: f32, tint := WHITE) {
-	draw_texture_fit(tex, dst, src, origin, rotation, tint)
+	draw_texture_fit(tex, src, dst, origin, rotation, tint)
 }
 
 // Tells you how much space some text of a certain size will use on the screen. The font used is the
@@ -1191,7 +1205,7 @@ draw_text :: proc(
 		}
 
 		char_origin := origin + {position.x - q.x0, position.y - q.y0}
-		draw_texture_fit(font_object.atlas, dst, src, char_origin, rotation, color)
+		draw_texture_fit(font_object.atlas, src, dst, char_origin, rotation, color)
 	}
 }
 

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -3062,6 +3062,10 @@ destroy_font :: proc(font: Font) {
 	s.fs.fonts[f.fontstash_handle].glyphs = {}
 }
 
+@(deprecated="Use FONT_DEFAULT constant instead")
+get_default_font :: proc() -> Font {
+	return FONT_DEFAULT
+}
 
 //---------//
 // SHADERS //
@@ -3746,7 +3750,10 @@ Font :: distinct int
 DEFAULT_FONT_DATA :: #load("default_fonts/roboto.ttf")
 
 FONT_NONE :: Font(0)
-FONT_DEFAULT :: Font(1) // There is always a default font at index 1, loaded in `init`
+
+// The default font. It's a font called "roboto". It is loaded from `DEFAULT_FONT_DATA` on Karl2D is
+// initialized.
+FONT_DEFAULT :: Font(1) 
 
 TEXTURE_NONE :: Texture_Handle {}
 RENDER_TARGET_NONE :: Render_Target_Handle {}

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -663,38 +663,13 @@ set_gamepad_vibration :: proc(gamepad: Gamepad_Index, left: f32, right: f32) {
 
 // Draw a colored rectangle. The rectangles have their (x, y) position in the top-left corner of the
 // rectangle.
-draw_rect :: proc(r: Rect, c: Color) {
-	if s.vertex_buffer_cpu_used + s.batch_shader.vertex_size * 6 > len(s.vertex_buffer_cpu) {
-		draw_current_batch()
-	}
-
-	if s.batch_texture != s.shape_drawing_texture {
-		draw_current_batch()
-	}
-
-	s.batch_texture = s.shape_drawing_texture
-
-	batch_vertex({r.x, r.y}, {0, 0}, c)
-	batch_vertex({r.x + r.w, r.y}, {1, 0}, c)
-	batch_vertex({r.x + r.w, r.y + r.h}, {1, 1}, c)
-	batch_vertex({r.x, r.y}, {0, 0}, c)
-	batch_vertex({r.x + r.w, r.y + r.h}, {1, 1}, c)
-	batch_vertex({r.x, r.y + r.h}, {0, 1}, c)
-}
-
-// Creates a rectangle from a position and a size and draws it.
-draw_rect_vec :: proc(pos: Vec2, size: Vec2, c: Color) {
-	draw_rect({pos.x, pos.y, size.x, size.y}, c)
-}
-
-// Draw a rectangle with a custom origin and rotation.
 //
-// The origin says which point the rotation rotates around. If the origin is `(0, 0)`, then the
-// rectangle rotates around the top-left corner of the rectangle. If it is `(rect.w/2, rect.h/2)`
-// then the rectangle rotates around its center.
-//
-// Rotation unit: Radians.
-draw_rect_ex :: proc(r: Rect, origin: Vec2, rot: f32, c: Color) {
+// Optional parameters:
+// - origin: The point to rotate around, also offsets the position of the rect. If the origin is
+//   `(0, 0)`, then the rectangle rotates around the top-left corner of the rectangle. If it is
+//   `(rect.w/2, rect.h/2)` then the rectangle rotates around its center.
+// - rotation: The rotation to apply, in radians
+draw_rect :: proc(rect: Rect, c: Color, origin: Vec2 = {}, rotation: f32 = 0) {
 	if s.vertex_buffer_cpu_used + s.batch_shader.vertex_size * 6 > len(s.vertex_buffer_cpu) {
 		draw_current_batch()
 	}
@@ -707,18 +682,18 @@ draw_rect_ex :: proc(r: Rect, origin: Vec2, rot: f32, c: Color) {
 	tl, tr, bl, br: Vec2
 
 	// Rotation adapted from Raylib's "DrawTexturePro"
-	if rot == 0 {
-		x := r.x - origin.x
-		y := r.y - origin.y
-		tl = { x,         y }
-		tr = { x + r.w, y }
-		bl = { x,         y + r.h }
-		br = { x + r.w, y + r.h }
+	if rotation == 0 {
+		x := rect.x - origin.x
+		y := rect.y - origin.y
+		tl = { x,          y }
+		tr = { x + rect.w, y }
+		bl = { x,          y + rect.h }
+		br = { x + rect.w, y + rect.h }
 	} else {
-		sin_rot := math.sin(rot)
-		cos_rot := math.cos(rot)
-		x := r.x
-		y := r.y
+		sin_rot := math.sin(rotation)
+		cos_rot := math.cos(rotation)
+		x := rect.x
+		y := rect.y
 		dx := -origin.x
 		dy := -origin.y
 
@@ -728,18 +703,18 @@ draw_rect_ex :: proc(r: Rect, origin: Vec2, rot: f32, c: Color) {
 		}
 
 		tr = {
-			x + (dx + r.w) * cos_rot - dy * sin_rot,
-			y + (dx + r.w) * sin_rot + dy * cos_rot,
+			x + (dx + rect.w) * cos_rot - dy * sin_rot,
+			y + (dx + rect.w) * sin_rot + dy * cos_rot,
 		}
 
 		bl = {
-			x + dx * cos_rot - (dy + r.h) * sin_rot,
-			y + dx * sin_rot + (dy + r.h) * cos_rot,
+			x + dx * cos_rot - (dy + rect.h) * sin_rot,
+			y + dx * sin_rot + (dy + rect.h) * cos_rot,
 		}
 
 		br = {
-			x + (dx + r.w) * cos_rot - (dy + r.h) * sin_rot,
-			y + (dx + r.w) * sin_rot + (dy + r.h) * cos_rot,
+			x + (dx + rect.w) * cos_rot - (dy + rect.h) * sin_rot,
+			y + (dx + rect.w) * sin_rot + (dy + rect.h) * cos_rot,
 		}
 	}
 
@@ -841,7 +816,7 @@ draw_line :: proc(start: Vec2, end: Vec2, thickness: f32, color: Color) {
 
 	rot := math.atan2(end.y - start.y, end.x - start.x)
 
-	draw_rect_ex(r, origin, rot, color)
+	draw_rect(r, color, origin, rot)
 }
 
 // Draws a triangle using three vertices. The order of the vertices does not matter: Clockwise and

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1118,6 +1118,11 @@ measure_text :: proc(text: string, font_size: f32, font: Font = FONT_DEFAULT) ->
 	return TextBounds(&s.fs, font_object.fontstash_handle, font_size, text)
 }
 
+@(deprecated="Use measure_text(text, font_size, font) instead")
+measure_text_ex :: proc(font_handle: Font, text: string, font_size: f32) -> Vec2 {
+	return measure_text(text, font_size, font_handle)
+}
+
 // Draw text at a position with a size.
 //
 // Optional parameters:

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1091,16 +1091,17 @@ measure_text :: proc(text: string, font_size: f32, font: Font = FONT_DEFAULT) ->
 	return TextBounds(&s.fs, font_object.fontstash_handle, font_size, text)
 }
 
-// Draw text at a position with a size, using a custom font. `pos` will be equal to the  top-left
-// position of the text.
-// Draw text at a position with a size. This uses the default font. `pos` will be equal to the 
-// top-left position of the text.
+// Draw text at a position with a size.
+//
+// Optional parameters:
+// - color: The color of the text.
+// - font: The font to use, uses a default font if none is specified.
 draw_text :: proc(
 	text: string,
 	pos: Vec2,
 	font_size: f32,
-	color := BLACK,
 	font := FONT_DEFAULT,
+	color := BLACK,
 ) {
 	if int(font) >= len(s.fonts) {
 		return

--- a/tools/api_doc_builder/api_doc_builder.odin
+++ b/tools/api_doc_builder/api_doc_builder.odin
@@ -43,6 +43,13 @@ main :: proc() {
 		decl_loop: for &d in f.decls {
 			#partial switch &dd in d.derived {
 			case ^ast.Value_Decl:
+				for a in dd.attributes {
+					attr_text := f.src[a.pos.offset:a.close.offset]
+					if strings.contains(attr_text, "deprecated") {
+						continue decl_loop						
+					}
+				}
+
 				val: string
 				for v, vi in dd.values {
 					#partial switch vd in v.derived {


### PR DESCRIPTION
API changes for the `draw_texture` procs so we always have origin and rotation available. Renamed the procs to more descriptive names. I've added deprecated versions of the old procs where possible.

```odin
draw_texture :: proc(
	texture: Texture,
	position: Vec2,
	origin: Vec2 = {},
	rotation: f32 = 0,
	tint := WHITE,
)

draw_texture_section :: proc(
	texture: Texture,
	source: Rect,
	position: Vec2,
	origin: Vec2 = {},
	rotation: f32 = 0,
	tint := WHITE,
)

draw_texture_fit :: proc(
	texture: Texture,
	source: Rect,
	dest: Rect,
	origin: Vec2 = {},
	rotation: f32 = 0,
	tint := WHITE,
)
```

Also added origin + rotation to `draw_text`, inspired by #54 