### PR TITLE
fix doc formatting for code blocks

### DIFF
--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -33,24 +33,27 @@ init :: proc(
 // application to decide if it wants to shut down or if it (for example) wants to show a 
 // confirmation dialogue.
 //
-// Commonly used for creating the "main loop" of a game: `for k2.update() {}`
+// Commonly used for creating the "main loop" of a game: 
+// 
+//	for k2.update() {}
 //
 // To get more control over how the frame is set up, you can skip calling this proc and instead use
 // the procs it calls directly:
 //
-//// for {
-////     k2.reset_frame_allocator()
-////     k2.calculate_frame_time()
-////     k2.process_events()
-////     k2.update_audio_mixer()
-////     
-////     k2.clear(k2.BLUE)
-////     k2.present()
-////     
-////     if k2.close_window_requested() {
-////         break
-////     }
-//// }
+//
+////	for {
+////	     k2.reset_frame_allocator()
+////	     k2.calculate_frame_time()
+////	     k2.process_events()
+////	     k2.update_audio_mixer()
+////	     
+////	     k2.clear(k2.BLUE)
+////	     k2.present()
+////	     
+////	     if k2.close_window_requested() {
+////	         break
+////	     }
+////	 }
 update :: proc() -> bool
 
 // Returns true the user has pressed the close button on the window, or used a key stroke such as
@@ -197,14 +200,15 @@ key_is_held :: proc(key: Keyboard_Key) -> bool
 // Returns which modifiers are held. The possible values are `Control`, `Alt`, `Shift` and `Super`.
 // You can check that an exact set of modifiers are held like so:
 //
-// `if k2.get_held_modifiers() == { .Control, Shift} {}`
+//	if k2.get_held_modifiers() == { .Control, Shift} {}
 //
 // This will only be true if left/right control are held and left/right shift are held, but it also
 // makes sure that no alt or super (windows) key are held.
 //
 // This is useful for checking for held modifiers for hotkeys in user interfaces. If you want to
 // associate an in-game action with a specific key such as Left Control, then it's better to just do
-// `if k2.key_is_held(.Left_Control) {}`
+// 
+//	if k2.key_is_held(.Left_Control) {}
 get_held_modifiers :: proc() -> bit_set[Modifier]
 
 // Returns true if a mouse button went down between the current and the previous frame. Specify
@@ -314,8 +318,8 @@ draw_triangle :: proc(vertices: [3]Vec2, c: Color)
 //
 // If you want to rotate around the middle of the texture, then try this:
 // 
-//// middle := k2.rect_middle(k2.get_texture_rect(tex))
-//// draw_texture(tex, pos + middle, middle, rot)
+//// 	middle := k2.rect_middle(k2.get_texture_rect(tex))
+//// 	draw_texture(tex, pos + middle, middle, rot)
 draw_texture :: proc(
 	texture: Texture,
 	position: Vec2,

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -161,24 +161,27 @@ init :: proc(
 // application to decide if it wants to shut down or if it (for example) wants to show a 
 // confirmation dialogue.
 //
-// Commonly used for creating the "main loop" of a game: `for k2.update() {}`
+// Commonly used for creating the "main loop" of a game: 
+// 
+//	for k2.update() {}
 //
 // To get more control over how the frame is set up, you can skip calling this proc and instead use
 // the procs it calls directly:
 //
-//// for {
-////     k2.reset_frame_allocator()
-////     k2.calculate_frame_time()
-////     k2.process_events()
-////     k2.update_audio_mixer()
-////     
-////     k2.clear(k2.BLUE)
-////     k2.present()
-////     
-////     if k2.close_window_requested() {
-////         break
-////     }
-//// }
+//
+////	for {
+////	     k2.reset_frame_allocator()
+////	     k2.calculate_frame_time()
+////	     k2.process_events()
+////	     k2.update_audio_mixer()
+////	     
+////	     k2.clear(k2.BLUE)
+////	     k2.present()
+////	     
+////	     if k2.close_window_requested() {
+////	         break
+////	     }
+////	 }
 update :: proc() -> bool {
 	reset_frame_allocator()
 	calculate_frame_time()
@@ -545,14 +548,15 @@ key_is_held :: proc(key: Keyboard_Key) -> bool {
 // Returns which modifiers are held. The possible values are `Control`, `Alt`, `Shift` and `Super`.
 // You can check that an exact set of modifiers are held like so:
 //
-// `if k2.get_held_modifiers() == { .Control, Shift} {}`
+//	if k2.get_held_modifiers() == { .Control, Shift} {}
 //
 // This will only be true if left/right control are held and left/right shift are held, but it also
 // makes sure that no alt or super (windows) key are held.
 //
 // This is useful for checking for held modifiers for hotkeys in user interfaces. If you want to
 // associate an in-game action with a specific key such as Left Control, then it's better to just do
-// `if k2.key_is_held(.Left_Control) {}`
+// 
+//	if k2.key_is_held(.Left_Control) {}
 get_held_modifiers :: proc() -> bit_set[Modifier] {
 	res: bit_set[Modifier]
 
@@ -873,8 +877,8 @@ draw_triangle :: proc(vertices: [3]Vec2, c: Color) {
 //
 // If you want to rotate around the middle of the texture, then try this:
 // 
-//// middle := k2.rect_middle(k2.get_texture_rect(tex))
-//// draw_texture(tex, pos + middle, middle, rot)
+//// 	middle := k2.rect_middle(k2.get_texture_rect(tex))
+//// 	draw_texture(tex, pos + middle, middle, rot)
 draw_texture :: proc(
 	texture: Texture,
 	position: Vec2,


### PR DESCRIPTION
Changes from this:
<img width="1046" height="502" alt="image" src="https://github.com/user-attachments/assets/83cb5e3b-9de8-481a-ada6-18f953ff05e3" />

To this:
<img width="1004" height="569" alt="image" src="https://github.com/user-attachments/assets/c32bd831-52e1-40ad-b27f-31383680ebe8" />

Only done for the larger code blocks, not the parts with "`"