### PR TITLE
draw_texture_section -> draw_texture_rect

### DIFF
--- a/examples/dual_grid_tilemap/dual_grid_tilemap.odin
+++ b/examples/dual_grid_tilemap/dual_grid_tilemap.odin
@@ -156,7 +156,7 @@ step :: proc() -> bool {
 		// Always draw "grass" below the tile, as they have transparent pixels.
 		k2.draw_rect(k2.rect_from_pos_size(pos, {TILE_SIZE, TILE_SIZE}), k2.LIGHT_GREEN)
 
-		k2.draw_texture_section(
+		k2.draw_texture_rect(
 			tileset_path_texture,
 			tile_rect,
 			pos,

--- a/examples/space_cat/space_cat.odin
+++ b/examples/space_cat/space_cat.odin
@@ -850,7 +850,7 @@ draw :: proc() {
 			r.w *= -1
 		}
 
-		k2.draw_texture_section(
+		k2.draw_texture_rect(
 			s.tex,
 			r,
 			s.pos,
@@ -971,7 +971,7 @@ dual_grid_draw :: proc(world: World, x, y: int) {
 		f32(y) * TILE_SIZE - TILE_SIZE/2,
 	}
 
-	k2.draw_texture_section(space_tileset, tile_rect, pos)
+	k2.draw_texture_rect(space_tileset, tile_rect, pos)
 }
 
 DUAL_GRID_MASK_TO_TXTY := [16][2]int {

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -328,8 +328,8 @@ draw_texture :: proc(
 	tint := WHITE,
 )
 
-// Draw a section of a texture at a position. The section is chosen using the `source` parameter,
-// which is a rectangle that uses pixel coordinates. You can flip the texture by using negative
+// Draw a texture at a position, but only draw the region specified by the `source` rectangle. The
+// `source` rectangle is specified in pixel coordinates. You can flip the texture by using negative
 // width/height in `source`.
 //
 // Optional parameters:
@@ -345,9 +345,9 @@ draw_texture_rect :: proc(
 	tint := WHITE,
 )
 
-// Draw a section of a texture by fitting it into a rectangle. The section is chosen using the
-// rectangle parameter `source`, measured in pixels. The `dest` parameter is the rectangle on the
-// screen (or in the world) that we want to fit the texture section into.
+// Draw a texture by selecting a `source` rectangle and fitting it into a `dest` (destination)
+// rectangle. `source` is measured in texture-space pixels and `dest` is measured in world-space
+// pixels. You can flip the texture by using negative width/height for the `source` rectangle.
 //
 // Optional parameters:
 // - origin: An offset for the dest rectangle, and also the point to rotate around.

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -329,13 +329,14 @@ draw_texture :: proc(
 )
 
 // Draw a section of a texture at a position. The section is chosen using the `source` parameter,
-// which is a rectangle that uses pixel coordinates.
+// which is a rectangle that uses pixel coordinates. You can flip the texture by using negative
+// width/height in `source`.
 //
 // Optional parameters:
 // - origin: An offset for the position, and also the point to rotate around.
 // - rotation: Measured in radians. Rotates around the top-left corner, plus any `origin` shift.
 // - tint: A color to apply to the texture, in a multiplicative way. WHITE means no tinting.
-draw_texture_section :: proc(
+draw_texture_rect :: proc(
 	texture: Texture,
 	source: Rect,
 	position: Vec2,

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -909,8 +909,8 @@ draw_texture :: proc(
 	)
 }
 
-// Draw a section of a texture at a position. The section is chosen using the `source` parameter,
-// which is a rectangle that uses pixel coordinates. You can flip the texture by using negative
+// Draw a texture at a position, but only draw the region specified by the `source` rectangle. The
+// `source` rectangle is specified in pixel coordinates. You can flip the texture by using negative
 // width/height in `source`.
 //
 // Optional parameters:
@@ -940,9 +940,9 @@ draw_texture_rect :: proc(
 	)
 }
 
-// Draw a section of a texture by fitting it into a rectangle. The section is chosen using the
-// rectangle parameter `source`, measured in pixels. The `dest` parameter is the rectangle on the
-// screen (or in the world) that we want to fit the texture section into.
+// Draw a texture by selecting a `source` rectangle and fitting it into a `dest` (destination)
+// rectangle. `source` is measured in texture-space pixels and `dest` is measured in world-space
+// pixels. You can flip the texture by using negative width/height for the `source` rectangle.
 //
 // Optional parameters:
 // - origin: An offset for the dest rectangle, and also the point to rotate around.

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -910,13 +910,14 @@ draw_texture :: proc(
 }
 
 // Draw a section of a texture at a position. The section is chosen using the `source` parameter,
-// which is a rectangle that uses pixel coordinates.
+// which is a rectangle that uses pixel coordinates. You can flip the texture by using negative
+// width/height in `source`.
 //
 // Optional parameters:
 // - origin: An offset for the position, and also the point to rotate around.
 // - rotation: Measured in radians. Rotates around the top-left corner, plus any `origin` shift.
 // - tint: A color to apply to the texture, in a multiplicative way. WHITE means no tinting.
-draw_texture_section :: proc(
+draw_texture_rect :: proc(
 	texture: Texture,
 	source: Rect,
 	position: Vec2,
@@ -1083,9 +1084,16 @@ draw_texture_fit :: proc(
 	batch_vertex(bl, uv5, c)
 }
 
-@(deprecated="Use draw_texture_section instead")
-draw_texture_rect :: proc(tex: Texture, rect: Rect, pos: Vec2, tint := WHITE) {
-	draw_texture_section(tex, rect, pos, tint = tint)
+@(deprecated="Use draw_texture_rect instead")
+draw_texture_section :: proc(
+	texture: Texture,
+	source: Rect,
+	position: Vec2,
+	origin: Vec2 = {},
+	rotation: f32 = 0,
+	tint := WHITE,
+) {
+	draw_texture_rect(texture, source, position, origin, rotation, tint)
 }
 
 @(deprecated="Use draw_texture_fit instead")


### PR DESCRIPTION
My `draw_texture_section` name turned out awkward.

Quite often we just use this proc to flip a texture (by negating the width/height of the source rectangle). Therefore the word `section` does not make sense.

I have therefore reverted to `draw_texture_rect`