### PR TITLE
Fixed "BadMatch" issue on Linux Mint (X11) - Window was crashing after opening.

### DIFF
--- a/platform_linux_glue_gl_x11.odin
+++ b/platform_linux_glue_gl_x11.odin
@@ -1,55 +1,71 @@
+#+build linux
 // Glues together OpenGL with an X11 window. This is done by making a glX context and using it to
 // SwapBuffers etc.
-#+build linux
+
 
 package karl2d
 
+import "base:runtime"
+import "core:slice"
+import "log"
 import "platform_bindings/linux/glx"
 import gl "vendor:OpenGL"
 import X "vendor:x11/xlib"
-import "log"
-import "base:runtime"
-import "core:slice"
 
-@(private="package")
+@(private = "package")
 make_linux_gl_x11_glue :: proc(
 	display: ^X.Display,
 	window: X.Window,
 	allocator: runtime.Allocator,
-	loc := #caller_location
+	loc := #caller_location,
 ) -> Window_Render_Glue {
 	state := new(Linux_GL_X11_Glue_State, allocator, loc)
 	state.display = display
 	state.window = window
 	state.allocator = allocator
 	return {
-		state = (^Window_Render_Glue_State)(state),
+		state            = (^Window_Render_Glue_State)(state),
 
 		// these casts just make the proc take a Windows_GL_Glue_State instead of a Window_Render_Glue_State
-		make_context = cast(proc(state: ^Window_Render_Glue_State, options: Init_Options) -> bool)(linux_gl_x11_glue_make_context),
-		present = cast(proc(state: ^Window_Render_Glue_State))(linux_gl_x11_glue_present),
-		destroy = cast(proc(state: ^Window_Render_Glue_State))(linux_gl_x11_glue_destroy),
-		viewport_resized = cast(proc(state: ^Window_Render_Glue_State))(linux_gl_x11_glue_viewport_resized),
+		make_context     = cast(proc(
+			state: ^Window_Render_Glue_State,
+			options: Init_Options,
+		) -> bool)(linux_gl_x11_glue_make_context),
+		present          = cast(proc(state: ^Window_Render_Glue_State))(linux_gl_x11_glue_present),
+		destroy          = cast(proc(state: ^Window_Render_Glue_State))(linux_gl_x11_glue_destroy),
+		viewport_resized = cast(proc(
+			state: ^Window_Render_Glue_State,
+		))(linux_gl_x11_glue_viewport_resized),
 	}
 }
 
 Linux_GL_X11_Glue_State :: struct {
-	display: ^X.Display,
-	window: X.Window,
-	gl_ctx: ^glx.Context,
+	display:   ^X.Display,
+	window:    X.Window,
+	gl_ctx:    ^glx.Context,
 	allocator: runtime.Allocator,
 }
 
-linux_gl_x11_glue_make_context :: proc(s: ^Linux_GL_X11_Glue_State, options: Init_Options) -> bool {
+linux_gl_x11_glue_make_context :: proc(
+	s: ^Linux_GL_X11_Glue_State,
+	options: Init_Options,
+) -> bool {
 	visual_attribs := slice.to_dynamic(
 		[]i32 {
-			glx.RENDER_TYPE, glx.RGBA_BIT,
-			glx.DRAWABLE_TYPE, glx.WINDOW_BIT,
-			glx.DOUBLEBUFFER, 1,
-			glx.RED_SIZE, 8,
-			glx.GREEN_SIZE, 8,
-			glx.BLUE_SIZE, 8,
-			glx.ALPHA_SIZE, 8,
+			glx.RENDER_TYPE,
+			glx.RGBA_BIT,
+			glx.DRAWABLE_TYPE,
+			glx.WINDOW_BIT,
+			glx.DOUBLEBUFFER,
+			1,
+			glx.RED_SIZE,
+			8,
+			glx.GREEN_SIZE,
+			8,
+			glx.BLUE_SIZE,
+			8,
+			glx.ALPHA_SIZE,
+			0,
 		},
 		frame_allocator,
 	)
@@ -65,7 +81,7 @@ linux_gl_x11_glue_make_context :: proc(s: ^Linux_GL_X11_Glue_State, options: Ini
 	num_fbc: i32
 	screen := X.DefaultScreen(s.display)
 	fbc := glx.ChooseFBConfig(s.display, screen, raw_data(visual_attribs), &num_fbc)
-   
+
 	if fbc == nil {
 		log.error("Failed choosing GLX framebuffer config")
 		return false
@@ -73,7 +89,7 @@ linux_gl_x11_glue_make_context :: proc(s: ^Linux_GL_X11_Glue_State, options: Ini
 
 	glxCreateContextAttribsARB: glx.CreateContextAttribsARBProc
 	glx.SetProcAddress((rawptr)(&glxCreateContextAttribsARB), "glXCreateContextAttribsARB")
-	
+
 	if glxCreateContextAttribsARB == {} {
 		log.error("Failed fetching glXCreateContextAttribsARB")
 		return false
@@ -88,9 +104,12 @@ linux_gl_x11_glue_make_context :: proc(s: ^Linux_GL_X11_Glue_State, options: Ini
 	}
 
 	context_attribs := []i32 {
-		glx.CONTEXT_MAJOR_VERSION_ARB, 3,
-		glx.CONTEXT_MINOR_VERSION_ARB, 3,
-		glx.CONTEXT_PROFILE_MASK_ARB, glx.CONTEXT_CORE_PROFILE_BIT_ARB,
+		glx.CONTEXT_MAJOR_VERSION_ARB,
+		3,
+		glx.CONTEXT_MINOR_VERSION_ARB,
+		3,
+		glx.CONTEXT_PROFILE_MASK_ARB,
+		glx.CONTEXT_CORE_PROFILE_BIT_ARB,
 		0,
 	}
 


### PR DESCRIPTION
I had this issue on Linux mint with KDE Plasma (X11):
> /home/fmatttt/Desarrollos/physics_odin/build.sh
X Error of failed request:  BadMatch (invalid parameter attributes)
  Major opcode of failed request:  152 (GLX)
  Minor opcode of failed request:  5 (X_GLXMakeCurrent)
  Serial number of failed request:  51
  Current serial number in output stream:  51
ERROR: exit code 1  [Elapsed: 1.038s]

The window was opening but crashing instantly, throwing the error above.

The way I fixed it was by changing the ALPHA_SIZE from 8 to 0 inside the "platform_linux_glue_gl_x11.odin" file. 
After doing that everything was working just fine.

I don't know if this is the right/best solution. As far as I understand gl was trying to use a 32bit visual which doesn't work for X11 (since it uses 24bit).