### PR TITLE
Added draw_polygon proc, custom UV and texture wrap support.

### DIFF
--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -309,6 +309,18 @@ draw_line :: proc(start: Vec2, end: Vec2, thickness: f32, color: Color)
 // counter-clockwise triangles will give the same result.
 draw_triangle :: proc(vertices: [3]Vec2, c: Color)
 
+// One vertex has a position (2D), texture coordinates (2D) and a color attribute.
+Vertex :: struct {
+	position: Vec2,
+	texcoord: Vec2,
+	color:    Color,
+}
+
+// Draw a triangle using a list of vertices. Every group of 3 consecutive vertices form a triangle.
+// each vertex can carry custom uv coordinates to make it possible to create texture patterns.
+// If no texture is supplied it uses a solid color
+draw_polygon :: proc(vertices: []Vertex, texture := TEXTURE_NONE)
+
 // Draw a texture at a position. The top-left corner of the texture will end up at the position.
 //
 // Optional parameters:
@@ -435,6 +447,9 @@ set_texture_filter_ex :: proc(
 	scale_up_filter: Texture_Filter,
 	mip_filter: Texture_Filter,
 )
+
+// Controls how a texture wraps when UV coordinates fall outside the [0, 1] range.
+set_texture_wrap :: proc(t: Texture, wrap: Texture_Wrap)
 
 //-------//
 // AUDIO //
@@ -1012,6 +1027,11 @@ Render_Texture :: struct {
 Texture_Filter :: enum {
 	Point,  // Similar to "nearest neighbor". Pixly texture scaling.
 	Linear, // Smoothed texture scaling.
+}
+
+Texture_Wrap :: enum {
+	Clamp,  // UV coords get clamped to the edge of the texture.
+	Repeat, // Coordinates tile and wrap around the texture.
 }
 
 Camera :: struct {

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -868,6 +868,40 @@ draw_triangle :: proc(vertices: [3]Vec2, c: Color) {
 	batch_vertex(vertices[2], {0, 1}, c)
 }
 
+// One vertex has a position (2D), texture coordinates (2D) and a color attribute.
+Vertex :: struct {
+	position: Vec2,
+	texcoord: Vec2,
+	color:    Color,
+}
+
+// Draw a triangle using a list of vertices. Every group of 3 consecutive vertices form a triangle.
+// each vertex can carry custom uv coordinates to make it possible to create texture patterns.
+// If no texture is supplied it uses a solid color
+draw_polygon :: proc(vertices: []Vertex, texture := TEXTURE_NONE) {
+	if s.vertex_buffer_cpu_used + s.batch_shader.vertex_size * len(vertices) > len(s.vertex_buffer_cpu) {
+		draw_current_batch()
+	}
+
+	if texture == TEXTURE_NONE {
+		if s.batch_texture != s.shape_drawing_texture {
+			draw_current_batch()
+		}
+
+		s.batch_texture = s.shape_drawing_texture
+	} else {
+		if s.batch_texture != texture {
+			draw_current_batch()
+		}
+
+		s.batch_texture = texture
+	}
+
+	for v in vertices {
+		batch_vertex(v.position, v.texcoord, v.color)
+	}
+}
+
 // Draw a texture at a position. The top-left corner of the texture will end up at the position.
 //
 // Optional parameters:
@@ -1374,6 +1408,11 @@ set_texture_filter_ex :: proc(
 	mip_filter: Texture_Filter,
 ) {
 	rb.set_texture_filter(t.handle, scale_down_filter, scale_up_filter, mip_filter)
+}
+
+// Controls how a texture wraps when UV coordinates fall outside the [0, 1] range.
+set_texture_wrap :: proc(t: Texture, wrap: Texture_Wrap) {
+	rb.set_texture_wrap(t.handle, wrap)
 }
 
 //-------//
@@ -3726,6 +3765,11 @@ Render_Texture :: struct {
 Texture_Filter :: enum {
 	Point,  // Similar to "nearest neighbor". Pixly texture scaling.
 	Linear, // Smoothed texture scaling.
+}
+
+Texture_Wrap :: enum {
+	Clamp,  // UV coords get clamped to the edge of the texture.
+	Repeat, // Coordinates tile and wrap around the texture.
 }
 
 Camera :: struct {

--- a/render_backend_d3d11.odin
+++ b/render_backend_d3d11.odin
@@ -24,6 +24,7 @@ RENDER_BACKEND_D3D11 :: Render_Backend_Interface {
 	create_render_texture = d3d11_create_render_texture,
 	destroy_render_target = d3d11_destroy_render_target,
 	set_texture_filter = d3d11_set_texture_filter,
+	set_texture_wrap = d3d11_set_texture_wrap,
 	load_shader = d3d11_load_shader,
 	destroy_shader = d3d11_destroy_shader,
 	default_shader_vertex_source = d3d11_default_shader_vertex_source,
@@ -495,7 +496,7 @@ create_texture :: proc(
 		tex = texture,
 		format = format,
 		view = texture_view,
-		sampler = create_sampler(.MIN_MAG_MIP_POINT),
+		sampler = create_sampler(.MIN_MAG_MIP_POINT, .Clamp), // use clamp as it was the defualt option before adding "t.wrap"
 	}
 
 	tex_handle, tex_add_err := hm.add(&s.textures, tex)
@@ -543,7 +544,7 @@ d3d11_create_render_texture :: proc(width: int, height: int) -> (Texture_Handle,
 		tex = texture,
 		view = texture_view,
 		format = .RGBA_32_Float,
-		sampler = create_sampler(.MIN_MAG_MIP_POINT),
+		sampler = create_sampler(.MIN_MAG_MIP_POINT, .Clamp), // use clamp as it was the defualt option before adding "t.wrap"
 	}
 
 	d3d11_render_target := D3D11_Render_Target {
@@ -658,19 +659,43 @@ d3d11_set_texture_filter :: proc(
 		f = .MIN_POINT_MAG_LINEAR_MIP_POINT
 	}
 
+	t.filter = f
+
 	if t.sampler != nil {
 		t.sampler->Release()
 	}
 
-	t.sampler = create_sampler(f)
+	t.sampler = create_sampler(f, t.wrap)
 }
 
-create_sampler :: proc(filter: d3d11.FILTER) -> ^d3d11.ISamplerState {
+d3d11_set_texture_wrap :: proc(th: Texture_Handle, wrap: Texture_Wrap) {
+	t := hm.get(&s.textures, th)
+
+	if t == nil {
+		log.error("Trying to set texture wrap for invalid texture %v", th)
+		return
+	}
+
+	t.wrap = wrap
+
+	if t.sampler != nil {
+		t.sampler->Release()
+	}
+
+	// As far as I understand D3D11 packs both filter and wrap in a single sampler.
+	// because of this the cleanest approach I could come up with was to pass the filter
+	// through the texture struct, assign it in the "set_filter" proc and use it here.
+	t.sampler = create_sampler(t.filter, wrap)
+}
+
+create_sampler :: proc(filter: d3d11.FILTER, wrap: Texture_Wrap) -> ^d3d11.ISamplerState {
+	address_mode: d3d11.TEXTURE_ADDRESS_MODE = wrap == .Repeat ? .WRAP : .CLAMP
+
 	sampler_desc := d3d11.SAMPLER_DESC{
-		Filter = filter,
-		AddressU = .CLAMP,
-		AddressV = .CLAMP,
-		AddressW = .CLAMP,
+		Filter         = filter,
+		AddressU       = address_mode,
+		AddressV       = address_mode,
+		AddressW       = address_mode,
 		ComparisonFunc = .NEVER,
 	}
 
@@ -1100,6 +1125,8 @@ D3D11_Texture :: struct {
 	tex: ^d3d11.ITexture2D,
 	view: ^d3d11.IShaderResourceView,
 	format: Pixel_Format,
+	wrap: Texture_Wrap,
+	filter: d3d11.FILTER,
 
 	// It may seem strange that we have a sampler here. But samplers are reused if you recreate them
 	// with the same options. D3D11 will return the same object. So each time we set the filter

--- a/render_backend_gl.odin
+++ b/render_backend_gl.odin
@@ -23,6 +23,7 @@ RENDER_BACKEND_GL :: Render_Backend_Interface {
 	create_render_texture = gl_create_render_texture,
 	destroy_render_target = gl_destroy_render_target,
 	set_texture_filter = gl_set_texture_filter,
+	set_texture_wrap = gl_set_texture_wrap,
 	load_shader = gl_load_shader,
 	destroy_shader = gl_destroy_shader,
 
@@ -526,6 +527,22 @@ gl_set_texture_filter :: proc(
 
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, min_filter)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, mag_filter)
+}
+
+gl_set_texture_wrap :: proc(th: Texture_Handle, wrap: Texture_Wrap) {
+	t := hm.get(&s.textures, th)
+
+	if t == nil {
+		log.error("Trying to set texture wrap for invalid texture %v", th)
+		return
+	}
+
+	gl.BindTexture(gl.TEXTURE_2D, t.id)
+
+	param: i32 = wrap == .Repeat ? gl.REPEAT : gl.CLAMP_TO_EDGE
+
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, param)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, param)
 }
 
 Shader_Compile_Result_OK :: struct {}

--- a/render_backend_interface.odin
+++ b/render_backend_interface.odin
@@ -60,6 +60,11 @@ Render_Backend_Interface :: struct #all_or_none {
 		mip_filter: Texture_Filter,
 	),
 
+	set_texture_wrap: proc(
+		handle: Texture_Handle,
+		wrap: Texture_Wrap,
+	),
+
 	load_shader: proc(
 		vertex_shader_data: []byte,
 		pixel_shader_data: []byte,

--- a/render_backend_nil.odin
+++ b/render_backend_nil.odin
@@ -22,6 +22,7 @@ RENDER_BACKEND_NIL :: Render_Backend_Interface {
 	create_render_texture = rbnil_create_render_texture,
 	destroy_render_target = rbnil_destroy_render_target,
 	set_texture_filter = rbnil_set_texture_filter,
+	set_texture_wrap = rbnil_set_texture_wrap,
 	load_shader = rbnil_load_shader,
 	destroy_shader = rbnil_destroy_shader,
 
@@ -113,6 +114,9 @@ rbnil_set_texture_filter :: proc(
 	scale_up_filter: Texture_Filter,
 	mip_filter: Texture_Filter,
 ) {
+}
+
+rbnil_set_texture_wrap :: proc(th: Texture_Handle, wrap: Texture_Wrap) {
 }
 
 rbnil_load_shader :: proc(

--- a/render_backend_webgl.odin
+++ b/render_backend_webgl.odin
@@ -23,6 +23,7 @@ RENDER_BACKEND_WEBGL :: Render_Backend_Interface {
 	create_render_texture = webgl_create_render_texture,
 	destroy_render_target = webgl_destroy_render_target,
 	set_texture_filter = webgl_set_texture_filter,
+	set_texture_wrap = webgl_set_texture_wrap,
 	load_shader = webgl_load_shader,
 	destroy_shader = webgl_destroy_shader,
 
@@ -500,6 +501,22 @@ webgl_set_texture_filter :: proc(
 
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, i32(min_filter))
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, i32(mag_filter))
+}
+
+webgl_set_texture_wrap :: proc(th: Texture_Handle, wrap: Texture_Wrap) {
+	t := hm.get(&s.textures, th)
+
+	if t == nil {
+		log.error("Trying to set texture wrap for invalid texture %v", th)
+		return
+	}
+
+	gl.BindTexture(gl.TEXTURE_2D, t.id)
+
+	param := wrap == .Repeat ? i32(gl.REPEAT) : i32(gl.CLAMP_TO_EDGE)
+
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, param)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, param)
 }
 
 Shader_Compile_Result_OK :: struct {}


### PR DESCRIPTION
Issue #149 - Add polygon drawing proc that can take custom UVs

**Added:**
- `Vertex` struct with `position`, `texcoord` and `color` fields.
- `draw_polygon` proc. Takes a `[]vertex` slice and a texture (optional)
- `Texture_Wrap` enum with options `Clamp` and `Repeat`.
- `set_texture_wrap` proc on all backends.

I tested this code using the "examples/basics" file, adding these 2 blocks:
```odin
// triangle with no texture
vertices := []k2.Vertex {
    {{ 50, 400}, {0, 0}, k2.RED},
    {{150, 400}, {1, 0}, k2.GREEN},
    {{100, 300}, {0.5, 1}, k2.BLUE},
}
k2.draw_polygon(vertices)

// quad with repeating texture (4x4)
k2.set_texture_wrap(tex, .Repeat)
tiled_verts := []k2.Vertex {
    {{200, 300}, {0, 0}, k2.WHITE},
    {{400, 300}, {4, 0}, k2.WHITE},
    {{400, 500}, {4, 4}, k2.WHITE},
    {{200, 300}, {0, 0}, k2.WHITE},
    {{400, 500}, {4, 4}, k2.WHITE},
    {{200, 500}, {0, 4}, k2.WHITE},
}
k2.draw_polygon(tiled_verts, tex.handle)
```

---

## Rules Checklist

You can always submit a draft pull request. But when you make your Pull Request "ready for review", then please make sure these rules are followed (put an x between each [ ]):
- [x] Make sure that the code you submit is working and tested.
- [x] Do not submit "basic" or "rudimentary" code that needs further work to actually be finished. Finish the code to the best of your abilities.
- [x] Do not modify any code that is unrelated to your changes. That just makes reviewing your code harder: I'll have a hard time seeing what you actually did. Do not use auto formatters such as odinfmt.
- [x] If you used an LLM to generate any code, then make that you understand every single line. In other words: No form of "vibe coded" PRs are allowed.
- [x] If you commit changes that were unintended, just do additional commits that undo them. Don't worry about polluting the commit history: I will do a "squash merge" of your Pull Request. Just make sure that the diff in the "Files changed" tab looks tidy.
- [x] If the GitHub testing action complain about the `karl2d.doc.odin` file being out-of-date, then please regenerate it by running `odin run tools/api_doc_builder`. This way you'll have an easier time seeing if you've made changes to the user-facing API.
- [x] Make sure that the code follows the same style as in `karl2d.odin`:
	- Please look through that file and pay attention to how characters such as `:` `=`, `(` `{` etc are placed.
	- Use tabs, not spaces.
	- Lines cannot be longer than 100 characters. See the `init` proc in `karl2d.odin` for an example of how to split up procedure signatures that are too long. That proc also shows how to write API comments. Use a ruler in your editor to make it easy to spot long lines.
