### PR TITLE
Adding a redraw callback to the platform layer (for moving / resize events)

### DIFF
--- a/karl2d.odin
+++ b/karl2d.odin
@@ -151,7 +151,19 @@ init :: proc(
 		hm.dynamic_init(&s.audio_streams, s.allocator)
 	}
 
+	// Register a callback for handling window redraw -- this is necessary for a platform like Windows
+	// where moving/resizing the window locks the main thread in an event loop
+	// This must be done after the render/audio setup so that they are available for redraw events on windows creation
+	callback := options.redraw_callback != nil ? options.redraw_callback : default_redraw_callback
+	pf.set_window_redraw_callback(callback);
+
 	return s
+}
+
+@(private="file")
+default_redraw_callback :: proc() {
+	// Just redraw current frame again (will cause stretching if window was resized)
+	present()
 }
 
 // Updates the internal state of the library. Call this early in the frame to make sure inputs and
@@ -3768,6 +3780,10 @@ Init_Options :: struct {
 	// platforms, such as Linux+Wayland, it does not work, because Wayland always auto scales all
 	// windows.
 	disable_auto_scale_hint: bool,
+
+	// In Windows, WM_SIZE and WM_MOVE events lock the message loop until the action is finished.
+	// You can provide a callback function here that will be called during these events
+	redraw_callback: proc()
 }
 
 Shader_Handle :: distinct Handle

--- a/platform_interface.odin
+++ b/platform_interface.odin
@@ -24,6 +24,7 @@ Platform_Interface :: struct #all_or_none {
 	get_window_scale: proc() -> f32,
 	set_window_mode: proc(window_mode: Window_Mode),
 	set_cursor_visible: proc(visible: bool),
+	set_window_redraw_callback: proc(callback: proc()),
 
 	is_gamepad_active: proc(gamepad: int) -> bool,
 	get_gamepad_axis: proc(gamepad: int, axis: Gamepad_Axis) -> f32,

--- a/platform_windows.odin
+++ b/platform_windows.odin
@@ -18,6 +18,7 @@ PLATFORM_WINDOWS :: Platform_Interface {
 	get_window_scale = windows_get_window_scale,
 	set_window_mode = windows_set_window_mode,
 	set_cursor_visible = windows_set_cursor_visible,
+	set_window_redraw_callback = windows_set_redraw_callback,
 
 	is_gamepad_active = windows_is_gamepad_active,
 	get_gamepad_axis = windows_get_gamepad_axis,
@@ -404,6 +405,7 @@ Windows_State :: struct {
 	in_resize_move_state: bool,
 	screen_width_before_resize_move: int,
 	screen_height_before_resize_move: int,
+	redraw_callback: proc(),
 
 	// left and right values for the triggers of each gamepad. We use this to known if a trigger has
 	// been pressed/released like a button.
@@ -564,6 +566,10 @@ window_proc :: proc "stdcall" (hwnd: win32.HWND, msg: win32.UINT, wparam: win32.
 
 			s.restore_window_pos_x = int(x)
 			s.restore_window_pos_y = int(y)
+
+			if(s.redraw_callback != nil) {
+				s.redraw_callback()
+			}
 		}
 
 	case win32.WM_DPICHANGED:
@@ -604,13 +610,17 @@ window_proc :: proc "stdcall" (hwnd: win32.HWND, msg: win32.UINT, wparam: win32.
 			s.restore_screen_height = s.screen_height
 		}
 
-		// We are actively resizing or moving the window, we'll save the event for later so it does
-		// not get spammy.
-		if !s.in_resize_move_state {
+		// During resize the windows event loop locks the main thread but will keep calling window_proc
+		// with WM_SIZE events, if a redraw callback is set the program can trigger a redraw during resize
+		if s.in_resize_move_state {
 			append(&s.events, Event_Screen_Resize {
 				width = s.screen_width,
 				height = s.screen_height,
 			})
+			
+			if(s.redraw_callback != nil) {
+				s.redraw_callback()
+			}
 		}
 
 	case win32.WM_SETFOCUS:
@@ -621,6 +631,10 @@ window_proc :: proc "stdcall" (hwnd: win32.HWND, msg: win32.UINT, wparam: win32.
 	}
 
 	return win32.DefWindowProcW(hwnd, msg, wparam, lparam)
+}
+
+windows_set_redraw_callback :: proc(callback: proc()) {
+	s.redraw_callback = callback
 }
 
 key_from_event_params :: proc(wparam: win32.WPARAM, lparam: win32.LPARAM) -> Keyboard_Key{


### PR DESCRIPTION
For single-threaded applications the Windows platform enters a modal loop during move and resize events.  This means everything is frozen until the event ends.  However, Windows does continue to send ``WM_MOVE`` and ``WM_SIZE`` event calls through the ``window_proc`` function.

Since some applications might need to see their UI dynamically resize when the window is changed, this PR implements an optional callback that can be defined in the options of ``k2.init``

Internally the default callback function is a call to ``k2.present`` which will cause the last frame to be redrawn (causing stretching).  An override can be provided during initialization like the following example:

```odin
// A minimal program to demonstrate Windows resizing
package minimal_resize_example

import k2 "../karl2d"
import "core:fmt"

main :: proc() {

	// Provide custom redraw callback
	k2.init(1280, 720, "Greetings from Karl2D!", {window_mode = .Windowed_Resizable, redraw_callback = on_redraw })

	for step() {}

	k2.shutdown()
}

on_redraw :: proc() {
	step()
}

step :: proc() -> bool {

	if !k2.update() {
        return false
    }

	k2.clear(k2.LIGHT_BLUE)
	
	// Display current elapsed time in center (for demonstration of adaptive redrawing)
	size := k2.get_screen_size()
	k2.draw_text(fmt.tprintf("%f s", k2.get_time()), {size.x/2, size.y/2}, 100, k2.DARK_BLUE)

	// Nothing you drew this frame is shown until you call this.
	k2.present()

	return true;
}
```

---

## Rules Checklist

You can always submit a draft pull request. But when you make your Pull Request "ready for review", then please make sure these rules are followed (put an x between each [ ]):
- [x] Make sure that the code you submit is working and tested.
- [x] Do not submit "basic" or "rudimentary" code that needs further work to actually be finished. Finish the code to the best of your abilities.
- [x] Do not modify any code that is unrelated to your changes. That just makes reviewing your code harder: I'll have a hard time seeing what you actually did. Do not use auto formatters such as odinfmt.
- [x] If you used an LLM to generate any code, then make that you understand every single line. In other words: No form of "vibe coded" PRs are allowed.
- [ ] If you commit changes that were unintended, just do additional commits that undo them. Don't worry about polluting the commit history: I will do a "squash merge" of your Pull Request. Just make sure that the diff in the "Files changed" tab looks tidy.
- [x] If the GitHub testing action complain about the `karl2d.doc.odin` file being out-of-date, then please regenerate it by running `odin run tools/api_doc_builder`. This way you'll have an easier time seeing if you've made changes to the user-facing API.
- [ ] Make sure that the code follows the same style as in `karl2d.odin`:
	- Please look through that file and pay attention to how characters such as `:` `=`, `(` `{` etc are placed.
	- Use tabs, not spaces.
	- Lines cannot be longer than 100 characters. See the `init` proc in `karl2d.odin` for an example of how to split up procedure signatures that are too long. That proc also shows how to write API comments. Use a ruler in your editor to make it easy to spot long lines.
