### PR TITLE
Call shutdown() in WASM builds

### DIFF
--- a/build_web/web_entry_templates/index_template.html
+++ b/build_web/web_entry_templates/index_template.html
@@ -46,6 +46,9 @@
 						prevTimeStamp = currTimeStamp;
 
 						if (!exports.step(dt, odin_ctx)) {
+							if (exports.shutdown) {
+								exports.shutdown(dt, odin_ctx);
+							}
 							if (exports._end) {
 								exports._end();
 							}

--- a/build_web/web_entry_templates/web_entry_template.odin
+++ b/build_web/web_entry_templates/web_entry_template.odin
@@ -20,3 +20,9 @@ step :: proc(dt: f64) -> bool {
 	context = ctx
 	return ex.step()
 }
+
+@export
+shutdown :: proc(dt: f64) {
+	context = ctx
+	ex.shutdown()
+}

--- a/examples/minimal_hello_world_web/minimal_hello_world_web.odin
+++ b/examples/minimal_hello_world_web/minimal_hello_world_web.odin
@@ -37,3 +37,8 @@ step :: proc() -> bool {
 
 	return true
 }
+
+shutdown :: proc() {
+	// Close the window and clean up the library's internal state.
+	k2.shutdown()
+}


### PR DESCRIPTION
This fixes #156 and makes it so that `shutdown()` is properly called when a WASM game exits. This is important when trying to use tracking allocators to see if there are any memory leaks.

---

## Rules Checklist

You can always submit a draft pull request. But when you make your Pull Request "ready for review", then please make sure these rules are followed (put an x between each [ ]):
- [x] Make sure that the code you submit is working and tested.
- [x] Do not submit "basic" or "rudimentary" code that needs further work to actually be finished. Finish the code to the best of your abilities.
- [x] Do not modify any code that is unrelated to your changes. That just makes reviewing your code harder: I'll have a hard time seeing what you actually did. Do not use auto formatters such as odinfmt.
- [x] If you used an LLM to generate any code, then make that you understand every single line. In other words: No form of "vibe coded" PRs are allowed.
- [x] If you commit changes that were unintended, just do additional commits that undo them. Don't worry about polluting the commit history: I will do a "squash merge" of your Pull Request. Just make sure that the diff in the "Files changed" tab looks tidy.
- [x] If the GitHub testing action complain about the `karl2d.doc.odin` file being out-of-date, then please regenerate it by running `odin run tools/api_doc_builder`. This way you'll have an easier time seeing if you've made changes to the user-facing API.
- [x] Make sure that the code follows the same style as in `karl2d.odin`:
	- Please look through that file and pay attention to how characters such as `:` `=`, `(` `{` etc are placed.
	- Use tabs, not spaces.
	- Lines cannot be longer than 100 characters. See the `init` proc in `karl2d.odin` for an example of how to split up procedure signatures that are too long. That proc also shows how to write API comments. Use a ruler in your editor to make it easy to spot long lines.
