### PR TITLE
Fix two small memleaks in web builds

### DIFF
--- a/platform_web.odin
+++ b/platform_web.odin
@@ -217,6 +217,7 @@ web_set_screen_size_to_window_size :: proc(canvas_id: HTML_Canvas_ID) {
 }
 
 web_shutdown :: proc() {
+	delete(s.events)
 	delete(s.key_from_js_event_key_code)
 }
 

--- a/render_backend_webgl.odin
+++ b/render_backend_webgl.odin
@@ -165,6 +165,7 @@ webgl_shutdown :: proc() {
 	hm.dynamic_destroy(&s.shaders)
 	hm.dynamic_destroy(&s.textures)
 	hm.dynamic_destroy(&s.render_targets)
+	delete_string(s.canvas_id)
 }
 
 webgl_clear :: proc(render_target: Render_Target_Handle, color: Color) {


### PR DESCRIPTION
Rperoducer:
```odin
package reproducer

import k2 "../karl2d"

import "core:fmt"
import "core:math"
import "core:mem"
import "base:runtime"

context_global : runtime.Context
mem_tracker: mem.Tracking_Allocator

main :: proc() {
	init()
	for step() {}
	shutdown()
}

init :: proc() {
	mem.tracking_allocator_init(&mem_tracker, context.allocator)
	context.allocator = mem.tracking_allocator(&mem_tracker)
	context_global = context

	k2.init(1280, 720, "", options = {window_mode = .Windowed_Resizable})
}

step :: proc() -> bool {
	context = context_global

	if !k2.update() {
		return false
	}

	if k2.key_went_down(.Escape) {
		return false
	}

	t := f32(k2.get_time() * 5)
	red   := u8((math.sin_f32(t + 0.0)   * 0.5 + 0.5) * 255)
	green := u8((math.sin_f32(t + 2.094) * 0.5 + 0.5) * 255)
	blue  := u8((math.sin_f32(t + 4.189) * 0.5 + 0.5) * 255)
	color := k2.Color{red, green, blue, 255}
	k2.clear(color)

	return true
}

shutdown :: proc() {
	context = context_global
	defer {
		if len(mem_tracker.allocation_map) > 0 {
			for _, entry in mem_tracker.allocation_map {
				fmt.eprintf("%v leaked %v bytes\n", entry.location, entry.size)
			}
		}
		mem.tracking_allocator_destroy(&mem_tracker)
	}

	k2.shutdown()
}
```

Press 'escape' to initiate shutdown. This requires the change in #167 for `shutdown()` to be called properly in wasm.

Without the mem leak fixes, you'll see this:

<img width="636" height="113" alt="image" src="https://github.com/user-attachments/assets/312c18cd-8dca-4f9f-a529-4e0a72146751" />
