### PR TITLE
Static "bitmap" fonts and some font reorg

### DIFF
--- a/examples/basics/basics.odin
+++ b/examples/basics/basics.odin
@@ -6,11 +6,9 @@ import k2 "../.."
 import "core:fmt"
 import "core:math"
 import "core:math/linalg"
-import "core:unicode/utf8"
 
 tex: k2.Texture
 pos: k2.Vec2
-cat_and_onion_font: k2.Font
 
 init :: proc() {
 	k2.init(1280, 720, "Karl2D Basics", options = {window_mode = .Windowed_Resizable})
@@ -19,17 +17,6 @@ init :: proc() {
 	// so in order to bundle textures with your game, you need to store them somewhere it can fetch
 	// them.
 	tex = k2.load_texture_from_bytes(#load("sixten.jpg"))
-
-	font_codepoints := utf8.string_to_runes(
-		"abcdefghiklmnopqrstuvxyzåäöABCDEFGHIKLMNOPQRSTUVXYZÅÄÖ!()1234567890., :",
-		context.temp_allocator,
-	)
-
-	cat_and_onion_font = k2.load_bitmap_font_from_bytes(
-		#load("../fonts/cat_and_onion_dialogue_font.ttf"),
-		48,
-		codepoints = font_codepoints,
-	)
 }
 
 step :: proc() -> bool {
@@ -102,10 +89,10 @@ step :: proc() -> bool {
 
 	// k2.color_alpha takes a pre-defined color and replaces the alpha (transparency).
 	k2.draw_rect({4, 95, msg2_width+20, 162}, k2.color_alpha(k2.DARK_GRAY, 192))
-	k2.draw_text("Hellöpe!", {15, 105}, 48, k2.LIGHT_RED, font = cat_and_onion_font)
+	k2.draw_text("Hellöpe!", {15, 105}, 48, k2.LIGHT_RED)
 
-	k2.draw_text(msg1, {15, 153}, 48, k2.ORANGE, font = cat_and_onion_font)
-	k2.draw_text(msg2, {15, 201}, 48, k2.LIGHT_PURPLE, font = cat_and_onion_font)
+	k2.draw_text(msg1, {15, 153}, 48, k2.ORANGE)
+	k2.draw_text(msg2, {15, 201}, 48, k2.LIGHT_PURPLE)
 
 	//
 	// BOTTOM BAR

--- a/examples/basics/basics.odin
+++ b/examples/basics/basics.odin
@@ -9,6 +9,7 @@ import "core:math/linalg"
 
 tex: k2.Texture
 pos: k2.Vec2
+cat_and_onion_font: k2.Font
 
 init :: proc() {
 	k2.init(1280, 720, "Karl2D Basics", options = {window_mode = .Windowed_Resizable})
@@ -17,6 +18,8 @@ init :: proc() {
 	// so in order to bundle textures with your game, you need to store them somewhere it can fetch
 	// them.
 	tex = k2.load_texture_from_bytes(#load("sixten.jpg"))
+
+	cat_and_onion_font = k2.load_bitmap_font_from_bytes(#load("../fonts/cat_and_onion_dialogue_font.ttf"), 48)
 }
 
 step :: proc() -> bool {
@@ -89,10 +92,10 @@ step :: proc() -> bool {
 
 	// k2.color_alpha takes a pre-defined color and replaces the alpha (transparency).
 	k2.draw_rect({4, 95, msg2_width+20, 162}, k2.color_alpha(k2.DARK_GRAY, 192))
-	k2.draw_text("Hellöpe!", {15, 105}, 48, k2.LIGHT_RED)
+	k2.draw_text("Hellöpe!", {15, 105}, 48, k2.LIGHT_RED, font = cat_and_onion_font)
 
-	k2.draw_text(msg1, {15, 153}, 48, k2.ORANGE)
-	k2.draw_text(msg2, {15, 201}, 48, k2.LIGHT_PURPLE)
+	k2.draw_text(msg1, {15, 153}, 48, k2.ORANGE, font = cat_and_onion_font)
+	k2.draw_text(msg2, {15, 201}, 48, k2.LIGHT_PURPLE, font = cat_and_onion_font)
 
 	//
 	// BOTTOM BAR

--- a/examples/basics/basics.odin
+++ b/examples/basics/basics.odin
@@ -6,6 +6,7 @@ import k2 "../.."
 import "core:fmt"
 import "core:math"
 import "core:math/linalg"
+import "core:unicode/utf8"
 
 tex: k2.Texture
 pos: k2.Vec2
@@ -19,7 +20,16 @@ init :: proc() {
 	// them.
 	tex = k2.load_texture_from_bytes(#load("sixten.jpg"))
 
-	cat_and_onion_font = k2.load_bitmap_font_from_bytes(#load("../fonts/cat_and_onion_dialogue_font.ttf"), 48)
+	font_codepoints := utf8.string_to_runes(
+		"abcdefghiklmnopqrstuvxyzåäöABCDEFGHIKLMNOPQRSTUVXYZÅÄÖ!()1234567890., :",
+		context.temp_allocator,
+	)
+
+	cat_and_onion_font = k2.load_bitmap_font_from_bytes(
+		#load("../fonts/cat_and_onion_dialogue_font.ttf"),
+		48,
+		codepoints = font_codepoints,
+	)
 }
 
 step :: proc() -> bool {

--- a/examples/fonts/fonts.odin
+++ b/examples/fonts/fonts.odin
@@ -2,6 +2,7 @@ package karl2d_fonts_example
 
 import k2 "../.."
 import "core:fmt"
+import "core:unicode/utf8"
 
 main :: proc() {
 	init()
@@ -13,9 +14,16 @@ cat_and_onion_font: k2.Font
 
 init :: proc() {
 	k2.init(1080, 1080, "Karl2D Fonts Example")
+
+	font_codepoints := utf8.string_to_runes(
+		"abcdefghiklmnopqrstuvwxyzåäöABCDEFGHIKLMNOPQRSTUVWXYZÅÄÖ!()1234567890., :",
+		context.temp_allocator,
+	)
+
 	cat_and_onion_font = k2.load_bitmap_font_from_bytes(
 		#load("cat_and_onion_dialogue_font.ttf"),
 		48,
+		font_codepoints,
 	)
 }
 

--- a/examples/fonts/fonts.odin
+++ b/examples/fonts/fonts.odin
@@ -20,7 +20,7 @@ init :: proc() {
 		context.temp_allocator,
 	)
 
-	cat_and_onion_font = k2.load_bitmap_font_from_bytes(
+	cat_and_onion_font = k2.load_static_font_from_bytes(
 		#load("cat_and_onion_dialogue_font.ttf"),
 		48,
 		font_codepoints,

--- a/examples/fonts/fonts.odin
+++ b/examples/fonts/fonts.odin
@@ -13,7 +13,10 @@ cat_and_onion_font: k2.Font
 
 init :: proc() {
 	k2.init(1080, 1080, "Karl2D Fonts Example")
-	cat_and_onion_font = k2.load_font_from_bytes(#load("cat_and_onion_dialogue_font.ttf"))
+	cat_and_onion_font = k2.load_bitmap_font_from_bytes(
+		#load("cat_and_onion_dialogue_font.ttf"),
+		48,
+	)
 }
 
 step :: proc() -> bool {
@@ -34,6 +37,8 @@ step :: proc() -> bool {
 
 	size := k2.measure_text(msg, 64, font)
 	size_msg := fmt.tprintf("The text above uses %.1f x %.1f pixels of space", size.x, size.y)
+
+	k2.draw_rect(k2.rect_from_pos_size({20, 20}, size), k2.color_alpha(k2.RED, 128))
 
 	k2.draw_text(size_msg, {20, 200}, 32, k2.BLACK)
 

--- a/examples/fonts/fonts.odin
+++ b/examples/fonts/fonts.odin
@@ -3,11 +3,24 @@ package karl2d_fonts_example
 import k2 "../.."
 import "core:fmt"
 import "core:unicode/utf8"
+import "core:mem"
 
 main :: proc() {
+	track: mem.Tracking_Allocator
+	mem.tracking_allocator_init(&track, context.allocator)
+	context.allocator = mem.tracking_allocator(&track)
+
 	init()
 	for step() {}
 	shutdown()
+
+	if len(track.allocation_map) > 0 {
+		fmt.eprintf("=== %v allocations not freed: ===\n", len(track.allocation_map))
+		for _, entry in track.allocation_map {
+			fmt.eprintf("- %v bytes @ %v\n", entry.size, entry.location)
+		}
+	}
+	mem.tracking_allocator_destroy(&track)
 }
 
 cat_and_onion_font: k2.Font
@@ -45,9 +58,6 @@ step :: proc() -> bool {
 
 	size := k2.measure_text(msg, 64, font)
 	size_msg := fmt.tprintf("The text above uses %.1f x %.1f pixels of space", size.x, size.y)
-
-	k2.draw_rect(k2.rect_from_pos_size({20, 20}, size), k2.color_alpha(k2.RED, 128))
-
 	k2.draw_text(size_msg, {20, 200}, 32, k2.BLACK)
 
 	ROTATING_TEXT :: "rotating text!"

--- a/examples/measure_text/measure_text.odin
+++ b/examples/measure_text/measure_text.odin
@@ -34,7 +34,7 @@ init :: proc() {
 
 	for &f in fonts {
 		f.font = f.bytes != nil\
-			? k2.load_font_from_bytes(f.bytes)\
+			? k2.load_dynamic_font_from_bytes(f.bytes)\
 			: k2.FONT_DEFAULT
 	}
 }

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -408,6 +408,8 @@ load_texture_from_bytes :: proc(bytes: []u8, options: Load_Texture_Options = {})
 // from a file on disk), then please use `load_texture_from_bytes` instead.
 load_texture_from_bytes_raw :: proc(bytes: []u8, width: int, height: int, format: Pixel_Format) -> Texture
 
+load_texture_from_image :: proc(image: Image) -> Texture
+
 // Get a rectangle that spans the whole texture. Coordinates will be (x, y) = (0, 0) and size
 // (w, h) = (texture_width, texture_height)
 get_texture_rect :: proc(t: Texture) -> Rect
@@ -740,11 +742,25 @@ rotate :: proc(v: Vec2, angle_radians: f32) -> Vec2
 // FONTS //
 //-------//
 
-// Loads a font from disk and returns a handle that represents it.
-load_font_from_file :: proc(filename: string, options: Font_Options = {}) -> Font
+// Like `load_static_font_from_bytes` but reads a file from disk using a specified name.
+load_static_font_from_file :: proc(filename: string, font_size: f32, codepoints: []rune = {}, options: Font_Options = {}) -> Font
 
-// Loads a font from a block of memory and returns a handle that represents it.
-load_font_from_bytes :: proc(data: []u8, options: Font_Options = {}) -> Font
+// Load the TTF font contained in `data` and bake it into a texture. The characters in the texture
+// will be of of the specified `font_size`. If you do not specify a list of `codepoints`, then this
+// procedure defaults to using all codepoints between 32 to 127 (ASCII).
+load_static_font_from_bytes :: proc(
+	data: []byte,
+	font_size: f32,
+	codepoints: []rune = {},
+	options: Font_Options = {},
+) -> Font
+
+// Like `load_dynamic_font_from_bytes`, but reads a file from disk using a filename.
+load_dynamic_font_from_file :: proc(filename: string, options: Font_Options = {}) -> Font
+
+// Load a TTF font stored in `data` as a dynamic font. This means that an atlas will be dynamically
+// built as you draw characters using this font.
+load_dynamic_font_from_bytes :: proc(data: []u8, options: Font_Options = {}) -> Font
 
 // Destroy a font previously loaded using `load_font_from_file` or `load_font_from_bytes`.
 destroy_font :: proc(font: Font)
@@ -1014,6 +1030,12 @@ Texture_Filter :: enum {
 	Linear, // Smoothed texture scaling.
 }
 
+Image :: struct {
+	pixels: []Color,
+	width: int,
+	height: int,
+}
+
 Camera :: struct {
 	// Where the camera looks.
 	target: Vec2,
@@ -1158,12 +1180,34 @@ Font_Options :: struct {
 	filter: Texture_Filter,
 }
 
+// Supported font types:
+// - Static: A pre-baked font where you specify a range of characters that are baked into a texture.
+// - Dynamic: A font where an atlas is continuously updated as you need need new characters. This
+//            mode current uses fontstash.
+//
+// Future types (TODO):
+// - Slug: Upload the character bezier curves to the GPU and render the text on the GPU without the
+//         need for any atlas texture. This will be based on the "slug font algorithm" that was
+//         recently put into public domain.
+Font_Type :: enum {
+	Static,
+	Dynamic,
+}
+
 Font_Data :: struct {
 	atlas: Texture,
 	options: Font_Options,
 
-	// internal
-	fontstash_handle: int,
+	type: Font_Type,
+
+	// type == .Static
+	static_glyphs: []Font_Baked_Glyph,
+	static_glyph_ranges: []Font_Baked_Glyph_Range,
+	static_font_size: f32,
+	static_line_spacing: f32,
+
+	// type == .Dynamic
+	dynamic_fontstash_handle: int,
 }
 
 Handle :: hm.Handle64
@@ -1171,6 +1215,21 @@ Texture_Handle :: distinct Handle
 Render_Target_Handle :: distinct Handle
 Font :: distinct int
 DEFAULT_FONT_DATA :: #load("default_fonts/roboto.ttf")
+
+Font_Baked_Glyph_Range :: struct {
+	start_idx: int,
+	start: rune,
+	end: rune,
+}
+
+Font_Baked_Glyph :: struct {
+	value: rune,
+	// stbtt index, for faster lookup
+	index: int,
+	rect: Rect,
+	offset: Vec2,
+	advance: f32,
+}
 
 FONT_NONE :: Font(0)
 

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -408,6 +408,8 @@ load_texture_from_bytes :: proc(bytes: []u8, options: Load_Texture_Options = {})
 // from a file on disk), then please use `load_texture_from_bytes` instead.
 load_texture_from_bytes_raw :: proc(bytes: []u8, width: int, height: int, format: Pixel_Format) -> Texture
 
+// Create a GPU texture from an image stored in RAM. There are currently no procedures to manipulate
+// the image. However, you can create an `Image` struct manually and fill out the data as needed.
 load_texture_from_image :: proc(image: Image) -> Texture
 
 // Get a rectangle that spans the whole texture. Coordinates will be (x, y) = (0, 0) and size
@@ -1030,6 +1032,8 @@ Texture_Filter :: enum {
 	Linear, // Smoothed texture scaling.
 }
 
+// An image kept in RAM, you can fill this out and pass it to `load_texture_from_image` in order
+// to transport it to the GPU.
 Image :: struct {
 	pixels: []Color,
 	width: int,

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -16,6 +16,7 @@ import "core:encoding/endian"
 import fs "vendor:fontstash"
 import stbv "vendor:stb/vorbis"
 import stbtt "vendor:stb/truetype"
+import stbrp "vendor:stb/rect_pack"
 
 import "core:image"
 import "core:image/jpeg"
@@ -1188,6 +1189,79 @@ draw_text :: proc(
 		return
 	}
 
+	font_object := &s.fonts[font]
+
+	switch font_object.type {
+	case .Bitmap:
+		_draw_text_bitmap(
+			text,
+			position,
+			font_size,
+			color,
+			font,
+			origin,
+			rotation,
+		)
+
+	case .Fontstash:
+		_draw_text_fontstash(
+			text,
+			position,
+			font_size,
+			color,
+			font,
+			origin,
+			rotation,
+		)
+	}
+}
+
+_draw_text_bitmap :: proc(
+	text: string,
+	position: Vec2,
+	font_size: f32,
+	color: Color,
+	font := FONT_DEFAULT,
+	origin: Vec2 = {},
+	rotation: f32 = 0,
+) {
+	if int(font) >= len(s.fonts) {
+		return
+	}
+
+	font_object := &s.fonts[font]
+
+	position := position
+
+	for c in text {
+		for g in font_object.glyphs {
+			if g.value == c {
+				draw_texture_rect(
+					font_object.atlas,
+					g.rect,
+					position + g.offset,
+					tint = color,
+				)
+
+				position.x += g.advance
+			}
+		}
+	}
+}
+
+_draw_text_fontstash :: proc(
+	text: string,
+	position: Vec2,
+	font_size: f32,
+	color: Color,
+	font := FONT_DEFAULT,
+	origin: Vec2 = {},
+	rotation: f32 = 0,
+) {
+	if int(font) >= len(s.fonts) {
+		return
+	}
+
 	_set_font(font)
 	font_object := &s.fonts[font]
 
@@ -1333,6 +1407,30 @@ load_texture_from_bytes_raw :: proc(bytes: []u8, width: int, height: int, format
 		handle = backend_tex,
 		width = width,
 		height = height,
+	}
+}
+
+load_texture_from_image :: proc(image: Image) -> Texture {
+	if image.width == 0 || image.height == 0 {
+		log.error("Invalid image: Height or width is zero")
+		return {}
+	}
+
+	if len(image.pixels) != (image.width*image.height) {
+		log.error("Invalid image: the pixels array is not of size image.width*image.height")
+		return {}
+	}
+
+	backend_tex := rb.load_texture(slice.reinterpret([]u8, image.pixels[:]), image.width, image.height, .RGBA_8_Norm)
+
+	if backend_tex == TEXTURE_NONE {
+		return {}
+	}
+
+	return {
+		handle = backend_tex,
+		width = image.width,
+		height = image.height,
 	}
 }
 
@@ -3129,6 +3227,7 @@ load_font_from_bytes :: proc(data: []u8, options: Font_Options = {}) -> Font {
 			width = FONT_DEFAULT_ATLAS_SIZE,
 			height = FONT_DEFAULT_ATLAS_SIZE,
 		},
+		type = .Fontstash,
 		options = options,
 	}
 
@@ -3149,10 +3248,6 @@ load_bitmap_font_from_file :: proc(filename: string, font_size: f32, codepoints:
 }
 
 load_bitmap_font_from_bytes :: proc(data: []byte, font_size: f32, codepoints: []rune = {}, options: Font_Options = {}) -> Font {
-	//
-	// This implementation is based on LoadFontData in Raylib.
-	//
-
 	codepoints := codepoints
 	font_info: stbtt.fontinfo
 	init_ok := stbtt.InitFont(&font_info, raw_data(data), 0)
@@ -3177,26 +3272,187 @@ load_bitmap_font_from_bytes :: proc(data: []byte, font_size: f32, codepoints: []
 		codepoints = default_codepoints[:]
 	}
 
-	num_glyphs: int
+	glyphs := make([dynamic]Font_Bitmap_Glyph, s.frame_allocator)
 
 	for c in codepoints {
-		if stbtt.FindGlyphIndex(&font_info, c) > 0 {
-			num_glyphs += 1
+		idx := stbtt.FindGlyphIndex(&font_info, c)
+		
+		if idx > 0 {
+			advance: i32
+			stbtt.GetGlyphHMetrics(&font_info, idx, &advance, nil)
+
+			append(&glyphs, Font_Bitmap_Glyph {
+				value = c,
+				index = int(idx),
+				advance = f32(advance) * scale_factor,
+			})
 		}
 	}
 
-	glyphs := make([]Font_Bitmap_Glyph, num_glyphs, s.allocator)
+	Glyph_Image_Data :: struct {
+		pixels: [^]byte,
+		width: i32,
+		height: i32,
+	}
 
-	for c, c_idx in codepoints {
+	glyphs_img_data := make([]Glyph_Image_Data, len(glyphs), s.frame_allocator)
+	glyphs_pack_rects := make([]stbrp.Rect, len(glyphs), s.frame_allocator)
+
+	for &g, g_idx in glyphs {
+		x_off, y_off: i32
 		w, h: i32
-		index := stbtt.FindGlyphIndex(&font_info, c) 
 
-		if index > 0 {
-			glyphs[c_idx].value = c
+		pixels := stbtt.GetCodepointBitmap(
+			&font_info,
+			scale_factor,
+			scale_factor,
+			g.value,
+			&w,
+			&h,
+			&x_off,
+			&y_off,
+		)
 
+		glyphs_img_data[g_idx] = {
+			pixels = pixels,
+			width = w,
+			height = h,
+		}
 
+		g.offset = {
+			f32(x_off),
+			f32(y_off),
+		}
+
+		glyphs_pack_rects[g_idx] = {
+			w = stbrp.Coord(w),
+			h = stbrp.Coord(h),
 		}
 	}
+
+	atlas_size := 128
+	MAX_ATLAS_SIZE :: 4096
+	atlas_packed := false
+
+	for atlas_size <= MAX_ATLAS_SIZE {
+		rp_ctx: stbrp.Context
+		rp_nodes := make([]stbrp.Node, i32(atlas_size), s.frame_allocator)
+		
+		stbrp.init_target(
+			&rp_ctx,
+			i32(atlas_size),
+			i32(atlas_size),
+			raw_data(rp_nodes),
+			i32(len(rp_nodes)),
+		)
+		
+		rect_pack_res := stbrp.pack_rects(
+			&rp_ctx,
+			raw_data(glyphs_pack_rects),
+			i32(len(glyphs_pack_rects)),
+		)
+
+		if rect_pack_res == 1 {
+			atlas_packed = true
+			break
+		}
+
+		atlas_size *= 2
+	}
+
+	if !atlas_packed {
+		log.error("Failed packing font atlas")
+		return {}
+	}
+
+	atlas := make([]Color, atlas_size*atlas_size, s.frame_allocator)
+
+	if options.premultiply_alpha {
+		for pr, pr_idx in glyphs_pack_rects {
+			g := &glyphs[pr_idx]
+
+			g.rect = {
+				f32(pr.x),
+				f32(pr.y),
+				f32(pr.w),
+				f32(pr.h),
+			}
+
+			gimg := glyphs_img_data[pr_idx]
+
+			for sx in 0..<gimg.width {
+				for sy in 0..<gimg.height {
+					dx := int(pr.x) + int(sx)
+					dy := int(pr.y) + int(sy)
+
+					assert(dx >= 0 && dx < atlas_size)
+					assert(dy >= 0 && dy < atlas_size)
+
+					alpha := gimg.pixels[sx * gimg.width + sy]
+					alpha_norm := f32(alpha)/255
+
+					atlas[dy * atlas_size + dx] = {
+						u8(255 * alpha_norm),
+						u8(255 * alpha_norm),
+						u8(255 * alpha_norm),
+						alpha,
+					}
+				}
+			}
+		}
+	} else {
+		for pr, pr_idx in glyphs_pack_rects {
+			g := &glyphs[pr_idx]
+
+			g.rect = {
+				f32(pr.x),
+				f32(pr.y),
+				f32(pr.w),
+				f32(pr.h),
+			}
+
+			gimg := glyphs_img_data[pr_idx]
+
+			for sx in 0..<gimg.width {
+				for sy in 0..<gimg.height {
+					dx := int(pr.x) + int(sx)
+					dy := int(pr.y) + int(sy)
+
+					assert(dx >= 0 && dx < atlas_size)
+					assert(dy >= 0 && dy < atlas_size)
+
+					alpha := gimg.pixels[sy * gimg.width + sx]
+
+					atlas[dy * atlas_size + dx] = {
+						255,
+						255,
+						255,
+						alpha,
+					}
+				}
+			}
+		}
+	}
+
+	img := Image {
+		pixels = atlas,
+		width = atlas_size,
+		height = atlas_size,
+	}
+
+	tex := load_texture_from_image(img)
+	set_texture_filter(tex, options.filter)
+
+	font := Font_Data {
+		atlas = tex,
+		type = .Bitmap,
+		options = options,
+		glyphs = slice.clone(glyphs[:], s.allocator),
+	}
+
+	font_handle := Font(len(s.fonts))
+	append(&s.fonts, font)
+	return font_handle
 }
 
 // Destroy a font previously loaded using `load_font_from_file` or `load_font_from_bytes`.
@@ -3674,6 +3930,8 @@ ui_button :: proc(r: Rect, text: string) -> bool {
 
 Vec2 :: [2]f32
 
+Vec2i :: [2]int
+
 Vec3 :: [3]f32
 
 Vec4 :: [4]f32
@@ -3789,6 +4047,12 @@ Render_Texture :: struct {
 Texture_Filter :: enum {
 	Point,  // Similar to "nearest neighbor". Pixly texture scaling.
 	Linear, // Smoothed texture scaling.
+}
+
+Image :: struct {
+	pixels: []Color,
+	width: int,
+	height: int,
 }
 
 Camera :: struct {
@@ -3935,11 +4199,21 @@ Font_Options :: struct {
 	filter: Texture_Filter,
 }
 
+Font_Type :: enum {
+	Bitmap,
+	Fontstash,
+}
+
 Font_Data :: struct {
 	atlas: Texture,
 	options: Font_Options,
 
-	// internal
+	type: Font_Type,
+
+	// type == .Bitmap
+	glyphs: []Font_Bitmap_Glyph,
+
+	// type == .Fontstash
 	fontstash_handle: int,
 }
 
@@ -3951,6 +4225,9 @@ DEFAULT_FONT_DATA :: #load("default_fonts/roboto.ttf")
 
 Font_Bitmap_Glyph :: struct {
 	value: rune,
+	// stbtt index, for faster lookup
+	index: int,
+	rect: Rect,
 	offset: Vec2,
 	advance: f32,
 }
@@ -4688,5 +4965,14 @@ f32_color_from_color :: proc(color: Color) -> Color_F32 {
 		f32(color.g) / 255,
 		f32(color.b) / 255,
 		f32(color.a) / 255,
+	}
+}
+
+color_from_f32_color :: proc(color: Color_F32) -> Color {
+	return {
+		u8(color.r * 255),
+		u8(color.g * 255),
+		u8(color.b * 255),
+		u8(color.a * 255),
 	}
 }

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1148,6 +1148,11 @@ measure_text :: proc(text: string, font_size: f32, font: Font = FONT_DEFAULT) ->
 				num_linebreaks += 1
 				continue
 			}
+
+			if c == '\t' {
+				line_w += font_size * 2
+				continue
+			}
 			
 			g: ^Font_Baked_Glyph
 
@@ -1303,6 +1308,8 @@ draw_text :: proc(
 		origin: Vec2 = {},
 		rotation: f32 = 0,
 	) {
+		// TODO: Add kerning.
+
 		if int(font) >= len(s.fonts) {
 			return
 		}
@@ -3454,7 +3461,7 @@ load_static_font_from_bytes :: proc(
 		}
 
 		glyphs_pack_rects[g_idx] = {
-			// w & h are packed wit 1 pixel padding, so we get 1 px spacing betwen characters.
+			// w & h are packed with 1 pixel padding, so we get 1 px spacing betwen characters.
 			w = stbrp.Coord(w) + 1,
 			h = stbrp.Coord(h) + 1,
 		}
@@ -3504,7 +3511,7 @@ load_static_font_from_bytes :: proc(
 			g.rect = {
 				f32(pr.x),
 				f32(pr.y),
-				// w & h are packed wit 1 pixel padding, so we get 1 px spacing betwen characters.
+				// w & h are packed with 1 pixel padding, so we get 1 px spacing betwen characters.
 				f32(pr.w) - 1,
 				f32(pr.h) - 1,
 			}
@@ -3538,7 +3545,7 @@ load_static_font_from_bytes :: proc(
 			g.rect = {
 				f32(pr.x),
 				f32(pr.y),
-				// w & h are packed wit 1 pixel padding, so we get 1 px spacing betwen characters.
+				// w & h are packed with 1 pixel padding, so we get 1 px spacing betwen characters.
 				f32(pr.w) - 1,
 				f32(pr.h) - 1,
 			}

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1230,21 +1230,37 @@ _draw_text_bitmap :: proc(
 	}
 
 	font_object := &s.fonts[font]
-
 	position := position
 
 	for c in text {
-		for g in font_object.glyphs {
-			if g.value == c {
-				draw_texture_rect(
-					font_object.atlas,
-					g.rect,
-					position + g.offset,
-					tint = color,
-				)
+		g: ^Font_Bitmap_Glyph
 
-				position.x += g.advance
+		for &gc in font_object.glyphs {
+			if gc.value == c {
+				g = &gc
+				break
 			}
+		}
+
+		if g != nil {
+			draw_texture_rect(
+				font_object.atlas,
+				g.rect,
+				position + g.offset,
+				tint = color,
+			)
+
+			position.x += g.advance
+		} else {
+			invalid_rect_size := Vec2 {font_size*0.5, font_size*0.5}
+			invalid_rect := rect_from_pos_size(position + {0, invalid_rect_size.y/2}, invalid_rect_size)
+			
+			draw_rect(
+				invalid_rect,
+				RED,
+			)
+
+			position.x += invalid_rect_size.x
 		}
 	}
 }
@@ -3321,7 +3337,7 @@ load_bitmap_font_from_bytes :: proc(data: []byte, font_size: f32, codepoints: []
 
 		g.offset = {
 			f32(x_off),
-			f32(y_off),
+			f32(y_off) + f32(ascent) * scale_factor,
 		}
 
 		glyphs_pack_rects[g_idx] = {

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1540,6 +1540,8 @@ load_texture_from_bytes_raw :: proc(bytes: []u8, width: int, height: int, format
 	}
 }
 
+// Create a GPU texture from an image stored in RAM. There are currently no procedures to manipulate
+// the image. However, you can create an `Image` struct manually and fill out the data as needed.
 load_texture_from_image :: proc(image: Image) -> Texture {
 	if image.width == 0 || image.height == 0 {
 		log.error("Invalid image: Height or width is zero")
@@ -4248,6 +4250,8 @@ Texture_Filter :: enum {
 	Linear, // Smoothed texture scaling.
 }
 
+// An image kept in RAM, you can fill this out and pass it to `load_texture_from_image` in order
+// to transport it to the GPU.
 Image :: struct {
 	pixels: []Color,
 	width: int,

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -3321,6 +3321,7 @@ rotate :: proc(v: Vec2, angle_radians: f32) -> Vec2 {
 // FONTS //
 //-------//
 
+// Like `load_static_font_from_bytes` but reads a file from disk using a specified name.
 load_static_font_from_file :: proc(filename: string, font_size: f32, codepoints: []rune = {}, options: Font_Options = {}) -> Font {
 	data, data_ok := read_entire_file(filename, s.frame_allocator)
 
@@ -3332,7 +3333,15 @@ load_static_font_from_file :: proc(filename: string, font_size: f32, codepoints:
 	return load_static_font_from_bytes(data, font_size, codepoints, options)
 }
 
-load_static_font_from_bytes :: proc(data: []byte, font_size: f32, codepoints: []rune = {}, options: Font_Options = {}) -> Font {
+// Load the TTF font contained in `data` and bake it into a texture. The characters in the texture
+// will be of of the specified `font_size`. If you do not specify a list of `codepoints`, then this
+// procedure defaults to using all codepoints between 32 to 127 (ASCII).
+load_static_font_from_bytes :: proc(
+	data: []byte,
+	font_size: f32,
+	codepoints: []rune = {},
+	options: Font_Options = {},
+) -> Font {
 	codepoints := codepoints
 	font_info: stbtt.fontinfo
 	font_offset := stbtt.GetFontOffsetForIndex(raw_data(data), 0)
@@ -3575,7 +3584,7 @@ load_static_font_from_bytes :: proc(data: []byte, font_size: f32, codepoints: []
 	return font_handle
 }
 
-// Loads a font from disk and returns a handle that represents it.
+// Like `load_dynamic_font_from_bytes`, but reads a file from disk using a filename.
 load_dynamic_font_from_file :: proc(filename: string, options: Font_Options = {}) -> Font {
 	data, data_ok := read_entire_file(filename, s.frame_allocator)
 
@@ -3587,7 +3596,8 @@ load_dynamic_font_from_file :: proc(filename: string, options: Font_Options = {}
 	return load_dynamic_font_from_bytes(data, options)
 }
 
-// Loads a font from a block of memory and returns a handle that represents it.
+// Load a TTF font stored in `data` as a dynamic font. This means that an atlas will be dynamically
+// built as you draw characters using this font.
 load_dynamic_font_from_bytes :: proc(data: []u8, options: Font_Options = {}) -> Font {
 	fontstash_handle := fs.AddFontMem(&s.fs, "", slice.clone(data, s.allocator), false)
 	h := Font(len(s.fonts))
@@ -4099,8 +4109,6 @@ ui_button :: proc(r: Rect, text: string) -> bool {
 //---------------------//
 
 Vec2 :: [2]f32
-
-Vec2i :: [2]int
 
 Vec3 :: [3]f32
 

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1147,12 +1147,12 @@ _measure_text_bitmap :: proc(text: string, font_size: f32, font: Font) -> Vec2 {
 			num_linebreaks += 1
 			continue
 		}
-
+		
 		g: ^Font_Bitmap_Glyph
 
-		for &gc in font_object.glyphs {
-			if gc.value == c {
-				g = &gc
+		for &r in font_object.glyph_ranges {
+			if c >= r.start && c < r.end {
+				g = &font_object.glyphs[r.start_idx + int(c - r.start)]
 				break
 			}
 		}
@@ -1321,9 +1321,9 @@ _draw_text_bitmap :: proc(
 
 		g: ^Font_Bitmap_Glyph
 
-		for &gc in font_object.glyphs {
-			if gc.value == c {
-				g = &gc
+		for &r in font_object.glyph_ranges {
+			if c >= r.start && c < r.end {
+				g = &font_object.glyphs[r.start_idx + int(c - r.start)]
 				break
 			}
 		}
@@ -3363,7 +3363,8 @@ load_bitmap_font_from_file :: proc(filename: string, font_size: f32, codepoints:
 load_bitmap_font_from_bytes :: proc(data: []byte, font_size: f32, codepoints: []rune = {}, options: Font_Options = {}) -> Font {
 	codepoints := codepoints
 	font_info: stbtt.fontinfo
-	init_ok := stbtt.InitFont(&font_info, raw_data(data), 0)
+	font_offset := stbtt.GetFontOffsetForIndex(raw_data(data), 0)
+	init_ok := stbtt.InitFont(&font_info, raw_data(data), font_offset)
 
 	if !init_ok {
 		log.error("Failed loading TTF bitmap font")
@@ -3385,6 +3386,7 @@ load_bitmap_font_from_bytes :: proc(data: []byte, font_size: f32, codepoints: []
 		codepoints = default_codepoints[:]
 	}
 
+	glyph_ranges := make([dynamic]Font_Bitmap_Glyph_Range, s.frame_allocator)
 	glyphs := make([dynamic]Font_Bitmap_Glyph, s.frame_allocator)
 
 	for c in codepoints {
@@ -3401,6 +3403,34 @@ load_bitmap_font_from_bytes :: proc(data: []byte, font_size: f32, codepoints: []
 			})
 		}
 	}
+
+	slice.sort_by(
+		glyphs[:],
+		proc(i, j: Font_Bitmap_Glyph) -> bool {
+			return i.value < j.value
+		},
+	)
+
+	cur_glyph_range: Font_Bitmap_Glyph_Range
+
+	for g, g_idx in glyphs {
+		if g_idx == 0 {
+			cur_glyph_range = {
+				start = g.value,
+				start_idx = g_idx,
+			}
+		} else if g.value != cur_glyph_range.end {
+			append(&glyph_ranges, cur_glyph_range)
+			cur_glyph_range = {
+				start = g.value,
+				start_idx = g_idx,
+			}
+		}
+
+		cur_glyph_range.end = g.value + 1
+	}
+
+	append(&glyph_ranges, cur_glyph_range)
 
 	Glyph_Image_Data :: struct {
 		pixels: [^]byte,
@@ -3561,6 +3591,7 @@ load_bitmap_font_from_bytes :: proc(data: []byte, font_size: f32, codepoints: []
 		type = .Bitmap,
 		options = options,
 		glyphs = slice.clone(glyphs[:], s.allocator),
+		glyph_ranges = slice.clone(glyph_ranges[:], s.allocator),
 		bitmap_font_size = font_size,
 
 		// from stbtt.GetFontVMetrics docs 
@@ -3579,12 +3610,19 @@ destroy_font :: proc(font: Font) {
 	}
 
 	f := &s.fonts[font]
-	rb.destroy_texture(f.atlas.handle)	
+	rb.destroy_texture(f.atlas.handle)
 
-	// TODO fontstash has no "destroy font" proc... I should make my own version of fontstash
-	delete(s.fs.fonts[f.fontstash_handle].glyphs)
-	delete(s.fs.fonts[f.fontstash_handle].loadedData, s.allocator)
-	s.fs.fonts[f.fontstash_handle].glyphs = {}
+	switch f.type {
+	case .Bitmap:
+		delete(f.glyphs, s.allocator)
+		delete(f.glyph_ranges, s.allocator)
+	case .Fontstash:
+		// TODO fontstash has no "destroy font" proc... I should make my own version of fontstash
+		delete(s.fs.fonts[f.fontstash_handle].glyphs)
+		delete(s.fs.fonts[f.fontstash_handle].loadedData, s.allocator)
+		s.fs.fonts[f.fontstash_handle].glyphs = {}
+	}
+
 }
 
 @(deprecated="Use FONT_DEFAULT constant instead")
@@ -4329,6 +4367,7 @@ Font_Data :: struct {
 
 	// type == .Bitmap
 	glyphs: []Font_Bitmap_Glyph,
+	glyph_ranges: []Font_Bitmap_Glyph_Range,
 	bitmap_font_size: f32,
 	bitmap_line_spacing: f32,
 
@@ -4341,6 +4380,12 @@ Texture_Handle :: distinct Handle
 Render_Target_Handle :: distinct Handle
 Font :: distinct int
 DEFAULT_FONT_DATA :: #load("default_fonts/roboto.ttf")
+
+Font_Bitmap_Glyph_Range :: struct {
+	start_idx: int,
+	start: rune,
+	end: rune,
+}
 
 Font_Bitmap_Glyph :: struct {
 	value: rune,

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -134,7 +134,7 @@ init :: proc(
 	// Dummy element so font with index 0 means 'no font'.
 	append_nothing(&s.fonts)
 
-	default_font := load_font_from_bytes(DEFAULT_FONT_DATA)
+	default_font := load_dynamic_font_from_bytes(DEFAULT_FONT_DATA)
 	log.assertf(default_font == FONT_DEFAULT, "Default font must be at index %i", FONT_DEFAULT)
 	_set_font(FONT_DEFAULT)
 
@@ -1111,130 +1111,132 @@ measure_text :: proc(text: string, font_size: f32, font: Font = FONT_DEFAULT) ->
 	font_object := s.fonts[font]
 
 	switch font_object.type {
-	case .Bitmap:
-		return _measure_text_bitmap(text, font_size, font)
+	case .Static:
+		return measure_text_static(text, font_size, font)
 
-	case .Fontstash:
-		return _measure_text_fontstash(text, font_size, font)
+	case .Dynamic:
+		return measure_text_dynamic(text, font_size, font)
 	}
 
 	return {}
-}
 
-_measure_text_bitmap :: proc(text: string, font_size: f32, font: Font) -> Vec2 {
-	w: f32
-	line_w: f32
+	// ----------
 
-	if int(font) >= len(s.fonts) {
-		return {}
-	}
+	measure_text_static :: proc(text: string, font_size: f32, font: Font) -> Vec2 {
+		w: f32
+		line_w: f32
 
-	font_object := &s.fonts[font]
-	scl := font_size / font_object.bitmap_font_size
-	num_linebreaks := 0
-
-	for c in text {
-		if c == '\r' {
-			continue
+		if int(font) >= len(s.fonts) {
+			return {}
 		}
 
-		if c == '\n' {
-			if line_w > w {
-				w = line_w
-			}
+		font_object := &s.fonts[font]
+		scl := font_size / font_object.static_font_size
+		num_linebreaks := 0
 
-			line_w = 0
-			num_linebreaks += 1
-			continue
-		}
-		
-		g: ^Font_Bitmap_Glyph
-
-		for &r in font_object.glyph_ranges {
-			if c >= r.start && c < r.end {
-				g = &font_object.glyphs[r.start_idx + int(c - r.start)]
-				break
-			}
-		}
-
-		if g != nil {
-			line_w += g.advance*scl
-		} else {
-			line_w += font_size * 0.5
-		}
-	}
-
-	// Check last line
-	if line_w > w {
-		w = line_w
-	}
-
-	h := f32(num_linebreaks + 1) * font_object.bitmap_line_spacing * scl
-
-	return {
-		w,
-		h,
-	}
-}
-
-_measure_text_fontstash :: proc(text: string, font_size: f32, font: Font) -> Vec2 {
-	if font < 0 || int(font) >= len(s.fonts) {
-		return {}
-	}
-
-	font_object := s.fonts[font]
-
-	// Temporary until I rewrite the font caching system.
-	_set_font(font)
-
-	// TextBounds from fontstash, but fixed and simplified for my purposes.
-	// The version in there is broken.
-	TextBounds :: proc(
-		ctx:  ^fs.FontContext,
-		font_idx: int,
-		size: f32,
-		text: string,
-	) -> Vec2 {
-		font  := fs.__getFont(ctx, font_idx)
-		isize := i16(size * 10)
-
-		x, y: f32
-		max_x := x
-
-		scale := fs.__getPixelHeightScale(font, f32(isize) / 10)
-		previousGlyphIndex: fs.Glyph_Index = -1
-		quad: fs.Quad
-		lines := 1
-
-		for codepoint in text {
-			if codepoint == '\n' {
-				x = 0
-				lines += 1
+		for c in text {
+			if c == '\r' {
 				continue
 			}
 
-			if glyph, ok := fs.__getGlyph(ctx, font, codepoint, isize); ok {
-				if glyph.xadvance > 0 {
-					x += f32(int(f32(glyph.xadvance) / 10 + 0.5))
-				} else {
-					// updates x
-					fs.__getQuad(ctx, font, previousGlyphIndex, glyph, scale, 0, &x, &y, &quad)
+			if c == '\n' {
+				if line_w > w {
+					w = line_w
 				}
 
-				if x > max_x {
-					max_x = x
-				}
+				line_w = 0
+				num_linebreaks += 1
+				continue
+			}
+			
+			g: ^Font_Baked_Glyph
 
-				previousGlyphIndex = glyph.index
-			} else {
-				previousGlyphIndex = -1
+			for &r in font_object.static_glyph_ranges {
+				if c >= r.start && c < r.end {
+					g = &font_object.static_glyphs[r.start_idx + int(c - r.start)]
+					break
+				}
 			}
 
+			if g != nil {
+				line_w += g.advance*scl
+			} else {
+				line_w += font_size * 0.5
+			}
 		}
-		return { max_x, f32(lines)*size }
+
+		// Check last line
+		if line_w > w {
+			w = line_w
+		}
+
+		h := f32(num_linebreaks + 1) * font_object.static_line_spacing * scl
+
+		return {
+			w,
+			h,
+		}
 	}
 
-	return TextBounds(&s.fs, font_object.fontstash_handle, font_size, text)
+	measure_text_dynamic :: proc(text: string, font_size: f32, font: Font) -> Vec2 {
+		if font < 0 || int(font) >= len(s.fonts) {
+			return {}
+		}
+
+		font_object := s.fonts[font]
+
+		// Temporary until I rewrite the font caching system.
+		_set_font(font)
+
+		// TextBounds from fontstash, but fixed and simplified for my purposes.
+		// The version in there is broken.
+		TextBounds :: proc(
+			ctx:  ^fs.FontContext,
+			font_idx: int,
+			size: f32,
+			text: string,
+		) -> Vec2 {
+			font  := fs.__getFont(ctx, font_idx)
+			isize := i16(size * 10)
+
+			x, y: f32
+			max_x := x
+
+			scale := fs.__getPixelHeightScale(font, f32(isize) / 10)
+			previousGlyphIndex: fs.Glyph_Index = -1
+			quad: fs.Quad
+			lines := 1
+
+			for codepoint in text {
+				if codepoint == '\n' {
+					x = 0
+					lines += 1
+					continue
+				}
+
+				if glyph, ok := fs.__getGlyph(ctx, font, codepoint, isize); ok {
+					if glyph.xadvance > 0 {
+						x += f32(int(f32(glyph.xadvance) / 10 + 0.5))
+					} else {
+						// updates x
+						fs.__getQuad(ctx, font, previousGlyphIndex, glyph, scale, 0, &x, &y, &quad)
+					}
+
+					if x > max_x {
+						max_x = x
+					}
+
+					previousGlyphIndex = glyph.index
+				} else {
+					previousGlyphIndex = -1
+				}
+
+			}
+			return { max_x, f32(lines)*size }
+		}
+
+		return TextBounds(&s.fs, font_object.dynamic_fontstash_handle, font_size, text)
+	}
 
 }
 
@@ -1267,8 +1269,8 @@ draw_text :: proc(
 	font_object := &s.fonts[font]
 
 	switch font_object.type {
-	case .Bitmap:
-		_draw_text_bitmap(
+	case .Static:
+		draw_text_static(
 			text,
 			position,
 			font_size,
@@ -1278,8 +1280,8 @@ draw_text :: proc(
 			rotation,
 		)
 
-	case .Fontstash:
-		_draw_text_fontstash(
+	case .Dynamic:
+		draw_text_dynamic(
 			text,
 			position,
 			font_size,
@@ -1289,148 +1291,151 @@ draw_text :: proc(
 			rotation,
 		)
 	}
-}
 
-_draw_text_bitmap :: proc(
-	text: string,
-	position: Vec2,
-	font_size: f32,
-	color: Color,
-	font := FONT_DEFAULT,
-	origin: Vec2 = {},
-	rotation: f32 = 0,
-) {
-	if int(font) >= len(s.fonts) {
-		return
-	}
+	// ----------
 
-	font_object := &s.fonts[font]
-	char_offset: Vec2
-	scl := font_size / font_object.bitmap_font_size
-
-	for c in text {
-		if c == '\r' {
-			continue
+	draw_text_static :: proc(
+		text: string,
+		position: Vec2,
+		font_size: f32,
+		color: Color,
+		font := FONT_DEFAULT,
+		origin: Vec2 = {},
+		rotation: f32 = 0,
+	) {
+		if int(font) >= len(s.fonts) {
+			return
 		}
 
-		if c == '\n' {
-			char_offset.x = 0 
-			char_offset.y += font_object.bitmap_line_spacing * scl
-			continue
-		}
+		font_object := &s.fonts[font]
+		char_offset: Vec2
+		scl := font_size / font_object.static_font_size
 
-		g: ^Font_Bitmap_Glyph
+		for c in text {
+			if c == '\r' {
+				continue
+			}
 
-		for &r in font_object.glyph_ranges {
-			if c >= r.start && c < r.end {
-				g = &font_object.glyphs[r.start_idx + int(c - r.start)]
-				break
+			if c == '\n' {
+				char_offset.x = 0 
+				char_offset.y += font_object.static_line_spacing * scl
+				continue
+			}
+
+			g: ^Font_Baked_Glyph
+
+			for &r in font_object.static_glyph_ranges {
+				if c >= r.start && c < r.end {
+					g = &font_object.static_glyphs[r.start_idx + int(c - r.start)]
+					break
+				}
+			}
+
+			if g != nil {
+				src := g.rect
+
+				dst := Rect {
+					position.x, position.y,
+					src.w * scl, src.h * scl,
+				}
+
+				char_origin := origin - (char_offset + g.offset*scl)
+
+				draw_texture_fit(
+					font_object.atlas,
+					src,
+					dst,
+					tint = color,
+					origin = char_origin,
+					rotation = rotation,
+				)
+
+				char_offset.x += g.advance*scl
+			} else {
+				invalid_rect_size := Vec2 {font_size*0.5, font_size*0.5}
+				invalid_rect := rect_from_pos_size(position + char_offset + {0, invalid_rect_size.y/2}, invalid_rect_size)
+				
+				draw_rect(
+					invalid_rect,
+					RED,
+				)
+
+				char_offset.x += invalid_rect_size.x
 			}
 		}
+	}
 
-		if g != nil {
-			src := g.rect
+	draw_text_dynamic :: proc(
+		text: string,
+		position: Vec2,
+		font_size: f32,
+		color: Color,
+		font := FONT_DEFAULT,
+		origin: Vec2 = {},
+		rotation: f32 = 0,
+	) {
+		if int(font) >= len(s.fonts) {
+			return
+		}
 
+		_set_font(font)
+		font_object := &s.fonts[font]
+
+		camera_zoom: f32 = 1
+
+		if cam, cam_ok := s.batch_camera.?; cam_ok && cam.zoom > 0.001 {
+			camera_zoom = cam.zoom
+		}
+
+		// Bake the glyph at font_size*camera_zoom pixels so it is sharp at the current zoom level.
+		// We then divide quad positions back by camera_zoom to recover world-space coordinates.
+		render_size := font_size * camera_zoom
+		scaled_pos  := position * camera_zoom
+
+		fs.SetSize(&s.fs, render_size)
+		iter := fs.TextIterInit(&s.fs, scaled_pos.x, scaled_pos.y, text)
+
+		q: fs.Quad
+		for fs.TextIterNext(&s.fs, &iter, &q) {
+			if iter.codepoint == '\n' {
+				iter.nexty += render_size
+				iter.nextx = scaled_pos.x
+				continue
+			}
+
+			if iter.codepoint == '\t' {
+				iter.nextx += 2*render_size
+				continue
+			}
+
+			src := Rect {
+				q.s0, q.t0,
+				q.s1 - q.s0, q.t1 - q.t0,
+			}
+
+			w := f32(FONT_DEFAULT_ATLAS_SIZE)
+			h := f32(FONT_DEFAULT_ATLAS_SIZE)
+			src.x *= w
+			src.y *= h
+			src.w *= w
+			src.h *= h
+
+			// Unscale quad positions from atlas-space back to world-space.
+			qx0 := q.x0 / camera_zoom
+			qy0 := q.y0 / camera_zoom
+			qx1 := q.x1 / camera_zoom
+			qy1 := q.y1 / camera_zoom
+			
 			dst := Rect {
 				position.x, position.y,
-				src.w * scl, src.h * scl,
+				qx1 - qx0, qy1 - qy0,
 			}
 
-			char_origin := origin - (char_offset + g.offset*scl)
-
-			draw_texture_fit(
-				font_object.atlas,
-				src,
-				dst,
-				tint = color,
-				origin = char_origin,
-				rotation = rotation,
-			)
-
-			char_offset.x += g.advance*scl
-		} else {
-			invalid_rect_size := Vec2 {font_size*0.5, font_size*0.5}
-			invalid_rect := rect_from_pos_size(position + char_offset + {0, invalid_rect_size.y/2}, invalid_rect_size)
-			
-			draw_rect(
-				invalid_rect,
-				RED,
-			)
-
-			char_offset.x += invalid_rect_size.x
+			char_origin := origin + {position.x - qx0, position.y - qy0}
+			draw_texture_fit(font_object.atlas, src, dst, char_origin, rotation, color)
 		}
 	}
-}
 
-_draw_text_fontstash :: proc(
-	text: string,
-	position: Vec2,
-	font_size: f32,
-	color: Color,
-	font := FONT_DEFAULT,
-	origin: Vec2 = {},
-	rotation: f32 = 0,
-) {
-	if int(font) >= len(s.fonts) {
-		return
-	}
-
-	_set_font(font)
-	font_object := &s.fonts[font]
-
-	camera_zoom: f32 = 1
-
-	if cam, cam_ok := s.batch_camera.?; cam_ok && cam.zoom > 0.001 {
-		camera_zoom = cam.zoom
-	}
-
-	// Bake the glyph at font_size*camera_zoom pixels so it is sharp at the current zoom level.
-	// We then divide quad positions back by camera_zoom to recover world-space coordinates.
-	render_size := font_size * camera_zoom
-	scaled_pos  := position * camera_zoom
-
-	fs.SetSize(&s.fs, render_size)
-	iter := fs.TextIterInit(&s.fs, scaled_pos.x, scaled_pos.y, text)
-
-	q: fs.Quad
-	for fs.TextIterNext(&s.fs, &iter, &q) {
-		if iter.codepoint == '\n' {
-			iter.nexty += render_size
-			iter.nextx = scaled_pos.x
-			continue
-		}
-
-		if iter.codepoint == '\t' {
-			iter.nextx += 2*render_size
-			continue
-		}
-
-		src := Rect {
-			q.s0, q.t0,
-			q.s1 - q.s0, q.t1 - q.t0,
-		}
-
-		w := f32(FONT_DEFAULT_ATLAS_SIZE)
-		h := f32(FONT_DEFAULT_ATLAS_SIZE)
-		src.x *= w
-		src.y *= h
-		src.w *= w
-		src.h *= h
-
-		// Unscale quad positions from atlas-space back to world-space.
-		qx0 := q.x0 / camera_zoom
-		qy0 := q.y0 / camera_zoom
-		qx1 := q.x1 / camera_zoom
-		qy1 := q.y1 / camera_zoom
-		
-		dst := Rect {
-			position.x, position.y,
-			qx1 - qx0, qy1 - qy0,
-		}
-
-		char_origin := origin + {position.x - qx0, position.y - qy0}
-		draw_texture_fit(font_object.atlas, src, dst, char_origin, rotation, color)
-	}
 }
 
 @(deprecated="Use draw_text instead")
@@ -3316,8 +3321,7 @@ rotate :: proc(v: Vec2, angle_radians: f32) -> Vec2 {
 // FONTS //
 //-------//
 
-// Loads a font from disk and returns a handle that represents it.
-load_font_from_file :: proc(filename: string, options: Font_Options = {}) -> Font {
+load_static_font_from_file :: proc(filename: string, font_size: f32, codepoints: []rune = {}, options: Font_Options = {}) -> Font {
 	data, data_ok := read_entire_file(filename, s.frame_allocator)
 
 	if !data_ok {
@@ -3325,49 +3329,17 @@ load_font_from_file :: proc(filename: string, options: Font_Options = {}) -> Fon
 		return FONT_NONE
 	}
 
-	return load_font_from_bytes(data, options)
+	return load_static_font_from_bytes(data, font_size, codepoints, options)
 }
 
-// Loads a font from a block of memory and returns a handle that represents it.
-load_font_from_bytes :: proc(data: []u8, options: Font_Options = {}) -> Font {
-	fontstash_handle := fs.AddFontMem(&s.fs, "", slice.clone(data, s.allocator), false)
-	h := Font(len(s.fonts))
-
-	data := Font_Data {
-		fontstash_handle = fontstash_handle,
-		atlas = {
-			handle = rb.create_texture(FONT_DEFAULT_ATLAS_SIZE, FONT_DEFAULT_ATLAS_SIZE, .RGBA_8_Norm),
-			width = FONT_DEFAULT_ATLAS_SIZE,
-			height = FONT_DEFAULT_ATLAS_SIZE,
-		},
-		type = .Fontstash,
-		options = options,
-	}
-
-	set_texture_filter(data.atlas, options.filter)
-	append(&s.fonts, data)
-	return h
-}
-
-load_bitmap_font_from_file :: proc(filename: string, font_size: f32, codepoints: []rune = {}, options: Font_Options = {}) -> Font {
-	data, data_ok := read_entire_file(filename, s.frame_allocator)
-
-	if !data_ok {
-		log.errorf("Failed loading font %s", filename)
-		return FONT_NONE
-	}
-
-	return load_bitmap_font_from_bytes(data, font_size, codepoints, options)
-}
-
-load_bitmap_font_from_bytes :: proc(data: []byte, font_size: f32, codepoints: []rune = {}, options: Font_Options = {}) -> Font {
+load_static_font_from_bytes :: proc(data: []byte, font_size: f32, codepoints: []rune = {}, options: Font_Options = {}) -> Font {
 	codepoints := codepoints
 	font_info: stbtt.fontinfo
 	font_offset := stbtt.GetFontOffsetForIndex(raw_data(data), 0)
 	init_ok := stbtt.InitFont(&font_info, raw_data(data), font_offset)
 
 	if !init_ok {
-		log.error("Failed loading TTF bitmap font")
+		log.error("Failed loading TTF/TTC font")
 		return FONT_NONE
 	}
 
@@ -3386,8 +3358,8 @@ load_bitmap_font_from_bytes :: proc(data: []byte, font_size: f32, codepoints: []
 		codepoints = default_codepoints[:]
 	}
 
-	glyph_ranges := make([dynamic]Font_Bitmap_Glyph_Range, s.frame_allocator)
-	glyphs := make([dynamic]Font_Bitmap_Glyph, s.frame_allocator)
+	glyph_ranges := make([dynamic]Font_Baked_Glyph_Range, s.frame_allocator)
+	glyphs := make([dynamic]Font_Baked_Glyph, s.frame_allocator)
 
 	for c in codepoints {
 		idx := stbtt.FindGlyphIndex(&font_info, c)
@@ -3396,7 +3368,7 @@ load_bitmap_font_from_bytes :: proc(data: []byte, font_size: f32, codepoints: []
 			advance: i32
 			stbtt.GetGlyphHMetrics(&font_info, idx, &advance, nil)
 
-			append(&glyphs, Font_Bitmap_Glyph {
+			append(&glyphs, Font_Baked_Glyph {
 				value = c,
 				index = int(idx),
 				advance = f32(advance) * scale_factor,
@@ -3406,12 +3378,12 @@ load_bitmap_font_from_bytes :: proc(data: []byte, font_size: f32, codepoints: []
 
 	slice.sort_by(
 		glyphs[:],
-		proc(i, j: Font_Bitmap_Glyph) -> bool {
+		proc(i, j: Font_Baked_Glyph) -> bool {
 			return i.value < j.value
 		},
 	)
 
-	cur_glyph_range: Font_Bitmap_Glyph_Range
+	cur_glyph_range: Font_Baked_Glyph_Range
 
 	for g, g_idx in glyphs {
 		if g_idx == 0 {
@@ -3588,19 +3560,62 @@ load_bitmap_font_from_bytes :: proc(data: []byte, font_size: f32, codepoints: []
 
 	font := Font_Data {
 		atlas = tex,
-		type = .Bitmap,
+		type = .Static,
 		options = options,
-		glyphs = slice.clone(glyphs[:], s.allocator),
-		glyph_ranges = slice.clone(glyph_ranges[:], s.allocator),
-		bitmap_font_size = font_size,
+		static_glyphs = slice.clone(glyphs[:], s.allocator),
+		static_glyph_ranges = slice.clone(glyph_ranges[:], s.allocator),
+		static_font_size = font_size,
 
-		// from stbtt.GetFontVMetrics docs 
-		bitmap_line_spacing = f32(ascent - descent + line_gap) * scale_factor,
+		// Fomula from stbtt.GetFontVMetrics docs 
+		static_line_spacing = f32(ascent - descent + line_gap) * scale_factor,
 	}
 
 	font_handle := Font(len(s.fonts))
 	append(&s.fonts, font)
 	return font_handle
+}
+
+// Loads a font from disk and returns a handle that represents it.
+load_dynamic_font_from_file :: proc(filename: string, options: Font_Options = {}) -> Font {
+	data, data_ok := read_entire_file(filename, s.frame_allocator)
+
+	if !data_ok {
+		log.errorf("Failed loading font %s", filename)
+		return FONT_NONE
+	}
+
+	return load_dynamic_font_from_bytes(data, options)
+}
+
+// Loads a font from a block of memory and returns a handle that represents it.
+load_dynamic_font_from_bytes :: proc(data: []u8, options: Font_Options = {}) -> Font {
+	fontstash_handle := fs.AddFontMem(&s.fs, "", slice.clone(data, s.allocator), false)
+	h := Font(len(s.fonts))
+
+	data := Font_Data {
+		dynamic_fontstash_handle = fontstash_handle,
+		atlas = {
+			handle = rb.create_texture(FONT_DEFAULT_ATLAS_SIZE, FONT_DEFAULT_ATLAS_SIZE, .RGBA_8_Norm),
+			width = FONT_DEFAULT_ATLAS_SIZE,
+			height = FONT_DEFAULT_ATLAS_SIZE,
+		},
+		type = .Dynamic,
+		options = options,
+	}
+
+	set_texture_filter(data.atlas, options.filter)
+	append(&s.fonts, data)
+	return h
+}
+
+@(deprecated="Use load_dynamic_font_from_file or load_static_font_from_file.")
+load_font_from_file :: proc(filename: string, options: Font_Options = {}) -> Font {
+	return load_dynamic_font_from_file(filename, options)
+}
+
+@(deprecated="Use load_dynamic_font_from_bytes or load_static_font_from_bytes")
+load_font_from_bytes :: proc(data: []u8, options: Font_Options = {}) -> Font {
+	return load_dynamic_font_from_bytes(data, options)
 }
 
 // Destroy a font previously loaded using `load_font_from_file` or `load_font_from_bytes`.
@@ -3613,14 +3628,14 @@ destroy_font :: proc(font: Font) {
 	rb.destroy_texture(f.atlas.handle)
 
 	switch f.type {
-	case .Bitmap:
-		delete(f.glyphs, s.allocator)
-		delete(f.glyph_ranges, s.allocator)
-	case .Fontstash:
+	case .Static:
+		delete(f.static_glyphs, s.allocator)
+		delete(f.static_glyph_ranges, s.allocator)
+	case .Dynamic:
 		// TODO fontstash has no "destroy font" proc... I should make my own version of fontstash
-		delete(s.fs.fonts[f.fontstash_handle].glyphs)
-		delete(s.fs.fonts[f.fontstash_handle].loadedData, s.allocator)
-		s.fs.fonts[f.fontstash_handle].glyphs = {}
+		delete(s.fs.fonts[f.dynamic_fontstash_handle].glyphs)
+		delete(s.fs.fonts[f.dynamic_fontstash_handle].loadedData, s.allocator)
+		s.fs.fonts[f.dynamic_fontstash_handle].glyphs = {}
 	}
 
 }
@@ -4354,9 +4369,18 @@ Font_Options :: struct {
 	filter: Texture_Filter,
 }
 
+// Supported font types:
+// - Static: A pre-baked font where you specify a range of characters that are baked into a texture.
+// - Dynamic: A font where an atlas is continuously updated as you need need new characters. This
+//            mode current uses fontstash.
+//
+// Future types (TODO):
+// - Slug: Upload the character bezier curves to the GPU and render the text on the GPU without the
+//         need for any atlas texture. This will be based on the "slug font algorithm" that was
+//         recently put into public domain.
 Font_Type :: enum {
-	Bitmap,
-	Fontstash,
+	Static,
+	Dynamic,
 }
 
 Font_Data :: struct {
@@ -4365,14 +4389,14 @@ Font_Data :: struct {
 
 	type: Font_Type,
 
-	// type == .Bitmap
-	glyphs: []Font_Bitmap_Glyph,
-	glyph_ranges: []Font_Bitmap_Glyph_Range,
-	bitmap_font_size: f32,
-	bitmap_line_spacing: f32,
+	// type == .Static
+	static_glyphs: []Font_Baked_Glyph,
+	static_glyph_ranges: []Font_Baked_Glyph_Range,
+	static_font_size: f32,
+	static_line_spacing: f32,
 
-	// type == .Fontstash
-	fontstash_handle: int,
+	// type == .Dynamic
+	dynamic_fontstash_handle: int,
 }
 
 Handle :: hm.Handle64
@@ -4381,13 +4405,13 @@ Render_Target_Handle :: distinct Handle
 Font :: distinct int
 DEFAULT_FONT_DATA :: #load("default_fonts/roboto.ttf")
 
-Font_Bitmap_Glyph_Range :: struct {
+Font_Baked_Glyph_Range :: struct {
 	start_idx: int,
 	start: rune,
 	end: rune,
 }
 
-Font_Bitmap_Glyph :: struct {
+Font_Baked_Glyph :: struct {
 	value: rune,
 	// stbtt index, for faster lookup
 	index: int,
@@ -5113,7 +5137,7 @@ _set_font :: proc(fh: Font) {
 	}
 
 	font := &s.fonts[fh]
-	fs.SetFont(&s.fs, font.fontstash_handle)
+	fs.SetFont(&s.fs, font.dynamic_fontstash_handle)
 }
 
 _ :: jpeg

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1322,6 +1322,11 @@ draw_text :: proc(
 				continue
 			}
 
+			if c == '\t' {
+				char_offset.x += font_size * 2
+				continue
+			}
+
 			g: ^Font_Baked_Glyph
 
 			for &r in font_object.static_glyph_ranges {
@@ -3426,11 +3431,11 @@ load_static_font_from_bytes :: proc(
 		x_off, y_off: i32
 		w, h: i32
 
-		pixels := stbtt.GetCodepointBitmap(
+		pixels := stbtt.GetGlyphBitmap(
 			&font_info,
 			scale_factor,
 			scale_factor,
-			g.value,
+			i32(g.index),
 			&w,
 			&h,
 			&x_off,
@@ -3449,8 +3454,9 @@ load_static_font_from_bytes :: proc(
 		}
 
 		glyphs_pack_rects[g_idx] = {
-			w = stbrp.Coord(w),
-			h = stbrp.Coord(h),
+			// w & h are packed wit 1 pixel padding, so we get 1 px spacing betwen characters.
+			w = stbrp.Coord(w) + 1,
+			h = stbrp.Coord(h) + 1,
 		}
 	}
 
@@ -3498,8 +3504,9 @@ load_static_font_from_bytes :: proc(
 			g.rect = {
 				f32(pr.x),
 				f32(pr.y),
-				f32(pr.w),
-				f32(pr.h),
+				// w & h are packed wit 1 pixel padding, so we get 1 px spacing betwen characters.
+				f32(pr.w) - 1,
+				f32(pr.h) - 1,
 			}
 
 			gimg := glyphs_img_data[pr_idx]
@@ -3512,7 +3519,7 @@ load_static_font_from_bytes :: proc(
 					assert(dx >= 0 && dx < atlas_size)
 					assert(dy >= 0 && dy < atlas_size)
 
-					alpha := gimg.pixels[sx * gimg.width + sy]
+					alpha := gimg.pixels[sy * gimg.width + sx]
 					alpha_norm := f32(alpha)/255
 
 					atlas[dy * atlas_size + dx] = {
@@ -3531,8 +3538,9 @@ load_static_font_from_bytes :: proc(
 			g.rect = {
 				f32(pr.x),
 				f32(pr.y),
-				f32(pr.w),
-				f32(pr.h),
+				// w & h are packed wit 1 pixel padding, so we get 1 px spacing betwen characters.
+				f32(pr.w) - 1,
+				f32(pr.h) - 1,
 			}
 
 			gimg := glyphs_img_data[pr_idx]
@@ -3555,6 +3563,12 @@ load_static_font_from_bytes :: proc(
 					}
 				}
 			}
+		}
+	}
+
+	for gimg in glyphs_img_data {
+		if gimg.pixels != nil {
+			stbtt.FreeBitmap(gimg.pixels, nil)
 		}
 	}
 

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1110,6 +1110,80 @@ measure_text :: proc(text: string, font_size: f32, font: Font = FONT_DEFAULT) ->
 
 	font_object := s.fonts[font]
 
+	switch font_object.type {
+	case .Bitmap:
+		return _measure_text_bitmap(text, font_size, font)
+
+	case .Fontstash:
+		return _measure_text_fontstash(text, font_size, font)
+	}
+
+	return {}
+}
+
+_measure_text_bitmap :: proc(text: string, font_size: f32, font: Font) -> Vec2 {
+	w: f32
+	line_w: f32
+
+	if int(font) >= len(s.fonts) {
+		return {}
+	}
+
+	font_object := &s.fonts[font]
+	scl := font_size / font_object.bitmap_font_size
+	num_linebreaks := 0
+
+	for c in text {
+		if c == '\r' {
+			continue
+		}
+
+		if c == '\n' {
+			if line_w > w {
+				w = line_w
+			}
+
+			line_w = 0
+			num_linebreaks += 1
+			continue
+		}
+
+		g: ^Font_Bitmap_Glyph
+
+		for &gc in font_object.glyphs {
+			if gc.value == c {
+				g = &gc
+				break
+			}
+		}
+
+		if g != nil {
+			line_w += g.advance*scl
+		} else {
+			line_w += font_size * 0.5
+		}
+	}
+
+	// Check last line
+	if line_w > w {
+		w = line_w
+	}
+
+	h := f32(num_linebreaks + 1) * font_object.bitmap_line_spacing * scl
+
+	return {
+		w,
+		h,
+	}
+}
+
+_measure_text_fontstash :: proc(text: string, font_size: f32, font: Font) -> Vec2 {
+	if font < 0 || int(font) >= len(s.fonts) {
+		return {}
+	}
+
+	font_object := s.fonts[font]
+
 	// Temporary until I rewrite the font caching system.
 	_set_font(font)
 
@@ -1161,6 +1235,7 @@ measure_text :: proc(text: string, font_size: f32, font: Font = FONT_DEFAULT) ->
 	}
 
 	return TextBounds(&s.fs, font_object.fontstash_handle, font_size, text)
+
 }
 
 @(deprecated="Use measure_text(text, font_size, font) instead")
@@ -1230,9 +1305,20 @@ _draw_text_bitmap :: proc(
 	}
 
 	font_object := &s.fonts[font]
-	position := position
+	char_offset: Vec2
+	scl := font_size / font_object.bitmap_font_size
 
 	for c in text {
+		if c == '\r' {
+			continue
+		}
+
+		if c == '\n' {
+			char_offset.x = 0 
+			char_offset.y += font_object.bitmap_line_spacing * scl
+			continue
+		}
+
 		g: ^Font_Bitmap_Glyph
 
 		for &gc in font_object.glyphs {
@@ -1243,24 +1329,35 @@ _draw_text_bitmap :: proc(
 		}
 
 		if g != nil {
-			draw_texture_rect(
+			src := g.rect
+
+			dst := Rect {
+				position.x, position.y,
+				src.w * scl, src.h * scl,
+			}
+
+			char_origin := origin - (char_offset + g.offset*scl)
+
+			draw_texture_fit(
 				font_object.atlas,
-				g.rect,
-				position + g.offset,
+				src,
+				dst,
 				tint = color,
+				origin = char_origin,
+				rotation = rotation,
 			)
 
-			position.x += g.advance
+			char_offset.x += g.advance*scl
 		} else {
 			invalid_rect_size := Vec2 {font_size*0.5, font_size*0.5}
-			invalid_rect := rect_from_pos_size(position + {0, invalid_rect_size.y/2}, invalid_rect_size)
+			invalid_rect := rect_from_pos_size(position + char_offset + {0, invalid_rect_size.y/2}, invalid_rect_size)
 			
 			draw_rect(
 				invalid_rect,
 				RED,
 			)
 
-			position.x += invalid_rect_size.x
+			char_offset.x += invalid_rect_size.x
 		}
 	}
 }
@@ -3464,6 +3561,10 @@ load_bitmap_font_from_bytes :: proc(data: []byte, font_size: f32, codepoints: []
 		type = .Bitmap,
 		options = options,
 		glyphs = slice.clone(glyphs[:], s.allocator),
+		bitmap_font_size = font_size,
+
+		// from stbtt.GetFontVMetrics docs 
+		bitmap_line_spacing = f32(ascent - descent + line_gap) * scale_factor,
 	}
 
 	font_handle := Font(len(s.fonts))
@@ -4228,6 +4329,8 @@ Font_Data :: struct {
 
 	// type == .Bitmap
 	glyphs: []Font_Bitmap_Glyph,
+	bitmap_font_size: f32,
+	bitmap_line_spacing: f32,
 
 	// type == .Fontstash
 	fontstash_handle: int,

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -15,6 +15,7 @@ import "core:encoding/endian"
 
 import fs "vendor:fontstash"
 import stbv "vendor:stb/vorbis"
+import stbtt "vendor:stb/truetype"
 
 import "core:image"
 import "core:image/jpeg"
@@ -3118,11 +3119,11 @@ load_font_from_file :: proc(filename: string, options: Font_Options = {}) -> Fon
 
 // Loads a font from a block of memory and returns a handle that represents it.
 load_font_from_bytes :: proc(data: []u8, options: Font_Options = {}) -> Font {
-	font := fs.AddFontMem(&s.fs, "", slice.clone(data, s.allocator), false)
+	fontstash_handle := fs.AddFontMem(&s.fs, "", slice.clone(data, s.allocator), false)
 	h := Font(len(s.fonts))
 
 	data := Font_Data {
-		fontstash_handle = font,
+		fontstash_handle = fontstash_handle,
 		atlas = {
 			handle = rb.create_texture(FONT_DEFAULT_ATLAS_SIZE, FONT_DEFAULT_ATLAS_SIZE, .RGBA_8_Norm),
 			width = FONT_DEFAULT_ATLAS_SIZE,
@@ -3134,6 +3135,68 @@ load_font_from_bytes :: proc(data: []u8, options: Font_Options = {}) -> Font {
 	set_texture_filter(data.atlas, options.filter)
 	append(&s.fonts, data)
 	return h
+}
+
+load_bitmap_font_from_file :: proc(filename: string, font_size: f32, codepoints: []rune = {}, options: Font_Options = {}) -> Font {
+	data, data_ok := read_entire_file(filename, s.frame_allocator)
+
+	if !data_ok {
+		log.errorf("Failed loading font %s", filename)
+		return FONT_NONE
+	}
+
+	return load_bitmap_font_from_bytes(data, font_size, codepoints, options)
+}
+
+load_bitmap_font_from_bytes :: proc(data: []byte, font_size: f32, codepoints: []rune = {}, options: Font_Options = {}) -> Font {
+	//
+	// This implementation is based on LoadFontData in Raylib.
+	//
+
+	codepoints := codepoints
+	font_info: stbtt.fontinfo
+	init_ok := stbtt.InitFont(&font_info, raw_data(data), 0)
+
+	if !init_ok {
+		log.error("Failed loading TTF bitmap font")
+		return FONT_NONE
+	}
+
+	scale_factor := stbtt.ScaleForPixelHeight(&font_info, font_size)
+
+	ascent, descent, line_gap: i32
+	stbtt.GetFontVMetrics(&font_info, &ascent, &descent, &line_gap)
+
+	default_codepoints: [95]rune
+
+	if len(codepoints) == 0 {
+		for &d, idx in default_codepoints {
+			d = rune(idx + 32)
+		}
+
+		codepoints = default_codepoints[:]
+	}
+
+	num_glyphs: int
+
+	for c in codepoints {
+		if stbtt.FindGlyphIndex(&font_info, c) > 0 {
+			num_glyphs += 1
+		}
+	}
+
+	glyphs := make([]Font_Bitmap_Glyph, num_glyphs, s.allocator)
+
+	for c, c_idx in codepoints {
+		w, h: i32
+		index := stbtt.FindGlyphIndex(&font_info, c) 
+
+		if index > 0 {
+			glyphs[c_idx].value = c
+
+
+		}
+	}
 }
 
 // Destroy a font previously loaded using `load_font_from_file` or `load_font_from_bytes`.
@@ -3885,6 +3948,12 @@ Texture_Handle :: distinct Handle
 Render_Target_Handle :: distinct Handle
 Font :: distinct int
 DEFAULT_FONT_DATA :: #load("default_fonts/roboto.ttf")
+
+Font_Bitmap_Glyph :: struct {
+	value: rune,
+	offset: Vec2,
+	advance: f32,
+}
 
 FONT_NONE :: Font(0)
 


### PR DESCRIPTION
Add support for pre-baked bitmap fonts. These are referred to as "static" fonts. I've renamed the fontstash fonts to "dynamic" fonts.

I may replace fontstash in a future PR with a custom solution for dynamic atlas baking.

On the horizon: Slug-style fonts, as a "fancy alternative" to the dynamic baking.