### PR TITLE
Mouse locking (capture the cursor)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ karl2d.doc.compare.odin
 .vscode
 .sublime
 scrap/
+.DS_Store

--- a/examples/mouse_capture/mouse_capture.odin
+++ b/examples/mouse_capture/mouse_capture.odin
@@ -17,13 +17,13 @@ step :: proc() -> bool {
 	}
 
 	if k2.mouse_button_went_down(.Left) {
-		k2.set_mouse_captured(true)
+		k2.lock_mouse()
 		k2.set_cursor_visible(false)
 		captured = true
 	}
 
 	if k2.key_went_down(.Escape) {
-		k2.set_mouse_captured(false)
+		k2.unlock_mouse()
 		k2.set_cursor_visible(true)
 		captured = false
 	}

--- a/examples/mouse_capture/mouse_capture.odin
+++ b/examples/mouse_capture/mouse_capture.odin
@@ -6,20 +6,33 @@ import k2 "../.."
 init :: proc() {
 	k2.init(1280, 720, "Karl2D Mouse Capture", options = {window_mode = .Windowed_Resizable})
 	pos = k2.get_screen_size() * 0.5
-	k2.set_mouse_captured(true)
-	k2.set_cursor_visible(false)
 }
 
 pos: k2.Vec2
+captured: bool
 
 step :: proc() -> bool {
 	if !k2.update() {
 		return false
 	}
 
+	if k2.mouse_button_went_down(.Left) {
+		k2.set_mouse_captured(true)
+		k2.set_cursor_visible(false)
+		captured = true
+	}
+
+	if k2.key_went_down(.Escape) {
+		k2.set_mouse_captured(false)
+		k2.set_cursor_visible(true)
+		captured = false
+	}
+
 	delta := k2.get_mouse_delta()
 
-	pos += delta * k2.get_frame_time() * 100
+	if captured {
+		pos += delta * k2.get_frame_time() * 100
+	}
 
 	if pos.x > f32(k2.get_screen_width()) {
 		pos.x = 0

--- a/examples/mouse_capture/mouse_capture.odin
+++ b/examples/mouse_capture/mouse_capture.odin
@@ -9,29 +9,32 @@ init :: proc() {
 }
 
 pos: k2.Vec2
-captured: bool
 
 step :: proc() -> bool {
 	if !k2.update() {
 		return false
 	}
 
-	if k2.mouse_button_went_down(.Left) {
-		k2.lock_mouse()
-		k2.set_cursor_visible(false)
-		captured = true
-	}
-
-	if k2.key_went_down(.Escape) {
-		k2.unlock_mouse()
-		k2.set_cursor_visible(true)
-		captured = false
-	}
-
 	delta := k2.get_mouse_delta()
 
 	if k2.is_mouse_locked() {
+		if k2.key_went_down(.Escape) {
+			k2.unlock_mouse()
+		}
+		
+		if k2.is_cursor_visible() {
+			k2.set_cursor_visible(false)
+		}
+
 		pos += delta * k2.get_frame_time() * 100
+	} else {
+		if k2.mouse_button_went_down(.Left) {
+			k2.lock_mouse()
+		}
+
+		if !k2.is_cursor_visible() {
+			k2.set_cursor_visible(true)
+		}
 	}
 
 	if pos.x > f32(k2.get_screen_width()) {

--- a/examples/mouse_capture/mouse_capture.odin
+++ b/examples/mouse_capture/mouse_capture.odin
@@ -1,0 +1,54 @@
+// Shows how to capture mouse cursor so that you can use it for non-cursor input.
+package karl2d_mouse_capture_example
+
+import k2 "../.."
+
+init :: proc() {
+	k2.init(1280, 720, "Karl2D Mouse Capture", options = {window_mode = .Windowed_Resizable})
+	pos = k2.get_screen_size() * 0.5
+	k2.set_mouse_captured(true)
+	k2.set_cursor_visible(false)
+}
+
+pos: k2.Vec2
+
+step :: proc() -> bool {
+	if !k2.update() {
+		return false
+	}
+
+	delta := k2.get_mouse_delta()
+
+	pos += delta * k2.get_frame_time() * 100
+
+	if pos.x > f32(k2.get_screen_width()) {
+		pos.x = 0
+	}
+
+	if pos.y > f32(k2.get_screen_height()) {
+		pos.y = 0
+	}
+
+	if pos.x < 0 {
+		pos.x = f32(k2.get_screen_width())
+	}
+
+	if pos.y < 0 {
+		pos.y = f32(k2.get_screen_height())
+	}
+
+	k2.clear(k2.LIGHT_BLUE)
+	k2.draw_circle(pos, 10, k2.RED)
+	k2.present()
+	return true
+}
+
+shutdown :: proc() {
+	k2.shutdown()
+}
+
+main :: proc() {
+	init()
+	for step() {}
+	shutdown()
+}

--- a/examples/mouse_capture/mouse_capture.odin
+++ b/examples/mouse_capture/mouse_capture.odin
@@ -30,7 +30,7 @@ step :: proc() -> bool {
 
 	delta := k2.get_mouse_delta()
 
-	if captured {
+	if k2.is_mouse_locked() {
 		pos += delta * k2.get_frame_time() * 100
 	}
 

--- a/examples/mouse_locking/mouse_locking.odin
+++ b/examples/mouse_locking/mouse_locking.odin
@@ -20,20 +20,14 @@ step :: proc() -> bool {
 	if k2.is_cursor_locked() {
 		if k2.key_went_down(.Escape) {
 			k2.set_cursor_locked(false)
-		}
-		
-		if k2.is_cursor_visible() {
-			k2.set_cursor_visible(false)
+			k2.set_cursor_hidden(false)
 		}
 
 		pos += delta * k2.get_frame_time() * 100
 	} else {
 		if k2.mouse_button_went_down(.Left) {
 			k2.set_cursor_locked(true)
-		}
-
-		if !k2.is_cursor_visible() {
-			k2.set_cursor_visible(true)
+			k2.set_cursor_hidden(true)
 		}
 	}
 

--- a/examples/mouse_locking/mouse_locking.odin
+++ b/examples/mouse_locking/mouse_locking.odin
@@ -1,10 +1,10 @@
-// Shows how to capture mouse cursor so that you can use it for non-cursor input.
-package karl2d_mouse_capture_example
+// Shows how to lock/capture mouse cursor so that you can use it for non-cursor input.
+package karl2d_mouse_locking_example
 
 import k2 "../.."
 
 init :: proc() {
-	k2.init(1280, 720, "Karl2D Mouse Capture", options = {window_mode = .Windowed_Resizable})
+	k2.init(1280, 720, "Karl2D Mouse Locking", options = {window_mode = .Windowed_Resizable})
 	pos = k2.get_screen_size() * 0.5
 }
 

--- a/examples/mouse_locking/mouse_locking.odin
+++ b/examples/mouse_locking/mouse_locking.odin
@@ -17,9 +17,9 @@ step :: proc() -> bool {
 
 	delta := k2.get_mouse_delta()
 
-	if k2.is_mouse_locked() {
+	if k2.is_cursor_locked() {
 		if k2.key_went_down(.Escape) {
-			k2.unlock_mouse()
+			k2.set_cursor_locked(false)
 		}
 		
 		if k2.is_cursor_visible() {
@@ -29,7 +29,7 @@ step :: proc() -> bool {
 		pos += delta * k2.get_frame_time() * 100
 	} else {
 		if k2.mouse_button_went_down(.Left) {
-			k2.lock_mouse()
+			k2.set_cursor_locked(true)
 		}
 
 		if !k2.is_cursor_visible() {

--- a/examples/mouse_locking/mouse_locking.odin
+++ b/examples/mouse_locking/mouse_locking.odin
@@ -19,16 +19,22 @@ step :: proc() -> bool {
 
 	if k2.key_went_down(.Escape) {
 		k2.set_cursor_locked(false)
-		k2.set_cursor_hidden(false)
 	}
-	
+
 	if k2.mouse_button_went_down(.Left) {
 		k2.set_cursor_locked(true)
-		k2.set_cursor_hidden(true)
 	}
 
 	if k2.is_cursor_locked() {
+		if !k2.is_cursor_hidden() {
+			k2.set_cursor_hidden(true)
+		}
+
 		pos += delta * k2.get_frame_time() * 100
+	} else {
+		if k2.is_cursor_hidden() {
+			k2.set_cursor_hidden(false)
+		}
 	}
 
 	if pos.x > f32(k2.get_screen_width()) {

--- a/examples/mouse_locking/mouse_locking.odin
+++ b/examples/mouse_locking/mouse_locking.odin
@@ -17,18 +17,18 @@ step :: proc() -> bool {
 
 	delta := k2.get_mouse_delta()
 
-	if k2.is_cursor_locked() {
-		if k2.key_went_down(.Escape) {
-			k2.set_cursor_locked(false)
-			k2.set_cursor_hidden(false)
-		}
+	if k2.key_went_down(.Escape) {
+		k2.set_cursor_locked(false)
+		k2.set_cursor_hidden(false)
+	}
+	
+	if k2.mouse_button_went_down(.Left) {
+		k2.set_cursor_locked(true)
+		k2.set_cursor_hidden(true)
+	}
 
+	if k2.is_cursor_locked() {
 		pos += delta * k2.get_frame_time() * 100
-	} else {
-		if k2.mouse_button_went_down(.Left) {
-			k2.set_cursor_locked(true)
-			k2.set_cursor_hidden(true)
-		}
 	}
 
 	if pos.x > f32(k2.get_screen_width()) {

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -151,8 +151,11 @@ get_window_scale :: proc() -> f32
 // Use to change between windowed mode, resizable windowed mode and fullscreen
 set_window_mode :: proc(window_mode: Window_Mode)
 
-// Hide or show the OS cursor.
+// Hide or show the mouse cursor. This is usually remembered if you unfocus and refocus the game.
 set_cursor_visible :: proc(visible: bool)
+
+// Returns true if the cursor is hidden.
+is_cursor_visible :: proc() -> bool
 
 // Flushes the current batch. This sends off everything to the GPU that has been queued in the
 // current batch. Normally, you do not need to do this manually. It is done automatically when these
@@ -235,6 +238,27 @@ get_mouse_position :: proc() -> Vec2
 
 // Returns how many pixels the mouse moved between the previous and the current frame.
 get_mouse_delta :: proc() -> Vec2
+
+// Locks the mouse cursor within the window. While the cursor is locked, you should no longer try to
+// use get_mouse_position, as it may have weird/static values. Instead, use get_mouse_delta to fetch
+// how much the mouse have been moved.
+//
+// On some platforms the cursor is just stuck at a specific point. On other platforms it may be
+// teleported back to the center of the window on each frame.
+//
+// This call does not hide the cursor, do that separately using `set_cursor_visible`.
+//
+// If the window loses focus, then the mouse may get unlocked. You can query the current lock status
+// using `is_mouse_locked`, which should take into account if the OS has unlocked it for you.
+lock_mouse :: proc()
+
+// Unlock the mouse, so that it is free to move outside the window.
+unlock_mouse :: proc()
+
+// Returns true if the mouse is currently locked. Note that the mouse can get unlocked by the OS,
+// even though you called `lock_mouse` in the past. Therefore, it's best to check the current status
+// using this procedure and then lock the mouse if needed.
+is_mouse_locked :: proc() -> bool
 
 // Returns true if a gamepad with the supplied index is connected. The parameter should be a value
 // between 0 and MAX_GAMEPADS.
@@ -1673,6 +1697,7 @@ Event :: union {
 	Event_Mouse_Wheel,
 	Event_Mouse_Button_Went_Down,
 	Event_Mouse_Button_Went_Up,
+	Event_Mouse_Teleported,
 	Event_Gamepad_Button_Went_Down,
 	Event_Gamepad_Button_Went_Up,
 	Event_Screen_Resize,
@@ -1708,6 +1733,12 @@ Event_Gamepad_Button_Went_Up :: struct {
 }
 
 Event_Close_Window_Requested :: struct {}
+
+// Used by mouse capturing to inform us that the cursor was teleported. This is like a mouse move,
+// but will not be used for calculating mouse delta movement.
+Event_Mouse_Teleported :: struct {
+	position: Vec2,
+}
 
 Event_Mouse_Move :: struct {
 	position: Vec2,

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -233,14 +233,18 @@ get_mouse_position :: proc() -> Vec2
 // Returns how many pixels the mouse moved between the previous and the current frame.
 get_mouse_delta :: proc() -> Vec2
 
-// Hide or show the mouse cursor. This is usually remembered if you unfocus and refocus the game.
+// Hide or show the mouse cursor. The cursor may get shown again if the window loses focus.
+// Therefore, it's often best to use `is_cursor_hidden` to check the current status and use this
+// proc to hide the cursor as needed.
 //
 // This call does not lock the cursor within the window, do that using a separate call to
 // `set_cursor_locked`.
-set_cursor_visible :: proc(visible: bool)
+set_cursor_hidden :: proc(hidden: bool)
 
-// Returns true if the cursor is hidden.
-is_cursor_visible :: proc() -> bool
+// Returns true if the cursor is hidden. The cursor may get re-shown by the OS, for example when the
+// window loses focus. Therefore, this procedure may return false even though you've hidden the
+// cursor previously. It should always reflect the true hide-state of the cursor.
+is_cursor_hidden :: proc() -> bool
 
 // Locks the mouse cursor within the window. While the cursor is locked, you should no longer use
 // get_mouse_position, as it may have weird/static values. Instead, use get_mouse_delta to fetch how

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -235,7 +235,7 @@ get_mouse_delta :: proc() -> Vec2
 
 // Hide or show the mouse cursor. The cursor may get shown again if the window loses focus.
 // Therefore, it's often best to use `is_cursor_hidden` to check the current status and use this
-// proc to hide the cursor as needed.
+// procedure to hide the cursor as needed.
 //
 // This call does not lock the cursor within the window, do that using a separate call to
 // `set_cursor_locked`.
@@ -260,8 +260,8 @@ is_cursor_hidden :: proc() -> bool
 set_cursor_locked :: proc(locked: bool)
 
 // Returns true if the mouse cursor is currently locked. Note that the mouse can get unlocked by the
-// OS, even though you previously called `lock_mouse`. Therefore, it's best to check the current
-// status using this procedure and then lock the mouse if needed.
+// OS, even though you previously called `set_cursor_locked(true)`. Therefore, it's best to check
+// the current status using this procedure and then lock the mouse if needed.
 is_cursor_locked :: proc() -> bool
 
 // Returns true if a gamepad with the supplied index is connected. The parameter should be a value

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -151,12 +151,6 @@ get_window_scale :: proc() -> f32
 // Use to change between windowed mode, resizable windowed mode and fullscreen
 set_window_mode :: proc(window_mode: Window_Mode)
 
-// Hide or show the mouse cursor. This is usually remembered if you unfocus and refocus the game.
-set_cursor_visible :: proc(visible: bool)
-
-// Returns true if the cursor is hidden.
-is_cursor_visible :: proc() -> bool
-
 // Flushes the current batch. This sends off everything to the GPU that has been queued in the
 // current batch. Normally, you do not need to do this manually. It is done automatically when these
 // procedures run:
@@ -239,26 +233,32 @@ get_mouse_position :: proc() -> Vec2
 // Returns how many pixels the mouse moved between the previous and the current frame.
 get_mouse_delta :: proc() -> Vec2
 
-// Locks the mouse cursor within the window. While the cursor is locked, you should no longer try to
-// use get_mouse_position, as it may have weird/static values. Instead, use get_mouse_delta to fetch
-// how much the mouse have been moved.
+// Hide or show the mouse cursor. This is usually remembered if you unfocus and refocus the game.
+//
+// This call does not lock the cursor within the window, do that using a separate call to
+// `set_cursor_locked`.
+set_cursor_visible :: proc(visible: bool)
+
+// Returns true if the cursor is hidden.
+is_cursor_visible :: proc() -> bool
+
+// Locks the mouse cursor within the window. While the cursor is locked, you should no longer use
+// get_mouse_position, as it may have weird/static values. Instead, use get_mouse_delta to fetch how
+// much the mouse have been moved.
 //
 // On some platforms the cursor is just stuck at a specific point. On other platforms it may be
 // teleported back to the center of the window on each frame.
 //
 // This call does not hide the cursor, do that separately using `set_cursor_visible`.
 //
-// If the window loses focus, then the mouse may get unlocked. You can query the current lock status
-// using `is_mouse_locked`, which should take into account if the OS has unlocked it for you.
-lock_mouse :: proc()
+// If the window loses focus, then the cursor may get unlocked. You can query the current lock
+// status using `is_cursor_locked`, which should take into account if the OS has unlocked it for you
+set_cursor_locked :: proc(locked: bool)
 
-// Unlock the mouse, so that it is free to move outside the window.
-unlock_mouse :: proc()
-
-// Returns true if the mouse is currently locked. Note that the mouse can get unlocked by the OS,
-// even though you called `lock_mouse` in the past. Therefore, it's best to check the current status
-// using this procedure and then lock the mouse if needed.
-is_mouse_locked :: proc() -> bool
+// Returns true if the mouse cursor is currently locked. Note that the mouse can get unlocked by the
+// OS, even though you previously called `lock_mouse`. Therefore, it's best to check the current
+// status using this procedure and then lock the mouse if needed.
+is_cursor_locked :: proc() -> bool
 
 // Returns true if a gamepad with the supplied index is connected. The parameter should be a value
 // between 0 and MAX_GAMEPADS.

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -329,6 +329,10 @@ process_events :: proc() {
 
 			s.mouse_delta = s.mouse_position - prev_pos
 
+		case Event_Mouse_Teleported:
+			s.mouse_position.x = e.position.x
+			s.mouse_position.y = e.position.y
+
 		case Event_Mouse_Wheel:
 			s.mouse_wheel_delta = e.delta
 
@@ -616,6 +620,10 @@ get_mouse_position :: proc() -> Vec2 {
 // Returns how many pixels the mouse moved between the previous and the current frame.
 get_mouse_delta :: proc() -> Vec2 {
 	return s.mouse_delta
+}
+
+set_mouse_captured :: proc(captured: bool) {
+	pf.set_mouse_captured(captured)
 }
 
 // Returns true if a gamepad with the supplied index is connected. The parameter should be a value
@@ -4892,6 +4900,7 @@ Event :: union {
 	Event_Mouse_Wheel,
 	Event_Mouse_Button_Went_Down,
 	Event_Mouse_Button_Went_Up,
+	Event_Mouse_Teleported,
 	Event_Gamepad_Button_Went_Down,
 	Event_Gamepad_Button_Went_Up,
 	Event_Screen_Resize,
@@ -4927,6 +4936,12 @@ Event_Gamepad_Button_Went_Up :: struct {
 }
 
 Event_Close_Window_Requested :: struct {}
+
+// Used by mouse capturing to inform us that the cursor was teleported. This is like a mouse move,
+// but will not be used for calculating mouse delta movement.
+Event_Mouse_Teleported :: struct {
+	position: Vec2,
+}
 
 Event_Mouse_Move :: struct {
 	position: Vec2,

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -462,6 +462,10 @@ set_cursor_visible :: proc(visible: bool) {
 	pf.set_cursor_visible(visible)
 }
 
+is_cursor_visible :: proc() -> bool {
+	return pf.is_cursor_visible()
+}
+
 // Flushes the current batch. This sends off everything to the GPU that has been queued in the
 // current batch. Normally, you do not need to do this manually. It is done automatically when these
 // procedures run:

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -622,8 +622,12 @@ get_mouse_delta :: proc() -> Vec2 {
 	return s.mouse_delta
 }
 
-set_mouse_captured :: proc(captured: bool) {
-	pf.set_mouse_captured(captured)
+lock_mouse :: proc() {
+	pf.lock_mouse()
+}
+
+unlock_mouse :: proc() {
+	pf.unlock_mouse()
 }
 
 // Returns true if a gamepad with the supplied index is connected. The parameter should be a value

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -619,7 +619,7 @@ get_mouse_delta :: proc() -> Vec2 {
 
 // Hide or show the mouse cursor. The cursor may get shown again if the window loses focus.
 // Therefore, it's often best to use `is_cursor_hidden` to check the current status and use this
-// proc to hide the cursor as needed.
+// procedure to hide the cursor as needed.
 //
 // This call does not lock the cursor within the window, do that using a separate call to
 // `set_cursor_locked`.
@@ -655,8 +655,8 @@ set_cursor_locked :: proc(locked: bool) {
 }
 
 // Returns true if the mouse cursor is currently locked. Note that the mouse can get unlocked by the
-// OS, even though you previously called `lock_mouse`. Therefore, it's best to check the current
-// status using this procedure and then lock the mouse if needed.
+// OS, even though you previously called `set_cursor_locked(true)`. Therefore, it's best to check
+// the current status using this procedure and then lock the mouse if needed.
 is_cursor_locked :: proc() -> bool {
 	return pf.is_cursor_locked()
 }

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -457,11 +457,12 @@ set_window_mode :: proc(window_mode: Window_Mode) {
 	pf.set_window_mode(window_mode)
 }
 
-// Hide or show the OS cursor.
+// Hide or show the mouse cursor. This is usually remembered if you unfocus and refocus the game.
 set_cursor_visible :: proc(visible: bool) {
 	pf.set_cursor_visible(visible)
 }
 
+// Returns true if the cursor is hidden.
 is_cursor_visible :: proc() -> bool {
 	return pf.is_cursor_visible()
 }
@@ -626,14 +627,29 @@ get_mouse_delta :: proc() -> Vec2 {
 	return s.mouse_delta
 }
 
+// Locks the mouse cursor within the window. While the cursor is locked, you should no longer try to
+// use get_mouse_position, as it may have weird/static values. Instead, use get_mouse_delta to fetch
+// how much the mouse have been moved.
+//
+// On some platforms the cursor is just stuck at a specific point. On other platforms it may be
+// teleported back to the center of the window on each frame.
+//
+// This call does not hide the cursor, do that separately using `set_cursor_visible`.
+//
+// If the window loses focus, then the mouse may get unlocked. You can query the current lock status
+// using `is_mouse_locked`, which should take into account if the OS has unlocked it for you.
 lock_mouse :: proc() {
 	pf.lock_mouse()
 }
 
+// Unlock the mouse, so that it is free to move outside the window.
 unlock_mouse :: proc() {
 	pf.unlock_mouse()
 }
 
+// Returns true if the mouse is currently locked. Note that the mouse can get unlocked by the OS,
+// even though you called `lock_mouse` in the past. Therefore, it's best to check the current status
+// using this procedure and then lock the mouse if needed.
 is_mouse_locked :: proc() -> bool {
 	return pf.is_mouse_locked()
 }

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -617,17 +617,21 @@ get_mouse_delta :: proc() -> Vec2 {
 	return s.mouse_delta
 }
 
-// Hide or show the mouse cursor. This is usually remembered if you unfocus and refocus the game.
+// Hide or show the mouse cursor. The cursor may get shown again if the window loses focus.
+// Therefore, it's often best to use `is_cursor_hidden` to check the current status and use this
+// proc to hide the cursor as needed.
 //
 // This call does not lock the cursor within the window, do that using a separate call to
 // `set_cursor_locked`.
-set_cursor_visible :: proc(visible: bool) {
-	pf.set_cursor_visible(visible)
+set_cursor_hidden :: proc(hidden: bool) {
+	pf.set_cursor_hidden(hidden)
 }
 
-// Returns true if the cursor is hidden.
-is_cursor_visible :: proc() -> bool {
-	return pf.is_cursor_visible()
+// Returns true if the cursor is hidden. The cursor may get re-shown by the OS, for example when the
+// window loses focus. Therefore, this procedure may return false even though you've hidden the
+// cursor previously. It should always reflect the true hide-state of the cursor.
+is_cursor_hidden :: proc() -> bool {
+	return pf.is_cursor_hidden()
 }
 
 // Locks the mouse cursor within the window. While the cursor is locked, you should no longer use

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -630,6 +630,10 @@ unlock_mouse :: proc() {
 	pf.unlock_mouse()
 }
 
+is_mouse_locked :: proc() -> bool {
+	return pf.is_mouse_locked()
+}
+
 // Returns true if a gamepad with the supplied index is connected. The parameter should be a value
 // between 0 and MAX_GAMEPADS.
 is_gamepad_active :: proc(gamepad: Gamepad_Index) -> bool {

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -457,16 +457,6 @@ set_window_mode :: proc(window_mode: Window_Mode) {
 	pf.set_window_mode(window_mode)
 }
 
-// Hide or show the mouse cursor. This is usually remembered if you unfocus and refocus the game.
-set_cursor_visible :: proc(visible: bool) {
-	pf.set_cursor_visible(visible)
-}
-
-// Returns true if the cursor is hidden.
-is_cursor_visible :: proc() -> bool {
-	return pf.is_cursor_visible()
-}
-
 // Flushes the current batch. This sends off everything to the GPU that has been queued in the
 // current batch. Normally, you do not need to do this manually. It is done automatically when these
 // procedures run:
@@ -627,31 +617,39 @@ get_mouse_delta :: proc() -> Vec2 {
 	return s.mouse_delta
 }
 
-// Locks the mouse cursor within the window. While the cursor is locked, you should no longer try to
-// use get_mouse_position, as it may have weird/static values. Instead, use get_mouse_delta to fetch
-// how much the mouse have been moved.
+// Hide or show the mouse cursor. This is usually remembered if you unfocus and refocus the game.
+//
+// This call does not lock the cursor within the window, do that using a separate call to
+// `set_cursor_locked`.
+set_cursor_visible :: proc(visible: bool) {
+	pf.set_cursor_visible(visible)
+}
+
+// Returns true if the cursor is hidden.
+is_cursor_visible :: proc() -> bool {
+	return pf.is_cursor_visible()
+}
+
+// Locks the mouse cursor within the window. While the cursor is locked, you should no longer use
+// get_mouse_position, as it may have weird/static values. Instead, use get_mouse_delta to fetch how
+// much the mouse have been moved.
 //
 // On some platforms the cursor is just stuck at a specific point. On other platforms it may be
 // teleported back to the center of the window on each frame.
 //
 // This call does not hide the cursor, do that separately using `set_cursor_visible`.
 //
-// If the window loses focus, then the mouse may get unlocked. You can query the current lock status
-// using `is_mouse_locked`, which should take into account if the OS has unlocked it for you.
-lock_mouse :: proc() {
-	pf.lock_mouse()
+// If the window loses focus, then the cursor may get unlocked. You can query the current lock
+// status using `is_cursor_locked`, which should take into account if the OS has unlocked it for you
+set_cursor_locked :: proc(locked: bool) {
+	pf.set_cursor_locked(locked)
 }
 
-// Unlock the mouse, so that it is free to move outside the window.
-unlock_mouse :: proc() {
-	pf.unlock_mouse()
-}
-
-// Returns true if the mouse is currently locked. Note that the mouse can get unlocked by the OS,
-// even though you called `lock_mouse` in the past. Therefore, it's best to check the current status
-// using this procedure and then lock the mouse if needed.
-is_mouse_locked :: proc() -> bool {
-	return pf.is_mouse_locked()
+// Returns true if the mouse cursor is currently locked. Note that the mouse can get unlocked by the
+// OS, even though you previously called `lock_mouse`. Therefore, it's best to check the current
+// status using this procedure and then lock the mouse if needed.
+is_cursor_locked :: proc() -> bool {
+	return pf.is_cursor_locked()
 }
 
 // Returns true if a gamepad with the supplied index is connected. The parameter should be a value

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -634,6 +634,11 @@ is_cursor_hidden :: proc() -> bool {
 	return pf.is_cursor_hidden()
 }
 
+@(deprecated="Use set_cursor_hidden")
+set_cursor_visible :: proc(visible: bool) {
+	pf.set_cursor_hidden(!visible)
+}
+
 // Locks the mouse cursor within the window. While the cursor is locked, you should no longer use
 // get_mouse_position, as it may have weird/static values. Instead, use get_mouse_delta to fetch how
 // much the mouse have been moved.

--- a/platform_bindings/linux/wayland/wayland_cursor.odin
+++ b/platform_bindings/linux/wayland/wayland_cursor.odin
@@ -1,0 +1,46 @@
+package wayland
+
+import "core:c"
+
+foreign import lib_cursor "system:wayland-cursor"
+
+// wl_shm — needed to load a cursor theme
+
+SHM :: struct {
+	using proxy: Proxy,
+}
+
+shm_interface := Interface {
+	"wl_shm",
+	2,
+	1,
+	raw_data([]Message{{"create_pool", "nhi", raw_data([]^Interface{nil, nil, nil})}}),
+	1,
+	raw_data([]Message{{"format", "u", raw_data([]^Interface{nil})}}),
+}
+
+// libwayland-cursor types and bindings
+
+Cursor_Image :: struct {
+	width:     u32,
+	height:    u32,
+	hotspot_x: u32,
+	hotspot_y: u32,
+	delay:     u32,
+}
+
+Cursor :: struct {
+	image_count: u32,
+	images:      [^]^Cursor_Image,
+	name:        cstring,
+}
+
+Cursor_Theme :: struct {}
+
+@(default_calling_convention = "c", link_prefix = "wl_")
+foreign lib_cursor {
+	cursor_theme_load    :: proc(name: cstring, size: c.int, shm: ^SHM) -> ^Cursor_Theme ---
+	cursor_theme_destroy :: proc(theme: ^Cursor_Theme) ---
+	cursor_theme_get_cursor :: proc(theme: ^Cursor_Theme, name: cstring) -> ^Cursor ---
+	cursor_image_get_buffer :: proc(image: ^Cursor_Image) -> ^Buffer ---
+}

--- a/platform_bindings/linux/wayland/wayland_pointer_constraints.odin
+++ b/platform_bindings/linux/wayland/wayland_pointer_constraints.odin
@@ -1,0 +1,139 @@
+package wayland
+
+ZWP_Pointer_Constraints_V1 :: struct {
+	using proxy: Proxy,
+}
+
+ZWP_Locked_Pointer_V1 :: struct {
+	using proxy: Proxy,
+}
+
+ZWP_Pointer_Constraints_V1_Lifetime :: enum u32 {
+	ONESHOT,
+	PERSISTENT,
+}
+
+ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_ONESHOT    :: ZWP_Pointer_Constraints_V1_Lifetime.ONESHOT
+ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT :: ZWP_Pointer_Constraints_V1_Lifetime.PERSISTENT
+
+ZWP_Locked_Pointer_V1_Listener :: struct {
+	locked: proc "c" (
+		data: rawptr,
+		locked_pointer: ^ZWP_Locked_Pointer_V1,
+	),
+	unlocked: proc "c" (
+		data: rawptr,
+		locked_pointer: ^ZWP_Locked_Pointer_V1,
+	),
+}
+
+zwp_pointer_constraints_v1_interface := Interface {
+	"zwp_pointer_constraints_v1",
+	1,
+	3,
+	raw_data([]Message {
+		{"destroy", "", raw_data([]^Interface{})},
+		{"lock_pointer", "noo?ou", raw_data([]^Interface {
+			&zwp_locked_pointer_v1_interface,
+			&surface_interface,
+			&pointer_interface,
+			nil,
+			nil,
+			nil,
+		})},
+		{"confine_pointer", "noo?ou", raw_data([]^Interface {
+			nil,
+			&surface_interface,
+			&pointer_interface,
+			nil,
+			nil,
+			nil,
+		})},
+	}),
+	0,
+	nil,
+}
+
+zwp_locked_pointer_v1_interface := Interface {
+	"zwp_locked_pointer_v1",
+	1,
+	3,
+	raw_data([]Message {
+		{"destroy", "", raw_data([]^Interface{})},
+		{"set_cursor_position_hint", "ff", raw_data([]^Interface {nil, nil})},
+		{"set_region", "?o", raw_data([]^Interface {nil})},
+	}),
+	2,
+	raw_data([]Message {
+		{"locked", "", raw_data([]^Interface{})},
+		{"unlocked", "", raw_data([]^Interface{})},
+	}),
+}
+
+zwp_pointer_constraints_v1_destroy :: proc(self: ^ZWP_Pointer_Constraints_V1) {
+	proxy_marshal_flags(
+		self,
+		0,
+		nil,
+		proxy_get_version(self),
+		MARSHAL_FLAG_DESTROY,
+	)
+}
+
+zwp_pointer_constraints_v1_lock_pointer :: proc(
+	self: ^ZWP_Pointer_Constraints_V1,
+	surface: ^Surface,
+	pointer: ^Pointer,
+	region: ^Proxy,
+	lifetime: ZWP_Pointer_Constraints_V1_Lifetime,
+) -> ^ZWP_Locked_Pointer_V1 {
+	return (^ZWP_Locked_Pointer_V1)(proxy_marshal_flags(
+		self,
+		1,
+		&zwp_locked_pointer_v1_interface,
+		proxy_get_version(self),
+		0,
+		nil,
+		surface,
+		pointer,
+		region,
+		u32(lifetime),
+	))
+}
+
+zwp_locked_pointer_v1_destroy :: proc(self: ^ZWP_Locked_Pointer_V1) {
+	proxy_marshal_flags(
+		self,
+		0,
+		nil,
+		proxy_get_version(self),
+		MARSHAL_FLAG_DESTROY,
+	)
+}
+
+zwp_locked_pointer_v1_set_cursor_position_hint :: proc(
+	self: ^ZWP_Locked_Pointer_V1,
+	surface_x: Fixed,
+	surface_y: Fixed,
+) {
+	proxy_marshal_flags(
+		self,
+		1,
+		nil,
+		proxy_get_version(self),
+		0,
+		surface_x,
+		surface_y,
+	)
+}
+
+zwp_locked_pointer_v1_set_region :: proc(self: ^ZWP_Locked_Pointer_V1, region: ^Proxy) {
+	proxy_marshal_flags(
+		self,
+		2,
+		nil,
+		proxy_get_version(self),
+		0,
+		region,
+	)
+}

--- a/platform_bindings/linux/wayland/wayland_protocol.odin
+++ b/platform_bindings/linux/wayland/wayland_protocol.odin
@@ -189,6 +189,19 @@ surface_destroy :: proc "c" (surface: ^Surface) {
 	)
 }
 
+surface_attach :: proc "c" (surface: ^Surface, buffer: ^Buffer, x: c.int32_t, y: c.int32_t) {
+	proxy_marshal_flags(
+		surface,
+		1,
+		nil,
+		proxy_get_version(surface),
+		0,
+		buffer,
+		x,
+		y,
+	)
+}
+
 surface_frame :: proc "c" (surface: ^Surface) -> ^Callback {
 	callback: ^Proxy
 	callback = proxy_marshal_flags(

--- a/platform_bindings/linux/wayland/wayland_relative_pointer.odin
+++ b/platform_bindings/linux/wayland/wayland_relative_pointer.odin
@@ -1,0 +1,82 @@
+package wayland
+
+ZWP_Relative_Pointer_Manager_V1 :: struct {
+	using proxy: Proxy,
+}
+
+ZWP_Relative_Pointer_V1 :: struct {
+	using proxy: Proxy,
+}
+
+ZWP_Relative_Pointer_V1_Listener :: struct {
+	relative_motion: proc "c" (
+		data: rawptr,
+		relative_pointer: ^ZWP_Relative_Pointer_V1,
+		utime_hi: u32,
+		utime_lo: u32,
+		dx: Fixed,
+		dy: Fixed,
+		dx_unaccel: Fixed,
+		dy_unaccel: Fixed,
+	),
+}
+
+zwp_relative_pointer_manager_v1_interface := Interface {
+	"zwp_relative_pointer_manager_v1",
+	1,
+	2,
+	raw_data([]Message {
+		{"destroy", "", raw_data([]^Interface{})},
+		{"get_relative_pointer", "no", raw_data([]^Interface {
+			&zwp_relative_pointer_v1_interface,
+			&pointer_interface,
+		})},
+	}),
+	0,
+	nil,
+}
+
+zwp_relative_pointer_v1_interface := Interface {
+	"zwp_relative_pointer_v1",
+	1,
+	1,
+	raw_data([]Message {
+		{"destroy", "", raw_data([]^Interface{})},
+	}),
+	1,
+	raw_data([]Message {
+		{"relative_motion", "uuffff", raw_data([]^Interface {
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+		})},
+	}),
+}
+
+zwp_relative_pointer_manager_v1_destroy :: proc(self: ^ZWP_Relative_Pointer_Manager_V1) {
+	proxy_marshal_flags(
+		self,
+		0,
+		nil,
+		proxy_get_version(self),
+		MARSHAL_FLAG_DESTROY,
+	)
+}
+
+zwp_relative_pointer_manager_v1_get_relative_pointer :: proc(
+	self: ^ZWP_Relative_Pointer_Manager_V1,
+	pointer: ^Pointer,
+) -> ^ZWP_Relative_Pointer_V1 {
+	return (^ZWP_Relative_Pointer_V1)(proxy_marshal_flags(
+		self,
+		1,
+		&zwp_relative_pointer_v1_interface,
+		proxy_get_version(self),
+		0,
+		nil,
+		pointer,
+	))
+}

--- a/platform_bindings/mac/cocoa_extras/cocoa_extras.odin
+++ b/platform_bindings/mac/cocoa_extras/cocoa_extras.odin
@@ -27,6 +27,14 @@ Event_pressedMouseButtons :: proc "c" () -> NS.UInteger {
 	return msgSend(NS.UInteger, NS.Event, "pressedMouseButtons")
 }
 
+Event_deltaX :: proc "c" (self: ^NS.Event) -> NS.Float {
+	return msgSend(NS.Float, self, "deltaX")
+}
+
+Event_deltaY :: proc "c" (self: ^NS.Event) -> NS.Float {
+	return msgSend(NS.Float, self, "deltaY")
+}
+
 // NSTrackingArea options (bit flags). See NSTrackingArea documentation for the full list.
 TRACKING_MOUSE_ENTERED_AND_EXITED :: NS.UInteger(0x01)
 TRACKING_CURSOR_UPDATE            :: NS.UInteger(0x04)
@@ -72,4 +80,5 @@ foreign import CoreGraphics "system:CoreGraphics.framework"
 @(default_calling_convention="c")
 foreign CoreGraphics {
 	CGWarpMouseCursorPosition :: proc(point: CGPoint) -> CGError ---
+	CGAssociateMouseAndMouseCursorPosition :: proc(connected: NS.BOOL) -> CGError ---
 }

--- a/platform_bindings/mac/cocoa_extras/cocoa_extras.odin
+++ b/platform_bindings/mac/cocoa_extras/cocoa_extras.odin
@@ -62,3 +62,14 @@ View_mouse_inRect :: proc "c" (self: ^NS.View, point: NS.Point, rect: NS.Rect) -
 Window_mouseLocationOutsideOfEventStream :: proc "c" (self: ^NS.Window) -> NS.Point {
 	return msgSend(NS.Point, self, "mouseLocationOutsideOfEventStream")
 }
+
+CGPoint :: [2]f64
+
+CGError :: distinct i32
+
+foreign import CoreGraphics "system:CoreGraphics.framework"
+
+@(default_calling_convention="c")
+foreign CoreGraphics {
+	CGWarpMouseCursorPosition :: proc(point: CGPoint) -> CGError ---
+}

--- a/platform_interface.odin
+++ b/platform_interface.odin
@@ -23,8 +23,8 @@ Platform_Interface :: struct #all_or_none {
 	get_screen_height: proc() -> int,
 	get_window_scale: proc() -> f32,
 	set_window_mode: proc(window_mode: Window_Mode),
-	set_cursor_visible: proc(visible: bool),
-	is_cursor_visible: proc() -> bool,
+	set_cursor_hidden: proc(hidden: bool),
+	is_cursor_hidden: proc() -> bool,
 	set_cursor_locked: proc(locked: bool),
 	is_cursor_locked: proc() -> bool,
 

--- a/platform_interface.odin
+++ b/platform_interface.odin
@@ -26,6 +26,7 @@ Platform_Interface :: struct #all_or_none {
 	set_cursor_visible: proc(visible: bool),
 	lock_mouse: proc(),
 	unlock_mouse: proc(),
+	is_mouse_locked: proc() -> bool,
 
 	is_gamepad_active: proc(gamepad: int) -> bool,
 	get_gamepad_axis: proc(gamepad: int, axis: Gamepad_Axis) -> f32,

--- a/platform_interface.odin
+++ b/platform_interface.odin
@@ -25,9 +25,8 @@ Platform_Interface :: struct #all_or_none {
 	set_window_mode: proc(window_mode: Window_Mode),
 	set_cursor_visible: proc(visible: bool),
 	is_cursor_visible: proc() -> bool,
-	lock_mouse: proc(),
-	unlock_mouse: proc(),
-	is_mouse_locked: proc() -> bool,
+	set_cursor_locked: proc(locked: bool),
+	is_cursor_locked: proc() -> bool,
 
 	is_gamepad_active: proc(gamepad: int) -> bool,
 	get_gamepad_axis: proc(gamepad: int, axis: Gamepad_Axis) -> f32,

--- a/platform_interface.odin
+++ b/platform_interface.odin
@@ -24,7 +24,8 @@ Platform_Interface :: struct #all_or_none {
 	get_window_scale: proc() -> f32,
 	set_window_mode: proc(window_mode: Window_Mode),
 	set_cursor_visible: proc(visible: bool),
-	set_mouse_captured: proc(captured: bool),
+	lock_mouse: proc(),
+	unlock_mouse: proc(),
 
 	is_gamepad_active: proc(gamepad: int) -> bool,
 	get_gamepad_axis: proc(gamepad: int, axis: Gamepad_Axis) -> f32,

--- a/platform_interface.odin
+++ b/platform_interface.odin
@@ -24,6 +24,7 @@ Platform_Interface :: struct #all_or_none {
 	get_window_scale: proc() -> f32,
 	set_window_mode: proc(window_mode: Window_Mode),
 	set_cursor_visible: proc(visible: bool),
+	is_cursor_visible: proc() -> bool,
 	lock_mouse: proc(),
 	unlock_mouse: proc(),
 	is_mouse_locked: proc() -> bool,

--- a/platform_interface.odin
+++ b/platform_interface.odin
@@ -24,6 +24,7 @@ Platform_Interface :: struct #all_or_none {
 	get_window_scale: proc() -> f32,
 	set_window_mode: proc(window_mode: Window_Mode),
 	set_cursor_visible: proc(visible: bool),
+	set_mouse_captured: proc(captured: bool),
 
 	is_gamepad_active: proc(gamepad: int) -> bool,
 	get_gamepad_axis: proc(gamepad: int, axis: Gamepad_Axis) -> f32,

--- a/platform_linux.odin
+++ b/platform_linux.odin
@@ -29,6 +29,7 @@ PLATFORM_LINUX :: Platform_Interface {
 	get_window_scale = linux_get_window_scale,
 	set_window_mode = linux_set_window_mode,
 	set_cursor_visible = linux_set_cursor_visible,
+	is_cursor_visible = linux_is_cursor_visible,
 	lock_mouse = linux_lock_mouse,
 	unlock_mouse = linux_unlock_mouse,
 	is_mouse_locked = linux_is_mouse_locked,
@@ -58,7 +59,7 @@ linux_init :: proc(
 	s.allocator = allocator
 	xdg_session_type := os.get_env("XDG_SESSION_TYPE", frame_allocator)
 	
-	if xdg_session_type == "wayland" {
+	if xdg_session_type == "waylanda" {
 		s.win = LINUX_WINDOW_WAYLAND
 	} else {
 		s.win = LINUX_WINDOW_X11
@@ -605,6 +606,10 @@ linux_set_cursor_visible :: proc(visible: bool) {
 	s.win.set_cursor_visible(visible)
 }
 
+linux_is_cursor_visible :: proc() -> bool {
+	return s.win.is_cursor_visible()
+}
+
 linux_lock_mouse :: proc() {
 	s.win.lock_mouse()
 }
@@ -650,6 +655,7 @@ Linux_Window_Interface :: struct #all_or_none {
 	get_window_scale: proc() -> f32,
 	set_window_mode: proc(window_mode: Window_Mode),
 	set_cursor_visible: proc(visible: bool),
+	is_cursor_visible: proc() -> bool,
 	lock_mouse: proc(),
 	unlock_mouse: proc(),
 	is_mouse_locked: proc() -> bool,

--- a/platform_linux.odin
+++ b/platform_linux.odin
@@ -58,7 +58,7 @@ linux_init :: proc(
 	s.allocator = allocator
 	xdg_session_type := os.get_env("XDG_SESSION_TYPE", frame_allocator)
 	
-	if xdg_session_type == "waylanda" {
+	if xdg_session_type == "wayland" {
 		s.win = LINUX_WINDOW_WAYLAND
 	} else {
 		s.win = LINUX_WINDOW_X11

--- a/platform_linux.odin
+++ b/platform_linux.odin
@@ -28,8 +28,8 @@ PLATFORM_LINUX :: Platform_Interface {
 	set_window_position = linux_set_window_position,
 	get_window_scale = linux_get_window_scale,
 	set_window_mode = linux_set_window_mode,
-	set_cursor_visible = linux_set_cursor_visible,
-	is_cursor_visible = linux_is_cursor_visible,
+	set_cursor_hidden = linux_set_cursor_hidden,
+	is_cursor_hidden = linux_is_cursor_hidden,
 	set_cursor_locked = linux_set_cursor_locked,
 	is_cursor_locked = linux_is_cursor_locked,
 	is_gamepad_active = linux_is_gamepad_active,
@@ -601,12 +601,12 @@ linux_set_window_mode :: proc(window_mode: Window_Mode) {
 	s.win.set_window_mode(window_mode)
 }
 
-linux_set_cursor_visible :: proc(visible: bool) {
-	s.win.set_cursor_visible(visible)
+linux_set_cursor_hidden :: proc(hidden: bool) {
+	s.win.set_cursor_hidden(hidden)
 }
 
-linux_is_cursor_visible :: proc() -> bool {
-	return s.win.is_cursor_visible()
+linux_is_cursor_hidden :: proc() -> bool {
+	return s.win.is_cursor_hidden()
 }
 
 linux_set_cursor_locked :: proc(locked: bool) {
@@ -649,8 +649,8 @@ Linux_Window_Interface :: struct #all_or_none {
 	get_screen_height: proc() -> int,
 	get_window_scale: proc() -> f32,
 	set_window_mode: proc(window_mode: Window_Mode),
-	set_cursor_visible: proc(visible: bool),
-	is_cursor_visible: proc() -> bool,
+	set_cursor_hidden: proc(hidden: bool),
+	is_cursor_hidden: proc() -> bool,
 	set_cursor_locked: proc(locked: bool),
 	is_cursor_locked: proc() -> bool,
 

--- a/platform_linux.odin
+++ b/platform_linux.odin
@@ -59,7 +59,7 @@ linux_init :: proc(
 	s.allocator = allocator
 	xdg_session_type := os.get_env("XDG_SESSION_TYPE", frame_allocator)
 	
-	if xdg_session_type == "waylanda" {
+	if xdg_session_type == "wayland" {
 		s.win = LINUX_WINDOW_WAYLAND
 	} else {
 		s.win = LINUX_WINDOW_X11

--- a/platform_linux.odin
+++ b/platform_linux.odin
@@ -30,9 +30,8 @@ PLATFORM_LINUX :: Platform_Interface {
 	set_window_mode = linux_set_window_mode,
 	set_cursor_visible = linux_set_cursor_visible,
 	is_cursor_visible = linux_is_cursor_visible,
-	lock_mouse = linux_lock_mouse,
-	unlock_mouse = linux_unlock_mouse,
-	is_mouse_locked = linux_is_mouse_locked,
+	set_cursor_locked = linux_set_cursor_locked,
+	is_cursor_locked = linux_is_cursor_locked,
 	is_gamepad_active = linux_is_gamepad_active,
 	get_gamepad_axis = linux_get_gamepad_axis,
 	set_gamepad_vibration = linux_set_gamepad_vibration,
@@ -59,7 +58,7 @@ linux_init :: proc(
 	s.allocator = allocator
 	xdg_session_type := os.get_env("XDG_SESSION_TYPE", frame_allocator)
 	
-	if xdg_session_type == "wayland" {
+	if xdg_session_type == "waylanda" {
 		s.win = LINUX_WINDOW_WAYLAND
 	} else {
 		s.win = LINUX_WINDOW_X11
@@ -610,16 +609,12 @@ linux_is_cursor_visible :: proc() -> bool {
 	return s.win.is_cursor_visible()
 }
 
-linux_lock_mouse :: proc() {
-	s.win.lock_mouse()
+linux_set_cursor_locked :: proc(locked: bool) {
+	s.win.set_cursor_locked(locked)
 }
 
-linux_unlock_mouse :: proc() {
-	s.win.unlock_mouse()
-}
-
-linux_is_mouse_locked :: proc() -> bool {
-	return s.win.is_mouse_locked(),
+linux_is_cursor_locked :: proc() -> bool {
+	return s.win.is_cursor_locked(),
 }
 
 Linux_State :: struct {
@@ -656,9 +651,8 @@ Linux_Window_Interface :: struct #all_or_none {
 	set_window_mode: proc(window_mode: Window_Mode),
 	set_cursor_visible: proc(visible: bool),
 	is_cursor_visible: proc() -> bool,
-	lock_mouse: proc(),
-	unlock_mouse: proc(),
-	is_mouse_locked: proc() -> bool,
+	set_cursor_locked: proc(locked: bool),
+	is_cursor_locked: proc() -> bool,
 
 	set_internal_state: proc(state: rawptr),
 }

--- a/platform_linux.odin
+++ b/platform_linux.odin
@@ -31,6 +31,7 @@ PLATFORM_LINUX :: Platform_Interface {
 	set_cursor_visible = linux_set_cursor_visible,
 	lock_mouse = linux_lock_mouse,
 	unlock_mouse = linux_unlock_mouse,
+	is_mouse_locked = linux_is_mouse_locked,
 	is_gamepad_active = linux_is_gamepad_active,
 	get_gamepad_axis = linux_get_gamepad_axis,
 	set_gamepad_vibration = linux_set_gamepad_vibration,
@@ -612,6 +613,10 @@ linux_unlock_mouse :: proc() {
 	s.win.unlock_mouse()
 }
 
+linux_is_mouse_locked :: proc() -> bool {
+	return s.win.is_mouse_locked(),
+}
+
 Linux_State :: struct {
 	win: Linux_Window_Interface,
 	win_state: rawptr,
@@ -647,6 +652,7 @@ Linux_Window_Interface :: struct #all_or_none {
 	set_cursor_visible: proc(visible: bool),
 	lock_mouse: proc(),
 	unlock_mouse: proc(),
+	is_mouse_locked: proc() -> bool,
 
 	set_internal_state: proc(state: rawptr),
 }

--- a/platform_linux.odin
+++ b/platform_linux.odin
@@ -614,7 +614,7 @@ linux_set_cursor_locked :: proc(locked: bool) {
 }
 
 linux_is_cursor_locked :: proc() -> bool {
-	return s.win.is_cursor_locked(),
+	return s.win.is_cursor_locked()
 }
 
 Linux_State :: struct {

--- a/platform_linux.odin
+++ b/platform_linux.odin
@@ -29,6 +29,8 @@ PLATFORM_LINUX :: Platform_Interface {
 	get_window_scale = linux_get_window_scale,
 	set_window_mode = linux_set_window_mode,
 	set_cursor_visible = linux_set_cursor_visible,
+	lock_mouse = linux_lock_mouse,
+	unlock_mouse = linux_unlock_mouse,
 	is_gamepad_active = linux_is_gamepad_active,
 	get_gamepad_axis = linux_get_gamepad_axis,
 	set_gamepad_vibration = linux_set_gamepad_vibration,
@@ -602,6 +604,14 @@ linux_set_cursor_visible :: proc(visible: bool) {
 	s.win.set_cursor_visible(visible)
 }
 
+linux_lock_mouse :: proc() {
+	s.win.lock_mouse()
+}
+
+linux_unlock_mouse :: proc() {
+	s.win.unlock_mouse()
+}
+
 Linux_State :: struct {
 	win: Linux_Window_Interface,
 	win_state: rawptr,
@@ -635,6 +645,8 @@ Linux_Window_Interface :: struct #all_or_none {
 	get_window_scale: proc() -> f32,
 	set_window_mode: proc(window_mode: Window_Mode),
 	set_cursor_visible: proc(visible: bool),
+	lock_mouse: proc(),
+	unlock_mouse: proc(),
 
 	set_internal_state: proc(state: rawptr),
 }

--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -92,6 +92,9 @@ wl_init :: proc(
 
 	wl.add_listener(s.relative_pointer, &relative_pointer_listener, nil)
 
+	s.cursor_surface = wl.compositor_create_surface(s.compositor)
+	s.cursor_theme = wl.cursor_theme_load(nil, 24, s.shm)
+
 	unscaled_width := screen_width
 	unscaled_height := screen_height
 
@@ -206,6 +209,15 @@ registry_listener := wl.Registry_Listener {
 				registry,
 				name,
 				&wl.zwp_pointer_constraints_v1_interface,
+				version,
+			)
+
+		case wl.shm_interface.name:
+			s.shm = wl.registry_bind(
+				wl.SHM,
+				registry,
+				name,
+				&wl.shm_interface,
 				version,
 			)
 		}
@@ -629,8 +641,33 @@ wl_unlock_mouse :: proc() {
 }
 
 apply_cursor_visible :: proc() {
-	if s.pointer != nil && !s.cursor_visible {
+	if s.pointer == nil {
+		return
+	}
+
+	if !s.cursor_visible {
 		wl.pointer_set_cursor(s.pointer, s.pointer_enter_serial, nil, 0, 0)
+	} else {
+		// Restore the default cursor. This would also happen if you leave and re-enter wind.
+		// This makes it happen instantly.
+		cursor_theme := wl.cursor_theme_load(nil, 24, s.shm)
+		cursor := wl.cursor_theme_get_cursor(cursor_theme, "left_ptr")
+
+		if cursor != nil && cursor.image_count > 0 {
+			image := cursor.images[0]
+			buf := wl.cursor_image_get_buffer(image)
+			
+			wl.pointer_set_cursor(
+				s.pointer,
+				s.pointer_enter_serial,
+				s.cursor_surface,
+				i32(image.hotspot_x),
+				i32(image.hotspot_y),
+			)
+
+			wl.surface_attach(s.cursor_surface, buf, 0, 0)
+			wl.surface_commit(s.cursor_surface)
+		}
 	}
 }
 
@@ -675,6 +712,9 @@ WL_State :: struct {
 	pointer: ^wl.Pointer,
 	pointer_enter_serial: u32,
 	cursor_visible: bool,
+	shm: ^wl.SHM,
+	cursor_surface: ^wl.Surface,
+	cursor_theme: ^wl.Cursor_Theme,
 
 	pointer_constraints: ^wl.ZWP_Pointer_Constraints_V1,
 	relative_pointer_manager: ^wl.ZWP_Relative_Pointer_Manager_V1,

--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -389,7 +389,7 @@ pointer_listener := wl.Pointer_Listener {
 	) {
 		context = s.odin_ctx
 		s.pointer_enter_serial = u32(serial)
-		apply_cursor_visiblity()
+		apply_cursor_visibility()
 	},
 	leave = proc "c" (
 		data: rawptr,
@@ -577,7 +577,7 @@ wl_set_window_mode :: proc(window_mode: Window_Mode) {
 
 wl_set_cursor_hidden :: proc(hidden: bool) {
 	s.cursor_hidden = hidden
-	apply_cursor_visiblity()
+	apply_cursor_visibility()
 }
 
 wl_is_cursor_hidden :: proc() -> bool {
@@ -654,7 +654,7 @@ wl_is_cursor_locked :: proc() -> bool {
 	return s.locked_pointer != nil
 }
 
-apply_cursor_visiblity :: proc() {
+apply_cursor_visibility :: proc() {
 	if s.pointer == nil {
 		return
 	}

--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -623,7 +623,7 @@ wl_lock_mouse :: proc() {
 
 wl_unlock_mouse :: proc() {
 	if s.locked_pointer != nil {
-		wl.destroy(s.locked_pointer)
+		wl.zwp_locked_pointer_v1_destroy(s.locked_pointer)
 		s.locked_pointer = nil
 	}
 }

--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -15,6 +15,7 @@ LINUX_WINDOW_WAYLAND :: Linux_Window_Interface {
 	get_window_scale = wl_get_window_scale,
 	set_window_mode = wl_set_window_mode,
 	set_cursor_visible = wl_set_cursor_visible,
+	is_cursor_visible = wl_is_cursor_visible,
 	lock_mouse = wl_lock_mouse,
 	unlock_mouse = wl_unlock_mouse,
 	is_mouse_locked = wl_is_mouse_locked,
@@ -579,6 +580,10 @@ wl_set_window_mode :: proc(window_mode: Window_Mode) {
 wl_set_cursor_visible :: proc(visible: bool) {
 	s.cursor_visible = visible
 	apply_cursor_visible()
+}
+
+wl_is_cursor_visible :: proc() -> bool {
+	return s.cursor_visible
 }
 
 locked_pointer_listener := wl.ZWP_Locked_Pointer_V1_Listener {

--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -17,6 +17,7 @@ LINUX_WINDOW_WAYLAND :: Linux_Window_Interface {
 	set_cursor_visible = wl_set_cursor_visible,
 	lock_mouse = wl_lock_mouse,
 	unlock_mouse = wl_unlock_mouse,
+	is_mouse_locked = wl_is_mouse_locked,
 	set_internal_state = wl_set_internal_state,
 }
 
@@ -84,6 +85,10 @@ wl_init :: proc(
 
 	fractional_scale := wl.wp_fractional_scale_manager_get_fractional_scale(s.fractional_scale_manager, s.surface)
 	wl.add_listener(fractional_scale, &fractional_scale_listener, nil)
+
+	wl.surface_commit(s.surface)
+	wl.display_dispatch_pending(s.display)
+	wl.display_roundtrip(s.display)
 
 	s.relative_pointer = wl.zwp_relative_pointer_manager_v1_get_relative_pointer(
 		s.relative_pointer_manager,
@@ -498,10 +503,8 @@ fractional_scale_listener := wl.WP_Fractional_Scale_V1_Listener {
 		context = s.odin_ctx
 		scl := f32(scale)/120
 		s.scale = scl
-
 		s.screen_width = int(f32(s.last_configure_width) * s.scale)
 		s.screen_height = int(f32(s.last_configure_height) * s.scale)
-
 		wl.egl_window_resize(s.window, i32(s.screen_width), i32(s.screen_height), 0, 0)
 
 		append(&s.events, Event_Window_Scale_Changed {
@@ -638,6 +641,10 @@ wl_unlock_mouse :: proc() {
 		wl.zwp_locked_pointer_v1_destroy(s.locked_pointer)
 		s.locked_pointer = nil
 	}
+}
+
+wl_is_mouse_locked :: proc() -> bool {
+	return s.locked_pointer != nil
 }
 
 apply_cursor_visible :: proc() {

--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -16,9 +16,8 @@ LINUX_WINDOW_WAYLAND :: Linux_Window_Interface {
 	set_window_mode = wl_set_window_mode,
 	set_cursor_visible = wl_set_cursor_visible,
 	is_cursor_visible = wl_is_cursor_visible,
-	lock_mouse = wl_lock_mouse,
-	unlock_mouse = wl_unlock_mouse,
-	is_mouse_locked = wl_is_mouse_locked,
+	set_cursor_locked = wl_set_cursor_locked,
+	is_cursor_locked = wl_is_cursor_locked,
 	set_internal_state = wl_set_internal_state,
 }
 
@@ -626,29 +625,32 @@ relative_pointer_listener := wl.ZWP_Relative_Pointer_V1_Listener {
 	},
 }
 
-wl_lock_mouse :: proc() {
-	if s.locked_pointer == nil {
+wl_set_cursor_locked :: proc(locked: bool) {
+	if locked {
+		if s.locked_pointer != nil {
+			return
+		}
+
 		s.locked_pointer = wl.zwp_pointer_constraints_v1_lock_pointer(
 			s.pointer_constraints, s.surface, s.pointer, nil,
 			wl.ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT,
 		)
 		wl.add_listener(s.locked_pointer, &locked_pointer_listener, nil)
-	}
 
-	// Synthetic teleport to center, so karl2d has the correct "previous position".
-	cx := f32(s.screen_width / 2)
-	cy := f32(s.screen_height / 2)
-	append(&s.events, Event_Mouse_Teleported { position = {cx, cy} })
-}
+		// Synthetic teleport to center, so karl2d has the correct "previous position".
+		cx := f32(s.screen_width / 2)
+		cy := f32(s.screen_height / 2)
+		append(&s.events, Event_Mouse_Teleported { position = {cx, cy} })
+	} else {
+		if s.locked_pointer == nil {
+			return
+		}
 
-wl_unlock_mouse :: proc() {
-	if s.locked_pointer != nil {
 		wl.zwp_locked_pointer_v1_destroy(s.locked_pointer)
 		s.locked_pointer = nil
 	}
 }
-
-wl_is_mouse_locked :: proc() -> bool {
+wl_is_cursor_locked :: proc() -> bool {
 	return s.locked_pointer != nil
 }
 

--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -14,8 +14,8 @@ LINUX_WINDOW_WAYLAND :: Linux_Window_Interface {
 	set_screen_size = wl_set_screen_size,
 	get_window_scale = wl_get_window_scale,
 	set_window_mode = wl_set_window_mode,
-	set_cursor_visible = wl_set_cursor_visible,
-	is_cursor_visible = wl_is_cursor_visible,
+	set_cursor_hidden = wl_set_cursor_hidden,
+	is_cursor_hidden = wl_is_cursor_hidden,
 	set_cursor_locked = wl_set_cursor_locked,
 	is_cursor_locked = wl_is_cursor_locked,
 	set_internal_state = wl_set_internal_state,
@@ -50,7 +50,6 @@ wl_init :: proc(
 	s = (^WL_State)(window_state)
 	s.allocator = allocator
 	s.scale = 1
-	s.cursor_visible = true
 	s.odin_ctx = context
 
 	s.display = wl.display_connect(nil)
@@ -390,7 +389,7 @@ pointer_listener := wl.Pointer_Listener {
 	) {
 		context = s.odin_ctx
 		s.pointer_enter_serial = u32(serial)
-		apply_cursor_visible()
+		apply_cursor_visiblity()
 	},
 	leave = proc "c" (
 		data: rawptr,
@@ -576,13 +575,13 @@ wl_set_window_mode :: proc(window_mode: Window_Mode) {
 	}
 }
 
-wl_set_cursor_visible :: proc(visible: bool) {
-	s.cursor_visible = visible
-	apply_cursor_visible()
+wl_set_cursor_hidden :: proc(hidden: bool) {
+	s.cursor_hidden = hidden
+	apply_cursor_visiblity()
 }
 
-wl_is_cursor_visible :: proc() -> bool {
-	return s.cursor_visible
+wl_is_cursor_hidden :: proc() -> bool {
+	return s.cursor_hidden
 }
 
 locked_pointer_listener := wl.ZWP_Locked_Pointer_V1_Listener {
@@ -650,16 +649,17 @@ wl_set_cursor_locked :: proc(locked: bool) {
 		s.locked_pointer = nil
 	}
 }
+
 wl_is_cursor_locked :: proc() -> bool {
 	return s.locked_pointer != nil
 }
 
-apply_cursor_visible :: proc() {
+apply_cursor_visiblity :: proc() {
 	if s.pointer == nil {
 		return
 	}
 
-	if !s.cursor_visible {
+	if s.cursor_hidden {
 		wl.pointer_set_cursor(s.pointer, s.pointer_enter_serial, nil, 0, 0)
 	} else {
 		// Restore the default cursor. This would also happen if you leave and re-enter wind.
@@ -724,7 +724,7 @@ WL_State :: struct {
 	keyboard: ^wl.Keyboard,
 	pointer: ^wl.Pointer,
 	pointer_enter_serial: u32,
-	cursor_visible: bool,
+	cursor_hidden: bool,
 	shm: ^wl.SHM,
 	cursor_surface: ^wl.Surface,
 	cursor_theme: ^wl.Cursor_Theme,

--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -15,6 +15,8 @@ LINUX_WINDOW_WAYLAND :: Linux_Window_Interface {
 	get_window_scale = wl_get_window_scale,
 	set_window_mode = wl_set_window_mode,
 	set_cursor_visible = wl_set_cursor_visible,
+	lock_mouse = wl_lock_mouse,
+	unlock_mouse = wl_unlock_mouse,
 	set_internal_state = wl_set_internal_state,
 }
 
@@ -82,6 +84,13 @@ wl_init :: proc(
 
 	fractional_scale := wl.wp_fractional_scale_manager_get_fractional_scale(s.fractional_scale_manager, s.surface)
 	wl.add_listener(fractional_scale, &fractional_scale_listener, nil)
+
+	s.relative_pointer = wl.zwp_relative_pointer_manager_v1_get_relative_pointer(
+		s.relative_pointer_manager,
+		s.pointer,
+	)
+
+	wl.add_listener(s.relative_pointer, &relative_pointer_listener, nil)
 
 	unscaled_width := screen_width
 	unscaled_height := screen_height
@@ -179,6 +188,24 @@ registry_listener := wl.Registry_Listener {
 				registry,
 				name,
 				&wl.wp_viewporter_interface,
+				version,
+			)
+
+		case wl.zwp_relative_pointer_manager_v1_interface.name:
+			s.relative_pointer_manager = wl.registry_bind(
+				wl.ZWP_Relative_Pointer_Manager_V1,
+				registry,
+				name,
+				&wl.zwp_relative_pointer_manager_v1_interface,
+				version,
+			)
+
+		case wl.zwp_pointer_constraints_v1_interface.name:
+			s.pointer_constraints = wl.registry_bind(
+				wl.ZWP_Pointer_Constraints_V1,
+				registry,
+				name,
+				&wl.zwp_pointer_constraints_v1_interface,
 				version,
 			)
 		}
@@ -539,6 +566,68 @@ wl_set_cursor_visible :: proc(visible: bool) {
 	apply_cursor_visible()
 }
 
+locked_pointer_listener := wl.ZWP_Locked_Pointer_V1_Listener {
+	locked = proc "c"(data: rawptr, lp: ^wl.ZWP_Locked_Pointer_V1) {
+		context = s.odin_ctx
+		s.locked_pointer = lp
+		cx := f32(s.screen_width / 2)
+		cy := f32(s.screen_height / 2)
+		append(&s.events, Event_Mouse_Teleported { position = {cx, cy} })
+	},
+	unlocked = proc "c"(data: rawptr, lp: ^wl.ZWP_Locked_Pointer_V1) {
+		context = s.odin_ctx
+		s.locked_pointer = nil
+	},
+}
+
+
+relative_pointer_listener := wl.ZWP_Relative_Pointer_V1_Listener {
+	relative_motion = proc "c" (
+		data: rawptr,
+		rp: ^wl.ZWP_Relative_Pointer_V1,
+		t_hi, t_lo: c.uint32_t,
+		dx, dy, dx_unaccel, dy_unaccel: wl.Fixed,
+	) {
+		// Only used when pointer is locked
+		if s.locked_pointer == nil {
+			return
+		}
+		context = s.odin_ctx
+		cx := f32(s.screen_width / 2)
+		cy := f32(s.screen_height / 2)
+		fdx := f32(dx_unaccel >> 8)
+		fdy := f32(dy_unaccel >> 8)
+		// Move relative to center, matching the warp-based platforms
+		append(&s.events, Event_Mouse_Move {
+			position = {cx + fdx, cy + fdy},
+		})
+		// Teleport back so next delta is also relative to center
+		append(&s.events, Event_Mouse_Teleported { position = {cx, cy} })
+	},
+}
+
+wl_lock_mouse :: proc() {
+	if s.locked_pointer == nil {
+		s.locked_pointer = wl.zwp_pointer_constraints_v1_lock_pointer(
+			s.pointer_constraints, s.surface, s.pointer, nil,
+			wl.ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT,
+		)
+		wl.add_listener(s.locked_pointer, &locked_pointer_listener, nil)
+	}
+
+	// Synthetic teleport to center, so karl2d has the correct "previous position".
+	cx := f32(s.screen_width / 2)
+	cy := f32(s.screen_height / 2)
+	append(&s.events, Event_Mouse_Teleported { position = {cx, cy} })
+}
+
+wl_unlock_mouse :: proc() {
+	if s.locked_pointer != nil {
+		wl.destroy(s.locked_pointer)
+		s.locked_pointer = nil
+	}
+}
+
 apply_cursor_visible :: proc() {
 	if s.pointer != nil && !s.cursor_visible {
 		wl.pointer_set_cursor(s.pointer, s.pointer_enter_serial, nil, 0, 0)
@@ -586,6 +675,11 @@ WL_State :: struct {
 	pointer: ^wl.Pointer,
 	pointer_enter_serial: u32,
 	cursor_visible: bool,
+
+	pointer_constraints: ^wl.ZWP_Pointer_Constraints_V1,
+	relative_pointer_manager: ^wl.ZWP_Relative_Pointer_Manager_V1,
+	locked_pointer: ^wl.ZWP_Locked_Pointer_V1,
+	relative_pointer: ^wl.ZWP_Relative_Pointer_V1,
 
 	// True if toplevel_listener.configure has run
 	configured: bool,

--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -664,8 +664,7 @@ apply_cursor_visible :: proc() {
 	} else {
 		// Restore the default cursor. This would also happen if you leave and re-enter wind.
 		// This makes it happen instantly.
-		cursor_theme := wl.cursor_theme_load(nil, 24, s.shm)
-		cursor := wl.cursor_theme_get_cursor(cursor_theme, "left_ptr")
+		cursor := wl.cursor_theme_get_cursor(s.cursor_theme, "left_ptr")
 
 		if cursor != nil && cursor.image_count > 0 {
 			image := cursor.images[0]

--- a/platform_linux_window_x11.odin
+++ b/platform_linux_window_x11.odin
@@ -19,6 +19,7 @@ LINUX_WINDOW_X11 :: Linux_Window_Interface {
 	set_cursor_visible = x11_set_cursor_visible,
 	lock_mouse = x11_lock_mouse,
 	unlock_mouse = x11_unlock_mouse,
+	is_mouse_locked = x11_is_mouse_locked,
 	set_internal_state = x11_set_internal_state,
 }
 
@@ -340,7 +341,11 @@ x11_lock_mouse :: proc() {
 }
 
 x11_unlock_mouse :: proc() {
-	
+
+}
+
+x11_is_mouse_locked :: proc() -> bool {
+	return false
 }
 
 x11_set_internal_state :: proc(state: rawptr) {

--- a/platform_linux_window_x11.odin
+++ b/platform_linux_window_x11.odin
@@ -17,6 +17,7 @@ LINUX_WINDOW_X11 :: Linux_Window_Interface {
 	get_window_scale = x11_get_window_scale,
 	set_window_mode = x11_set_window_mode,
 	set_cursor_visible = x11_set_cursor_visible,
+	is_cursor_visible = x11_is_cursor_visible,
 	lock_mouse = x11_lock_mouse,
 	unlock_mouse = x11_unlock_mouse,
 	is_mouse_locked = x11_is_mouse_locked,
@@ -37,16 +38,16 @@ x11_state_size :: proc() -> int {
 
 x11_init :: proc(
 	window_state: rawptr,
-	window_width: int,
-	window_height: int,
+	screen_width: int,
+	screen_height: int,
 	window_title: string,
 	init_options: Init_Options,
 	allocator: runtime.Allocator,
 ) {
 	s = (^X11_State)(window_state)
 	s.allocator = allocator
-	s.windowed_width = window_width
-	s.windowed_height = window_height
+	s.screen_width = screen_width
+	s.screen_height = screen_height
 	s.display = X.OpenDisplay(nil)
 	s.events = make([dynamic]Event, allocator)
 
@@ -54,7 +55,7 @@ x11_init :: proc(
 		s.display,
 		X.DefaultRootWindow(s.display),
 		0, 0,
-		u32(window_width), u32(window_height),
+		u32(screen_width), u32(screen_height),
 		0,
 		0,
 		0,
@@ -186,8 +187,8 @@ x11_get_events :: proc(events: ^[dynamic]Event) {
 
 		case .MotionNotify:
 			if s.mouse_locked {
-				cx := i32(s.width / 2)
-				cy := i32(s.height / 2)
+				cx := i32(s.screen_width / 2)
+				cy := i32(s.screen_height / 2)
 
 				if event.xmotion.x != cx || event.xmotion.y != cy {
 					append(events, Event_Mouse_Move {
@@ -205,14 +206,17 @@ x11_get_events :: proc(events: ^[dynamic]Event) {
 			w := int(event.xconfigure.width)
 			h := int(event.xconfigure.height)
 
-			if w != s.width || h != s.height {
-				s.width = w
-				s.height = h
+			if w != s.last_configure_width || h != s.last_configure_height {
+				s.last_configure_width = w
+				s.last_configure_width = h
 
 				if s.window_mode == .Windowed || s.window_mode == .Windowed_Resizable {
-					s.windowed_width = w
-					s.windowed_height = h
+					s.last_configure_windowed_width = w
+					s.last_configure_windowed_height = h
 				}
+
+				s.screen_width = w
+				s.screen_height = h
 
 				append(events, Event_Screen_Resize {
 					width = w,
@@ -234,11 +238,11 @@ x11_get_events :: proc(events: ^[dynamic]Event) {
 }
 
 x11_get_screen_width :: proc() -> int {
-	return s.width
+	return s.screen_width
 }
 
 x11_get_screen_height :: proc() -> int {
-	return s.height
+	return s.screen_height
 }
 
 x11_set_position :: proc(x: int, y: int) {
@@ -279,9 +283,14 @@ enter_borderless_fullscreen :: proc() {
 }
 
 leave_borderless_fullscreen :: proc() {
-	X.ResizeWindow(s.display, s.window, u32(s.windowed_width), u32(s.windowed_height))
-	s.width = s.windowed_width
-	s.height = s.windowed_height
+	X.ResizeWindow(
+		s.display,
+		s.window,
+		u32(s.last_configure_windowed_width),
+		u32(s.last_configure_windowed_height),
+	)
+	s.screen_width = s.last_configure_windowed_width
+	s.screen_height = s.last_configure_windowed_height
 
 	wm_state := X.InternAtom(s.display, "_NET_WM_STATE", true)
 	wm_fullscreen := X.InternAtom(s.display, "_NET_WM_STATE_FULLSCREEN", true)
@@ -323,10 +332,10 @@ x11_set_window_mode :: proc(window_mode: Window_Mode) {
 
 		hints := X.XSizeHints {
 			flags = { .PMinSize, .PMaxSize },
-			min_width = i32(s.width),
-			max_width = i32(s.width),
-			min_height = i32(s.height),
-			max_height = i32(s.height),
+			min_width = i32(s.screen_width),
+			max_width = i32(s.screen_width),
+			min_height = i32(s.screen_height),
+			max_height = i32(s.screen_height),
 		}
 
 		X.SetWMNormalHints(s.display, s.window, &hints)
@@ -347,12 +356,18 @@ x11_set_window_mode :: proc(window_mode: Window_Mode) {
 }
 
 x11_set_cursor_visible :: proc(visible: bool) {
+	s.cursor_visible = visible
+
 	if visible {
 		X.UndefineCursor(s.display, s.window)
 	} else {
 		X.DefineCursor(s.display, s.window, s.blank_cursor)
 	}
 	X.Flush(s.display)
+}
+
+x11_is_cursor_visible :: proc() -> bool {
+	return s.cursor_visible	
 }
 
 x11_lock_mouse :: proc() {
@@ -391,8 +406,8 @@ x11_is_mouse_locked :: proc() -> bool {
 }
 
 _x11_teleport_cursor_to_center :: proc() {
-	cx := s.width / 2
-	cy := s.height / 2
+	cx := s.screen_width / 2
+	cy := s.screen_height / 2
 	X.WarpPointer(s.display, 0, s.window, 0, 0, 0, 0, i32(cx), i32(cy))
 	X.Flush(s.display)
 	append(&s.events, Event_Mouse_Teleported {
@@ -407,16 +422,22 @@ x11_set_internal_state :: proc(state: rawptr) {
 
 X11_State :: struct {
 	allocator: runtime.Allocator,
-	width: int,
-	height: int,
-	windowed_width: int,
-	windowed_height: int,
+	
+	screen_width: int,
+	screen_height: int,
+	
+	last_configure_width: int,
+	last_configure_height: int,
+	last_configure_windowed_width: int,
+	last_configure_windowed_height: int,
+	
 	display: ^X.Display,
 	window: X.Window,
 	delete_msg: X.Atom,
 	window_mode: Window_Mode,
 	window_render_glue: Window_Render_Glue,
 	blank_cursor: X.Cursor,
+	cursor_visible: bool,
 	mouse_locked: bool,
 	events: [dynamic]Event,
 }

--- a/platform_linux_window_x11.odin
+++ b/platform_linux_window_x11.odin
@@ -48,6 +48,7 @@ x11_init :: proc(
 	s.windowed_width = window_width
 	s.windowed_height = window_height
 	s.display = X.OpenDisplay(nil)
+	s.events = make([dynamic]Event, allocator)
 
 	s.window = X.CreateSimpleWindow(
 		s.display,
@@ -110,6 +111,7 @@ x11_init :: proc(
 }
 
 x11_shutdown :: proc() {
+	delete(s.events)
 	X.FreeCursor(s.display, s.blank_cursor)
 	X.DestroyWindow(s.display, s.window)
 }
@@ -183,9 +185,21 @@ x11_get_events :: proc(events: ^[dynamic]Event) {
 			}
 
 		case .MotionNotify:
-			append(events, Event_Mouse_Move {
-				position = { f32(event.xmotion.x), f32(event.xmotion.y) }, 
-			})
+			if s.mouse_locked {
+				cx := i32(s.width / 2)
+				cy := i32(s.height / 2)
+
+				if event.xmotion.x != cx || event.xmotion.y != cy {
+					append(events, Event_Mouse_Move {
+						position = {f32(event.xmotion.x), f32(event.xmotion.y)},
+					})
+					_x11_teleport_cursor_to_center()
+				}
+			} else {
+				append(events, Event_Mouse_Move {
+					position = {f32(event.xmotion.x), f32(event.xmotion.y)},
+				})
+			}
 
 		case .ConfigureNotify:
 			w := int(event.xconfigure.width)
@@ -209,9 +223,14 @@ x11_get_events :: proc(events: ^[dynamic]Event) {
 			append(events, Event_Window_Focused{})
 
 		case .FocusOut:
+			// X11 unlocks the cursor if program loses focus
+			s.mouse_locked = false
 			append(events, Event_Window_Unfocused{})
 		}
 	}
+
+	append(events, ..s.events[:])
+	runtime.clear(&s.events)
 }
 
 x11_get_screen_width :: proc() -> int {
@@ -337,15 +356,48 @@ x11_set_cursor_visible :: proc(visible: bool) {
 }
 
 x11_lock_mouse :: proc() {
+	if s.mouse_locked {
+		return
+	}
+	s.mouse_locked = true
 
+	// Confine pointer to window (equivalent of Windows' ClipCursor)
+	X.GrabPointer(
+		s.display,
+		s.window,
+		false, // owner_events
+		{.PointerMotion, .ButtonPress, .ButtonRelease},
+		.GrabModeAsync,
+		.GrabModeAsync,
+		s.window, // confine_to: restrict to this window
+		0, // cursor: 0 = keep current
+		X.CurrentTime,
+	)
+
+	_x11_teleport_cursor_to_center()
 }
 
 x11_unlock_mouse :: proc() {
-
+	if !s.mouse_locked {
+		return
+	}
+	s.mouse_locked = false
+	X.UngrabPointer(s.display, X.CurrentTime)
+	X.Flush(s.display)
 }
 
 x11_is_mouse_locked :: proc() -> bool {
-	return false
+	return s.mouse_locked
+}
+
+_x11_teleport_cursor_to_center :: proc() {
+	cx := s.width / 2
+	cy := s.height / 2
+	X.WarpPointer(s.display, 0, s.window, 0, 0, 0, 0, i32(cx), i32(cy))
+	X.Flush(s.display)
+	append(&s.events, Event_Mouse_Teleported {
+		position = {f32(cx), f32(cy)},
+	})
 }
 
 x11_set_internal_state :: proc(state: rawptr) {
@@ -365,6 +417,8 @@ X11_State :: struct {
 	window_mode: Window_Mode,
 	window_render_glue: Window_Render_Glue,
 	blank_cursor: X.Cursor,
+	mouse_locked: bool,
+	events: [dynamic]Event,
 }
 
 s: ^X11_State

--- a/platform_linux_window_x11.odin
+++ b/platform_linux_window_x11.odin
@@ -207,7 +207,7 @@ x11_get_events :: proc(events: ^[dynamic]Event) {
 
 			if w != s.last_configure_width || h != s.last_configure_height {
 				s.last_configure_width = w
-				s.last_configure_width = h
+				s.last_configure_height = h
 
 				if s.window_mode == .Windowed || s.window_mode == .Windowed_Resizable {
 					s.last_configure_windowed_width = w

--- a/platform_linux_window_x11.odin
+++ b/platform_linux_window_x11.odin
@@ -17,6 +17,8 @@ LINUX_WINDOW_X11 :: Linux_Window_Interface {
 	get_window_scale = x11_get_window_scale,
 	set_window_mode = x11_set_window_mode,
 	set_cursor_visible = x11_set_cursor_visible,
+	lock_mouse = x11_lock_mouse,
+	unlock_mouse = x11_unlock_mouse,
 	set_internal_state = x11_set_internal_state,
 }
 
@@ -331,6 +333,14 @@ x11_set_cursor_visible :: proc(visible: bool) {
 		X.DefineCursor(s.display, s.window, s.blank_cursor)
 	}
 	X.Flush(s.display)
+}
+
+x11_lock_mouse :: proc() {
+
+}
+
+x11_unlock_mouse :: proc() {
+	
 }
 
 x11_set_internal_state :: proc(state: rawptr) {

--- a/platform_linux_window_x11.odin
+++ b/platform_linux_window_x11.odin
@@ -18,9 +18,8 @@ LINUX_WINDOW_X11 :: Linux_Window_Interface {
 	set_window_mode = x11_set_window_mode,
 	set_cursor_visible = x11_set_cursor_visible,
 	is_cursor_visible = x11_is_cursor_visible,
-	lock_mouse = x11_lock_mouse,
-	unlock_mouse = x11_unlock_mouse,
-	is_mouse_locked = x11_is_mouse_locked,
+	set_cursor_locked = x11_set_cursor_locked,
+	is_cursor_locked = x11_is_cursor_locked,
 	set_internal_state = x11_set_internal_state,
 }
 
@@ -186,7 +185,7 @@ x11_get_events :: proc(events: ^[dynamic]Event) {
 			}
 
 		case .MotionNotify:
-			if s.mouse_locked {
+			if s.cursor_locked {
 				cx := i32(s.screen_width / 2)
 				cy := i32(s.screen_height / 2)
 
@@ -228,7 +227,7 @@ x11_get_events :: proc(events: ^[dynamic]Event) {
 
 		case .FocusOut:
 			// X11 unlocks the cursor if program loses focus
-			s.mouse_locked = false
+			s.cursor_locked = false
 			append(events, Event_Window_Unfocused{})
 		}
 	}
@@ -370,39 +369,32 @@ x11_is_cursor_visible :: proc() -> bool {
 	return s.cursor_visible	
 }
 
-x11_lock_mouse :: proc() {
-	if s.mouse_locked {
-		return
+x11_set_cursor_locked :: proc(locked: bool) {
+	s.cursor_locked = locked
+
+	if locked {
+		// Confine pointer to window (equivalent of Windows' ClipCursor)
+		X.GrabPointer(
+			s.display,
+			s.window,
+			false, // owner_events
+			{.PointerMotion, .ButtonPress, .ButtonRelease},
+			.GrabModeAsync,
+			.GrabModeAsync,
+			s.window, // confine_to: restrict to this window
+			0, // cursor: 0 = keep current
+			X.CurrentTime,
+		)
+
+		_x11_teleport_cursor_to_center()
+	} else {
+		X.UngrabPointer(s.display, X.CurrentTime)
+		X.Flush(s.display)
 	}
-	s.mouse_locked = true
-
-	// Confine pointer to window (equivalent of Windows' ClipCursor)
-	X.GrabPointer(
-		s.display,
-		s.window,
-		false, // owner_events
-		{.PointerMotion, .ButtonPress, .ButtonRelease},
-		.GrabModeAsync,
-		.GrabModeAsync,
-		s.window, // confine_to: restrict to this window
-		0, // cursor: 0 = keep current
-		X.CurrentTime,
-	)
-
-	_x11_teleport_cursor_to_center()
 }
 
-x11_unlock_mouse :: proc() {
-	if !s.mouse_locked {
-		return
-	}
-	s.mouse_locked = false
-	X.UngrabPointer(s.display, X.CurrentTime)
-	X.Flush(s.display)
-}
-
-x11_is_mouse_locked :: proc() -> bool {
-	return s.mouse_locked
+x11_is_cursor_locked :: proc() -> bool {
+	return s.cursor_locked
 }
 
 _x11_teleport_cursor_to_center :: proc() {
@@ -438,7 +430,7 @@ X11_State :: struct {
 	window_render_glue: Window_Render_Glue,
 	blank_cursor: X.Cursor,
 	cursor_visible: bool,
-	mouse_locked: bool,
+	cursor_locked: bool,
 	events: [dynamic]Event,
 }
 

--- a/platform_linux_window_x11.odin
+++ b/platform_linux_window_x11.odin
@@ -16,8 +16,8 @@ LINUX_WINDOW_X11 :: Linux_Window_Interface {
 	set_screen_size = x11_set_screen_size,
 	get_window_scale = x11_get_window_scale,
 	set_window_mode = x11_set_window_mode,
-	set_cursor_visible = x11_set_cursor_visible,
-	is_cursor_visible = x11_is_cursor_visible,
+	set_cursor_hidden = x11_set_cursor_hidden,
+	is_cursor_hidden = x11_is_cursor_hidden,
 	set_cursor_locked = x11_set_cursor_locked,
 	is_cursor_locked = x11_is_cursor_locked,
 	set_internal_state = x11_set_internal_state,
@@ -354,19 +354,19 @@ x11_set_window_mode :: proc(window_mode: Window_Mode) {
 	}
 }
 
-x11_set_cursor_visible :: proc(visible: bool) {
-	s.cursor_visible = visible
+x11_set_cursor_hidden :: proc(hidden: bool) {
+	s.cursor_hidden = hidden
 
-	if visible {
-		X.UndefineCursor(s.display, s.window)
-	} else {
+	if hidden {
 		X.DefineCursor(s.display, s.window, s.blank_cursor)
+	} else {
+		X.UndefineCursor(s.display, s.window)
 	}
 	X.Flush(s.display)
 }
 
-x11_is_cursor_visible :: proc() -> bool {
-	return s.cursor_visible	
+x11_is_cursor_hidden :: proc() -> bool {
+	return s.cursor_hidden	
 }
 
 x11_set_cursor_locked :: proc(locked: bool) {
@@ -429,7 +429,7 @@ X11_State :: struct {
 	window_mode: Window_Mode,
 	window_render_glue: Window_Render_Glue,
 	blank_cursor: X.Cursor,
-	cursor_visible: bool,
+	cursor_hidden: bool,
 	cursor_locked: bool,
 	events: [dynamic]Event,
 }

--- a/platform_mac.odin
+++ b/platform_mac.odin
@@ -53,7 +53,8 @@ Mac_State :: struct {
 	cursor_hidden_by_us: bool,
 	cursor_tracker:      NS.id,
 
-	mouse_captured:      bool,
+	mouse_captured: bool,
+	mouse_ignore_next_move: bool,
 
 	screen_width:     int,
 	screen_height:    int,
@@ -329,6 +330,11 @@ mac_get_events :: proc(events: ^[dynamic]Event) {
 			append(&s.events, Event_Mouse_Button_Went_Up{button = .Middle})
 
 		case .MouseMoved, .LeftMouseDragged, .RightMouseDragged, .OtherMouseDragged:
+			if s.mouse_ignore_next_move {
+				s.mouse_ignore_next_move = false
+				break
+			}
+
 			event_window := event->window()
 
 			// event_window is nil when the cursor is outside all windows —
@@ -438,6 +444,7 @@ mac_set_mouse_captured :: proc(captured: bool) {
 	s.mouse_captured = captured
 
 	if captured {
+		s.mouse_ignore_next_move = true
 		ce.CGAssociateMouseAndMouseCursorPosition(false)
 		_mac_teleport_cursor_to_center()
 	} else {
@@ -451,7 +458,7 @@ _mac_teleport_cursor_to_center :: proc() {
 	scale := mac_get_window_scale()
 	frame := s.window->frame()
 	x := f64(frame.origin.x) + f64(cx)/f64(scale)
-	y := f64(frame.origin.y) + f64(cy)/f64(scale)
+	y := f64(frame.origin.y) + f64(s.screen_height)/f64(scale) - f64(cy)/f64(scale)
 	ce.CGWarpMouseCursorPosition({x, y})
 
 	append(&s.events, Event_Mouse_Teleported {

--- a/platform_mac.odin
+++ b/platform_mac.odin
@@ -348,10 +348,15 @@ mac_get_events :: proc(events: ^[dynamic]Event) {
 			px := loc.x * scale
 			py := NS.Float(s.screen_height) - loc.y * scale
 			
-			append(&s.events, Event_Mouse_Move { position = { f32(px), f32(py) }})
-			
 			if s.mouse_captured {
-				_mac_teleport_cursor_to_center()
+				dx := f32(ce.Event_deltaX(event)) * f32(s.window->backingScaleFactor())
+				dy := f32(ce.Event_deltaY(event)) * f32(s.window->backingScaleFactor())
+				cx := f32(s.screen_width/2)
+				cy := f32(s.screen_height/2)
+				append(&s.events, Event_Mouse_Move { position = { cx + dx, cy + dy}})
+				append(&s.events, Event_Mouse_Teleported { position = { cx, cy }})
+			} else {
+				append(&s.events, Event_Mouse_Move { position = { f32(px), f32(py) }})
 			}
 
 		case .ScrollWheel:
@@ -433,7 +438,10 @@ mac_set_mouse_captured :: proc(captured: bool) {
 	s.mouse_captured = captured
 
 	if captured {
+		ce.CGAssociateMouseAndMouseCursorPosition(false)
 		_mac_teleport_cursor_to_center()
+	} else {
+		ce.CGAssociateMouseAndMouseCursorPosition(true)
 	}
 }
 

--- a/platform_mac.odin
+++ b/platform_mac.odin
@@ -471,7 +471,7 @@ _mac_teleport_cursor_to_center :: proc() {
 	ce.CGWarpMouseCursorPosition({x, y})
 
 	append(&s.events, Event_Mouse_Teleported {
-		position = {f32(cx), f32(cy)}
+		position = {f32(cx), f32(cy)},
 	})
 }
 

--- a/platform_mac.odin
+++ b/platform_mac.odin
@@ -27,6 +27,7 @@ PLATFORM_MAC :: Platform_Interface {
 	get_window_scale = mac_get_window_scale,
 	set_window_mode = mac_set_window_mode,
 	set_cursor_visible = mac_set_cursor_visible,
+	set_mouse_captured = mac_set_mouse_captured,
 
 	is_gamepad_active = mac_is_gamepad_active,
 	get_gamepad_axis = mac_get_gamepad_axis,
@@ -51,6 +52,8 @@ Mac_State :: struct {
 	cursor_visible:      bool,
 	cursor_hidden_by_us: bool,
 	cursor_tracker:      NS.id,
+
+	mouse_captured:      bool,
 
 	screen_width:     int,
 	screen_height:    int,
@@ -345,9 +348,11 @@ mac_get_events :: proc(events: ^[dynamic]Event) {
 			px := loc.x * scale
 			py := NS.Float(s.screen_height) - loc.y * scale
 			
-			append(&s.events, Event_Mouse_Move{
-				position = {f32(px), f32(py)},
-			})
+			append(&s.events, Event_Mouse_Move { position = { f32(px), f32(py) }})
+			
+			if s.mouse_captured {
+				_mac_teleport_cursor_to_center()
+			}
 
 		case .ScrollWheel:
 			delta := event->scrollingDeltaY()
@@ -422,6 +427,28 @@ mac_get_window_scale :: proc() -> f32 {
 mac_set_cursor_visible :: proc(visible: bool) {
 	s.cursor_visible = visible
 	apply_cursor_state()
+}
+
+mac_set_mouse_captured :: proc(captured: bool) {
+	s.mouse_captured = captured
+
+	if captured {
+		_mac_teleport_cursor_to_center()
+	}
+}
+
+_mac_teleport_cursor_to_center :: proc() {
+	cx := s.screen_width/2
+	cy := s.screen_height/2
+	scale := mac_get_window_scale()
+	frame := s.window->frame()
+	x := f64(frame.origin.x) + f64(cx)/f64(scale)
+	y := f64(frame.origin.y) + f64(cy)/f64(scale)
+	ce.CGWarpMouseCursorPosition({x, y})
+
+	append(&s.events, Event_Mouse_Teleported {
+		position = {f32(cx), f32(cy)}
+	})
 }
 
 // NSCursor.hide/unhide are reference counted. These helpers ensure each hide is paired

--- a/platform_mac.odin
+++ b/platform_mac.odin
@@ -26,8 +26,8 @@ PLATFORM_MAC :: Platform_Interface {
 	set_window_position = mac_set_window_position,
 	get_window_scale = mac_get_window_scale,
 	set_window_mode = mac_set_window_mode,
-	set_cursor_visible = mac_set_cursor_visible,
-	is_cursor_visible = mac_is_cursor_visible,
+	set_cursor_hidden = mac_set_cursor_hidden,
+	is_cursor_hidden = mac_is_cursor_hidden,
 	set_cursor_locked = mac_set_cursor_locked,
 	is_cursor_locked = mac_is_cursor_locked,
 
@@ -51,7 +51,7 @@ Mac_State :: struct {
 
 	// Cursor visibility (the user's intent). The OS cursor is only actually hidden while
 	// the cursor is inside the content area of a key window — see `apply_cursor_state`.
-	cursor_visible:      bool,
+	cursor_hidden:       bool,
 	cursor_hidden_by_us: bool,
 	cursor_tracker:      NS.id,
 
@@ -102,7 +102,6 @@ mac_init :: proc(
 	s.odin_ctx = context
 	s.allocator = allocator
 	s.events = make([dynamic]Event, allocator)
-	s.cursor_visible = true
 
 	// Initialize NSApplication
 	s.app = NS.Application_sharedApplication()
@@ -437,13 +436,13 @@ mac_get_window_scale :: proc() -> f32 {
 	return f32(s.window->backingScaleFactor())
 }
 
-mac_set_cursor_visible :: proc(visible: bool) {
-	s.cursor_visible = visible
+mac_set_cursor_hidden :: proc(hidden: bool) {
+	s.cursor_hidden = hidden
 	apply_cursor_state()
 }
 
-mac_is_cursor_visible :: proc() -> bool {
-	return s.cursor_visible
+mac_is_cursor_hidden :: proc() -> bool {
+	return s.cursor_hidden
 }
 
 mac_set_cursor_locked :: proc(locked: bool) {
@@ -500,10 +499,10 @@ cursor_in_content_area :: proc() -> bool {
 }
 
 apply_cursor_state :: proc() {
-	if s.cursor_visible || !cursor_in_content_area() {
-		unhide_cursor_now()
-	} else {
+	if s.cursor_hidden && cursor_in_content_area() {
 		hide_cursor_now()
+	} else {
+		unhide_cursor_now()
 	}
 }
 
@@ -533,7 +532,7 @@ install_cursor_tracker :: proc() {
 
 cursor_tracker_mouse_entered :: proc "c" (self: NS.id, cmd: NS.SEL, event: NS.id) {
 	context = s.odin_ctx
-	if !s.cursor_visible {
+	if s.cursor_hidden {
 		hide_cursor_now()
 	}
 }

--- a/platform_mac.odin
+++ b/platform_mac.odin
@@ -27,7 +27,9 @@ PLATFORM_MAC :: Platform_Interface {
 	get_window_scale = mac_get_window_scale,
 	set_window_mode = mac_set_window_mode,
 	set_cursor_visible = mac_set_cursor_visible,
-	set_mouse_captured = mac_set_mouse_captured,
+	is_cursor_visible = mac_is_cursor_visible,
+	set_cursor_locked = mac_set_cursor_locked,
+	is_cursor_locked = mac_is_cursor_locked,
 
 	is_gamepad_active = mac_is_gamepad_active,
 	get_gamepad_axis = mac_get_gamepad_axis,
@@ -53,7 +55,7 @@ Mac_State :: struct {
 	cursor_hidden_by_us: bool,
 	cursor_tracker:      NS.id,
 
-	mouse_captured: bool,
+	cursor_locked: bool,
 	mouse_ignore_next_move: bool,
 
 	screen_width:     int,
@@ -354,7 +356,7 @@ mac_get_events :: proc(events: ^[dynamic]Event) {
 			px := loc.x * scale
 			py := NS.Float(s.screen_height) - loc.y * scale
 			
-			if s.mouse_captured {
+			if s.cursor_locked {
 				dx := f32(ce.Event_deltaX(event)) * f32(s.window->backingScaleFactor())
 				dy := f32(ce.Event_deltaY(event)) * f32(s.window->backingScaleFactor())
 				cx := f32(s.screen_width/2)
@@ -440,16 +442,24 @@ mac_set_cursor_visible :: proc(visible: bool) {
 	apply_cursor_state()
 }
 
-mac_set_mouse_captured :: proc(captured: bool) {
-	s.mouse_captured = captured
+mac_is_cursor_visible :: proc() -> bool {
+	return s.cursor_visible
+}
 
-	if captured {
+mac_set_cursor_locked :: proc(locked: bool) {
+	s.cursor_locked = locked
+
+	if locked {
 		s.mouse_ignore_next_move = true
 		ce.CGAssociateMouseAndMouseCursorPosition(false)
 		_mac_teleport_cursor_to_center()
 	} else {
 		ce.CGAssociateMouseAndMouseCursorPosition(true)
 	}
+}
+
+mac_is_cursor_locked :: proc() -> bool {
+	return s.cursor_locked
 }
 
 _mac_teleport_cursor_to_center :: proc() {

--- a/platform_web.odin
+++ b/platform_web.odin
@@ -19,6 +19,7 @@ PLATFORM_WEB :: Platform_Interface {
 	get_window_scale = web_get_window_scale,
 	set_window_mode = web_set_window_mode,
 	set_cursor_visible = web_set_cursor_visible,
+	set_mouse_captured = web_set_mouse_captured,
 	is_gamepad_active = web_is_gamepad_active,
 	get_gamepad_axis = web_get_gamepad_axis,
 	set_gamepad_vibration = web_set_gamepad_vibration,
@@ -131,12 +132,21 @@ web_event_window_resize :: proc(e: js.Event) {
 }
 
 web_event_mouse_move :: proc(e: js.Event) {
-	append(&s.events, Event_Mouse_Move {
-		position = {
-			math.floor(f32(e.mouse.client.x) * f32(js.device_pixel_ratio())),
-			math.floor(f32(e.mouse.client.y) * f32(js.device_pixel_ratio())),
-		},
-	})
+	if s.mouse_captured {
+		cx := f32(s.width / 2)
+		cy := f32(s.height / 2)
+		dx := f32(e.mouse.movement.x) * f32(js.device_pixel_ratio())
+		dy := f32(e.mouse.movement.y) * f32(js.device_pixel_ratio())
+		append(&s.events, Event_Mouse_Move { position = {cx + dx, cy + dy} })
+		append(&s.events, Event_Mouse_Teleported { position = {cx, cy} })
+	} else {
+		append(&s.events, Event_Mouse_Move {
+			position = {
+				math.floor(f32(e.mouse.client.x) * f32(js.device_pixel_ratio())),
+				math.floor(f32(e.mouse.client.y) * f32(js.device_pixel_ratio())),
+			},
+		})
+	}
 }
 
 web_event_mouse_down :: proc(e: js.Event) {
@@ -358,6 +368,19 @@ web_set_cursor_visible :: proc(visible: bool) {
 	}
 }
 
+web_set_mouse_captured :: proc(captured: bool) {
+	s.mouse_captured = captured
+
+	if captured {
+		js.evaluate("document.getElementById('webgl-canvas').requestPointerLock()")
+		cx := f32(s.width / 2)
+		cy := f32(s.height / 2)
+		append(&s.events, Event_Mouse_Teleported { position = {cx, cy} })
+	} else {
+		js.evaluate("document.exitPointerLock()")
+	}
+}
+
 web_is_gamepad_active :: proc(gamepad: int) -> bool {
 	if gamepad < 0 || gamepad >= MAX_GAMEPADS {
 		return false
@@ -420,6 +443,7 @@ Web_State :: struct {
 	height: int,
 	prev_scale: f32,
 	events: [dynamic]Event,
+	mouse_captured: bool,
 	gamepad_state: [MAX_GAMEPADS]js.Gamepad_State,
 	window_mode: Window_Mode,
 	key_from_js_event_key_code: map[string]Keyboard_Key,

--- a/platform_web.odin
+++ b/platform_web.odin
@@ -19,7 +19,10 @@ PLATFORM_WEB :: Platform_Interface {
 	get_window_scale = web_get_window_scale,
 	set_window_mode = web_set_window_mode,
 	set_cursor_visible = web_set_cursor_visible,
-	set_mouse_captured = web_set_mouse_captured,
+	is_cursor_visible = web_is_cursor_visible,
+	lock_mouse = web_lock_mouse,
+	unlock_mouse = web_unlock_mouse,
+	is_mouse_locked = web_is_mouse_locked,
 	is_gamepad_active = web_is_gamepad_active,
 	get_gamepad_axis = web_get_gamepad_axis,
 	set_gamepad_vibration = web_set_gamepad_vibration,
@@ -52,6 +55,7 @@ web_init :: proc(
 	s.events = make([dynamic]Event, allocator)
 	s.key_from_js_event_key_code = make(map[string]Keyboard_Key, allocator)
 	s.canvas_id = "webgl-canvas"
+	s.cursor_visible = true
 
 	js.set_document_title(window_title)
 	s.prev_scale = f32(js.device_pixel_ratio())
@@ -102,13 +106,12 @@ web_event_key_up :: proc(e: js.Event) {
 }
 
 web_event_focus :: proc(e: js.Event) {
-	append(&s.events, Event_Window_Focused {
-	})
+	append(&s.events, Event_Window_Focused {})
 }
 
 web_event_blur :: proc(e: js.Event) {
-	append(&s.events, Event_Window_Unfocused {
-	})
+	s.mouse_locked = false
+	append(&s.events, Event_Window_Unfocused {})
 }
 
 web_event_window_resize :: proc(e: js.Event) {
@@ -132,7 +135,7 @@ web_event_window_resize :: proc(e: js.Event) {
 }
 
 web_event_mouse_move :: proc(e: js.Event) {
-	if s.mouse_captured {
+	if s.mouse_locked {
 		cx := f32(s.width / 2)
 		cy := f32(s.height / 2)
 		dx := f32(e.mouse.movement.x) * f32(js.device_pixel_ratio())
@@ -361,6 +364,7 @@ web_set_window_mode :: proc(new_mode: Window_Mode) {
 }
 
 web_set_cursor_visible :: proc(visible: bool) {
+	s.cursor_visible = visible
 	if visible {
 		js.set_element_style(s.canvas_id, "cursor", "default")
 	} else {
@@ -368,17 +372,25 @@ web_set_cursor_visible :: proc(visible: bool) {
 	}
 }
 
-web_set_mouse_captured :: proc(captured: bool) {
-	s.mouse_captured = captured
+web_is_cursor_visible :: proc() -> bool {
+	return s.cursor_visible
+}
 
-	if captured {
-		js.evaluate("document.getElementById('webgl-canvas').requestPointerLock()")
-		cx := f32(s.width / 2)
-		cy := f32(s.height / 2)
-		append(&s.events, Event_Mouse_Teleported { position = {cx, cy} })
-	} else {
-		js.evaluate("document.exitPointerLock()")
-	}
+web_lock_mouse :: proc() {
+	js.evaluate("document.getElementById('webgl-canvas').requestPointerLock()")
+	cx := f32(s.width / 2)
+	cy := f32(s.height / 2)
+	append(&s.events, Event_Mouse_Teleported { position = {cx, cy} })
+	s.mouse_locked = true
+}
+
+web_unlock_mouse :: proc() {
+	js.evaluate("document.exitPointerLock()")
+	s.mouse_locked = false
+}
+
+web_is_mouse_locked :: proc() -> bool {
+	return s.mouse_locked
 }
 
 web_is_gamepad_active :: proc(gamepad: int) -> bool {
@@ -443,7 +455,8 @@ Web_State :: struct {
 	height: int,
 	prev_scale: f32,
 	events: [dynamic]Event,
-	mouse_captured: bool,
+	mouse_locked: bool,
+	cursor_visible: bool,
 	gamepad_state: [MAX_GAMEPADS]js.Gamepad_State,
 	window_mode: Window_Mode,
 	key_from_js_event_key_code: map[string]Keyboard_Key,

--- a/platform_web.odin
+++ b/platform_web.odin
@@ -80,6 +80,8 @@ web_init :: proc(
 	add_window_event_listener(.Focus, web_event_focus)
 	add_window_event_listener(.Blur, web_event_blur)
 
+	add_window_event_listener(.Pointer_Lock_Change, _web_event_pointer_lock_change)
+
 	if init_options.disable_auto_scale_hint {
 		log.warn("disable_auto_scale_hint not supported on web")
 	}
@@ -374,9 +376,12 @@ web_is_cursor_hidden :: proc() -> bool {
 	return s.cursor_hidden
 }
 
-web_set_cursor_locked :: proc(locked: bool) {
-	s.cursor_locked = locked
+_web_event_pointer_lock_change :: proc(e: js.Event) {
+	js.evaluate("document.getElementById('webgl-canvas')._pointerLocked = document.pointerLockElement !== null ? 1 : 0")
+	s.cursor_locked = js.get_element_key_f64("webgl-canvas", "_pointerLocked") != 0
+}
 
+web_set_cursor_locked :: proc(locked: bool) {
 	if locked {
 		js.evaluate("document.getElementById('webgl-canvas').requestPointerLock()")
 		cx := f32(s.width / 2)
@@ -385,6 +390,8 @@ web_set_cursor_locked :: proc(locked: bool) {
 	} else {
 		js.evaluate("document.exitPointerLock()")
 	}
+
+	// s.cursor_locked set by _web_event_pointer_lock_change
 }
 
 web_is_cursor_locked :: proc() -> bool {

--- a/platform_web.odin
+++ b/platform_web.odin
@@ -18,8 +18,8 @@ PLATFORM_WEB :: Platform_Interface {
 	set_window_position = web_set_position,
 	get_window_scale = web_get_window_scale,
 	set_window_mode = web_set_window_mode,
-	set_cursor_visible = web_set_cursor_visible,
-	is_cursor_visible = web_is_cursor_visible,
+	set_cursor_hidden = web_set_cursor_hidden,
+	is_cursor_hidden = web_is_cursor_hidden,
 	set_cursor_locked = web_set_cursor_locked,
 	is_cursor_locked = web_is_cursor_locked,
 	is_gamepad_active = web_is_gamepad_active,
@@ -54,7 +54,6 @@ web_init :: proc(
 	s.events = make([dynamic]Event, allocator)
 	s.key_from_js_event_key_code = make(map[string]Keyboard_Key, allocator)
 	s.canvas_id = "webgl-canvas"
-	s.cursor_visible = true
 
 	js.set_document_title(window_title)
 	s.prev_scale = f32(js.device_pixel_ratio())
@@ -362,17 +361,17 @@ web_set_window_mode :: proc(new_mode: Window_Mode) {
 	}
 }
 
-web_set_cursor_visible :: proc(visible: bool) {
-	s.cursor_visible = visible
-	if visible {
-		js.set_element_style(s.canvas_id, "cursor", "default")
-	} else {
+web_set_cursor_hidden :: proc(hidden: bool) {
+	s.cursor_hidden = hidden
+	if hidden {
 		js.set_element_style(s.canvas_id, "cursor", "none")
+	} else {
+		js.set_element_style(s.canvas_id, "cursor", "default")
 	}
 }
 
-web_is_cursor_visible :: proc() -> bool {
-	return s.cursor_visible
+web_is_cursor_hidden :: proc() -> bool {
+	return s.cursor_hidden
 }
 
 web_set_cursor_locked :: proc(locked: bool) {
@@ -455,7 +454,7 @@ Web_State :: struct {
 	prev_scale: f32,
 	events: [dynamic]Event,
 	cursor_locked: bool,
-	cursor_visible: bool,
+	cursor_hidden: bool,
 	gamepad_state: [MAX_GAMEPADS]js.Gamepad_State,
 	window_mode: Window_Mode,
 	key_from_js_event_key_code: map[string]Keyboard_Key,

--- a/platform_web.odin
+++ b/platform_web.odin
@@ -20,9 +20,8 @@ PLATFORM_WEB :: Platform_Interface {
 	set_window_mode = web_set_window_mode,
 	set_cursor_visible = web_set_cursor_visible,
 	is_cursor_visible = web_is_cursor_visible,
-	lock_mouse = web_lock_mouse,
-	unlock_mouse = web_unlock_mouse,
-	is_mouse_locked = web_is_mouse_locked,
+	set_cursor_locked = web_set_cursor_locked,
+	is_cursor_locked = web_is_cursor_locked,
 	is_gamepad_active = web_is_gamepad_active,
 	get_gamepad_axis = web_get_gamepad_axis,
 	set_gamepad_vibration = web_set_gamepad_vibration,
@@ -110,7 +109,7 @@ web_event_focus :: proc(e: js.Event) {
 }
 
 web_event_blur :: proc(e: js.Event) {
-	s.mouse_locked = false
+	s.cursor_locked = false
 	append(&s.events, Event_Window_Unfocused {})
 }
 
@@ -135,7 +134,7 @@ web_event_window_resize :: proc(e: js.Event) {
 }
 
 web_event_mouse_move :: proc(e: js.Event) {
-	if s.mouse_locked {
+	if s.cursor_locked {
 		cx := f32(s.width / 2)
 		cy := f32(s.height / 2)
 		dx := f32(e.mouse.movement.x) * f32(js.device_pixel_ratio())
@@ -376,21 +375,21 @@ web_is_cursor_visible :: proc() -> bool {
 	return s.cursor_visible
 }
 
-web_lock_mouse :: proc() {
-	js.evaluate("document.getElementById('webgl-canvas').requestPointerLock()")
-	cx := f32(s.width / 2)
-	cy := f32(s.height / 2)
-	append(&s.events, Event_Mouse_Teleported { position = {cx, cy} })
-	s.mouse_locked = true
+web_set_cursor_locked :: proc(locked: bool) {
+	s.cursor_locked = locked
+
+	if locked {
+		js.evaluate("document.getElementById('webgl-canvas').requestPointerLock()")
+		cx := f32(s.width / 2)
+		cy := f32(s.height / 2)
+		append(&s.events, Event_Mouse_Teleported { position = {cx, cy} })
+	} else {
+		js.evaluate("document.exitPointerLock()")
+	}
 }
 
-web_unlock_mouse :: proc() {
-	js.evaluate("document.exitPointerLock()")
-	s.mouse_locked = false
-}
-
-web_is_mouse_locked :: proc() -> bool {
-	return s.mouse_locked
+web_is_cursor_locked :: proc() -> bool {
+	return s.cursor_locked
 }
 
 web_is_gamepad_active :: proc(gamepad: int) -> bool {
@@ -455,7 +454,7 @@ Web_State :: struct {
 	height: int,
 	prev_scale: f32,
 	events: [dynamic]Event,
-	mouse_locked: bool,
+	cursor_locked: bool,
 	cursor_visible: bool,
 	gamepad_state: [MAX_GAMEPADS]js.Gamepad_State,
 	window_mode: Window_Mode,

--- a/platform_windows.odin
+++ b/platform_windows.odin
@@ -488,7 +488,6 @@ windows_set_cursor_locked :: proc(locked: bool) {
 	s.mouse_locked = locked
 
 	if locked {
-		s.mouse_locked = true
 		r: win32.RECT
 		win32.GetClientRect(s.hwnd, &r)
 		tl := win32.POINT{r.left, r.top}

--- a/platform_windows.odin
+++ b/platform_windows.odin
@@ -18,7 +18,10 @@ PLATFORM_WINDOWS :: Platform_Interface {
 	get_window_scale = windows_get_window_scale,
 	set_window_mode = windows_set_window_mode,
 	set_cursor_visible = windows_set_cursor_visible,
-	set_mouse_captured = windows_set_mouse_captured,
+	is_cursor_visible = windows_is_cursor_visible,
+	lock_mouse = windows_lock_mouse,
+	unlock_mouse = windows_unlock_mouse,
+	is_mouse_locked = windows_is_mouse_locked,
 
 	is_gamepad_active = windows_is_gamepad_active,
 	get_gamepad_axis = windows_get_gamepad_axis,
@@ -32,7 +35,6 @@ PLATFORM_WINDOWS :: Platform_Interface {
 import win32 "core:sys/windows"
 import "base:runtime"
 @require import "log"
-
 
 windows_state_size :: proc() -> int {
 	return size_of(Windows_State)
@@ -51,6 +53,7 @@ windows_init :: proc(
 	s.allocator = allocator
 	s.events = make([dynamic]Event, allocator = allocator)
 	s.custom_context = context
+	s.cursor_visible = true
 	
 	win32.SetProcessDpiAwarenessContext(win32.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)
 	win32.SetProcessDPIAware()
@@ -411,7 +414,8 @@ Windows_State :: struct {
 	previous_gamepad_triggers: [MAX_GAMEPADS][2]win32.BYTE,
 
 	events: [dynamic]Event,
-	mouse_captured: bool,
+	mouse_locked: bool,
+	cursor_visible: bool,
 
 	// for when returning from fullscreen to window mode
 	restore_window_pos_x: int,
@@ -474,26 +478,34 @@ windows_set_window_mode :: proc(window_mode: Window_Mode) {
 
 windows_set_cursor_visible :: proc(visible: bool) {
 	win32.ShowCursor(win32.BOOL(visible))
+	s.cursor_visible = visible
 }
 
-windows_set_mouse_captured :: proc(captured: bool) {
-	s.mouse_captured = captured
+windows_is_cursor_visible :: proc() -> bool {
+	return s.cursor_visible
+}
 
-	if captured {
-		// Clip cursor to window client rect. Makes it stay within the window.
-		r: win32.RECT
-		win32.GetClientRect(s.hwnd, &r)
-		tl := win32.POINT{r.left, r.top}
-		br := win32.POINT{r.right, r.bottom}
-		win32.ClientToScreen(s.hwnd, &tl)
-		win32.ClientToScreen(s.hwnd, &br)
-		clip := win32.RECT{tl.x, tl.y, br.x, br.y}
-		win32.ClipCursor(&clip)
-		
-		_windows_teleport_cursor_to_center()
-	} else {
-		win32.ClipCursor(nil)
-	}
+windows_lock_mouse :: proc() {
+	s.mouse_locked = true
+	r: win32.RECT
+	win32.GetClientRect(s.hwnd, &r)
+	tl := win32.POINT{r.left, r.top}
+	br := win32.POINT{r.right, r.bottom}
+	win32.ClientToScreen(s.hwnd, &tl)
+	win32.ClientToScreen(s.hwnd, &br)
+	clip := win32.RECT{tl.x, tl.y, br.x, br.y}
+	win32.ClipCursor(&clip)
+	
+	_windows_teleport_cursor_to_center()
+}
+
+windows_unlock_mouse :: proc() {
+	s.mouse_locked = false
+	win32.ClipCursor(nil)
+}
+
+windows_is_mouse_locked :: proc() -> bool {
+	return s.mouse_locked
 }
 
 _windows_teleport_cursor_to_center :: proc() {
@@ -545,7 +557,7 @@ _windows_window_proc :: proc "stdcall" (hwnd: win32.HWND, msg: win32.UINT, wpara
 		x := win32.GET_X_LPARAM(lparam)
 		y := win32.GET_Y_LPARAM(lparam)
 
-		if s.mouse_captured {
+		if s.mouse_locked {
 			cx := i32(s.screen_width / 2)
 			cy := i32(s.screen_height / 2)
 

--- a/platform_windows.odin
+++ b/platform_windows.odin
@@ -19,9 +19,8 @@ PLATFORM_WINDOWS :: Platform_Interface {
 	set_window_mode = windows_set_window_mode,
 	set_cursor_visible = windows_set_cursor_visible,
 	is_cursor_visible = windows_is_cursor_visible,
-	lock_mouse = windows_lock_mouse,
-	unlock_mouse = windows_unlock_mouse,
-	is_mouse_locked = windows_is_mouse_locked,
+	set_cursor_locked = windows_set_cursor_locked,
+	is_cursor_locked = windows_is_cursor_locked,
 
 	is_gamepad_active = windows_is_gamepad_active,
 	get_gamepad_axis = windows_get_gamepad_axis,
@@ -485,26 +484,27 @@ windows_is_cursor_visible :: proc() -> bool {
 	return s.cursor_visible
 }
 
-windows_lock_mouse :: proc() {
-	s.mouse_locked = true
-	r: win32.RECT
-	win32.GetClientRect(s.hwnd, &r)
-	tl := win32.POINT{r.left, r.top}
-	br := win32.POINT{r.right, r.bottom}
-	win32.ClientToScreen(s.hwnd, &tl)
-	win32.ClientToScreen(s.hwnd, &br)
-	clip := win32.RECT{tl.x, tl.y, br.x, br.y}
-	win32.ClipCursor(&clip)
-	
-	_windows_teleport_cursor_to_center()
+windows_set_cursor_locked :: proc(locked: bool) {
+	s.mouse_locked = locked
+
+	if locked {
+		s.mouse_locked = true
+		r: win32.RECT
+		win32.GetClientRect(s.hwnd, &r)
+		tl := win32.POINT{r.left, r.top}
+		br := win32.POINT{r.right, r.bottom}
+		win32.ClientToScreen(s.hwnd, &tl)
+		win32.ClientToScreen(s.hwnd, &br)
+		clip := win32.RECT{tl.x, tl.y, br.x, br.y}
+		win32.ClipCursor(&clip)
+		
+		_windows_teleport_cursor_to_center()
+	} else {
+		win32.ClipCursor(nil)
+	}
 }
 
-windows_unlock_mouse :: proc() {
-	s.mouse_locked = false
-	win32.ClipCursor(nil)
-}
-
-windows_is_mouse_locked :: proc() -> bool {
+windows_is_cursor_locked :: proc() -> bool {
 	return s.mouse_locked
 }
 

--- a/platform_windows.odin
+++ b/platform_windows.odin
@@ -17,8 +17,8 @@ PLATFORM_WINDOWS :: Platform_Interface {
 	set_screen_size = windows_set_screen_size,
 	get_window_scale = windows_get_window_scale,
 	set_window_mode = windows_set_window_mode,
-	set_cursor_visible = windows_set_cursor_visible,
-	is_cursor_visible = windows_is_cursor_visible,
+	set_cursor_hidden = windows_set_cursor_hidden,
+	is_cursor_hidden = windows_is_cursor_hidden,
 	set_cursor_locked = windows_set_cursor_locked,
 	is_cursor_locked = windows_is_cursor_locked,
 
@@ -52,7 +52,6 @@ windows_init :: proc(
 	s.allocator = allocator
 	s.events = make([dynamic]Event, allocator = allocator)
 	s.custom_context = context
-	s.cursor_visible = true
 	
 	win32.SetProcessDpiAwarenessContext(win32.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)
 	win32.SetProcessDPIAware()
@@ -413,8 +412,8 @@ Windows_State :: struct {
 	previous_gamepad_triggers: [MAX_GAMEPADS][2]win32.BYTE,
 
 	events: [dynamic]Event,
-	mouse_locked: bool,
-	cursor_visible: bool,
+	cursor_locked: bool,
+	cursor_hidden: bool,
 
 	// for when returning from fullscreen to window mode
 	restore_window_pos_x: int,
@@ -475,17 +474,17 @@ windows_set_window_mode :: proc(window_mode: Window_Mode) {
 	}
 }
 
-windows_set_cursor_visible :: proc(visible: bool) {
-	win32.ShowCursor(win32.BOOL(visible))
-	s.cursor_visible = visible
+windows_set_cursor_hidden :: proc(hidden: bool) {
+	win32.ShowCursor(win32.BOOL(!hidden))
+	s.cursor_hidden = hidden
 }
 
-windows_is_cursor_visible :: proc() -> bool {
-	return s.cursor_visible
+windows_is_cursor_hidden :: proc() -> bool {
+	return s.cursor_hidden
 }
 
 windows_set_cursor_locked :: proc(locked: bool) {
-	s.mouse_locked = locked
+	s.cursor_locked = locked
 
 	if locked {
 		r: win32.RECT
@@ -504,7 +503,7 @@ windows_set_cursor_locked :: proc(locked: bool) {
 }
 
 windows_is_cursor_locked :: proc() -> bool {
-	return s.mouse_locked
+	return s.cursor_locked
 }
 
 _windows_teleport_cursor_to_center :: proc() {
@@ -556,7 +555,7 @@ _windows_window_proc :: proc "stdcall" (hwnd: win32.HWND, msg: win32.UINT, wpara
 		x := win32.GET_X_LPARAM(lparam)
 		y := win32.GET_Y_LPARAM(lparam)
 
-		if s.mouse_locked {
+		if s.cursor_locked {
 			cx := i32(s.screen_width / 2)
 			cy := i32(s.screen_height / 2)
 
@@ -676,6 +675,11 @@ _windows_window_proc :: proc "stdcall" (hwnd: win32.HWND, msg: win32.UINT, wpara
 		append(&s.events, Event_Window_Focused {})
 
 	case win32.WM_KILLFOCUS:
+		s.cursor_locked = false
+		if s.cursor_hidden {
+			win32.ShowCursor(true)
+			s.cursor_hidden = false
+		}
 		append(&s.events, Event_Window_Unfocused {})
 	}
 

--- a/platform_windows.odin
+++ b/platform_windows.odin
@@ -18,6 +18,7 @@ PLATFORM_WINDOWS :: Platform_Interface {
 	get_window_scale = windows_get_window_scale,
 	set_window_mode = windows_set_window_mode,
 	set_cursor_visible = windows_set_cursor_visible,
+	set_mouse_captured = windows_set_mouse_captured,
 
 	is_gamepad_active = windows_is_gamepad_active,
 	get_gamepad_axis = windows_get_gamepad_axis,
@@ -58,7 +59,7 @@ windows_init :: proc(
 
 	cls := win32.WNDCLASSW {
 		style = win32.CS_OWNDC,
-		lpfnWndProc = window_proc,
+		lpfnWndProc = _windows_window_proc,
 		lpszClassName = CLASS_NAME,
 		hInstance = instance,
 		hCursor = win32.LoadCursorA(nil, win32.IDC_ARROW),
@@ -132,7 +133,7 @@ windows_get_window_render_glue :: proc() -> Window_Render_Glue {
 windows_get_events :: proc(events: ^[dynamic]Event) {
 	msg: win32.MSG
 
-	// This loop will call `window_proc` which will add more things to `frame_events`.
+	// This loop will call `_windows_window_proc` which will add more things to `frame_events`.
 	for win32.PeekMessageW(&msg, nil, 0, 0, win32.PM_REMOVE) {
 		win32.TranslateMessage(&msg)
 		win32.DispatchMessageW(&msg)
@@ -410,6 +411,7 @@ Windows_State :: struct {
 	previous_gamepad_triggers: [MAX_GAMEPADS][2]win32.BYTE,
 
 	events: [dynamic]Event,
+	mouse_captured: bool,
 
 	// for when returning from fullscreen to window mode
 	restore_window_pos_x: int,
@@ -474,9 +476,41 @@ windows_set_cursor_visible :: proc(visible: bool) {
 	win32.ShowCursor(win32.BOOL(visible))
 }
 
+windows_set_mouse_captured :: proc(captured: bool) {
+	s.mouse_captured = captured
+
+	if captured {
+		// Clip cursor to window client rect. Makes it stay within the window.
+		r: win32.RECT
+		win32.GetClientRect(s.hwnd, &r)
+		tl := win32.POINT{r.left, r.top}
+		br := win32.POINT{r.right, r.bottom}
+		win32.ClientToScreen(s.hwnd, &tl)
+		win32.ClientToScreen(s.hwnd, &br)
+		clip := win32.RECT{tl.x, tl.y, br.x, br.y}
+		win32.ClipCursor(&clip)
+		
+		_windows_teleport_cursor_to_center()
+	} else {
+		win32.ClipCursor(nil)
+	}
+}
+
+_windows_teleport_cursor_to_center :: proc() {
+	cx := s.screen_width / 2
+	cy := s.screen_height / 2
+	pt := win32.POINT{i32(cx), i32(cy)}
+	win32.ClientToScreen(s.hwnd, &pt)
+	win32.SetCursorPos(pt.x, pt.y)
+
+	append(&s.events, Event_Mouse_Teleported {
+		position = {f32(cx), f32(cy)},
+	})
+}
+
 s: ^Windows_State
 
-window_proc :: proc "stdcall" (hwnd: win32.HWND, msg: win32.UINT, wparam: win32.WPARAM, lparam: win32.LPARAM) -> win32.LRESULT {
+_windows_window_proc :: proc "stdcall" (hwnd: win32.HWND, msg: win32.UINT, wparam: win32.WPARAM, lparam: win32.LPARAM) -> win32.LRESULT {
 	context = s.custom_context
 
 	switch msg {
@@ -510,9 +544,23 @@ window_proc :: proc "stdcall" (hwnd: win32.HWND, msg: win32.UINT, wparam: win32.
 	case win32.WM_MOUSEMOVE:
 		x := win32.GET_X_LPARAM(lparam)
 		y := win32.GET_Y_LPARAM(lparam)
-		append(&s.events, Event_Mouse_Move {
-			position = {f32(x), f32(y)},
-		})
+
+		if s.mouse_captured {
+			cx := i32(s.screen_width / 2)
+			cy := i32(s.screen_height / 2)
+
+			if x != cx || y != cy {
+				append(&s.events, Event_Mouse_Move {
+					position = {f32(x), f32(y)},
+				})
+
+				_windows_teleport_cursor_to_center()
+			}
+		} else {
+			append(&s.events, Event_Mouse_Move {
+				position = {f32(x), f32(y)},
+			})
+		}
 
 	case win32.WM_MOUSEWHEEL:
 		delta := f32(win32.GET_WHEEL_DELTA_WPARAM(wparam))/win32.WHEEL_DELTA


### PR DESCRIPTION
Adds support for locking the cursor to the window. When locked, you can still fetch the mouse delta motion, and thus use the mouse for your own custom input needs.

Additional changes:
- Added a mouse_locking example to showcase the new features
- set_cursor_visible is now called set_cursor_hidden and the old one is deprecated
- Linux platforms now return the correct window size right after `init`

Fixes #145 