### PR TITLE
add Clipboard functionality

### DIFF
--- a/examples/clipboard/clipboard.odin
+++ b/examples/clipboard/clipboard.odin
@@ -1,0 +1,20 @@
+package clipboard
+
+import k2 "../.."
+import "core:fmt"
+
+main :: proc() {
+    k2.init(1280, 720, "Clipboard")
+
+    for k2.update() {
+        if k2.get_held_modifiers() == {.Control} && k2.key_went_down(.V) {
+			text := k2.get_clipboard_text(context.temp_allocator)
+			fmt.println(text)
+		}
+
+        k2.clear(k2.BLACK)
+        k2.present()
+
+        free_all(context.temp_allocator)
+    }
+}

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -548,6 +548,10 @@ key_is_held :: proc(key: Keyboard_Key) -> bool {
 	return s.key_is_held[key]
 }
 
+get_clipboard_text :: proc(allocator: runtime.Allocator) -> (string, bool) #optional_ok {
+	return pf.get_clipboard_text(allocator)
+}
+
 // Returns which modifiers are held. The possible values are `Control`, `Alt`, `Shift` and `Super`.
 // You can check that an exact set of modifiers are held like so:
 //

--- a/platform_interface.odin
+++ b/platform_interface.odin
@@ -24,6 +24,7 @@ Platform_Interface :: struct #all_or_none {
 	get_window_scale: proc() -> f32,
 	set_window_mode: proc(window_mode: Window_Mode),
 	set_cursor_visible: proc(visible: bool),
+	get_clipboard_text: proc(allocator: runtime.Allocator) -> (string, bool),
 
 	is_gamepad_active: proc(gamepad: int) -> bool,
 	get_gamepad_axis: proc(gamepad: int, axis: Gamepad_Axis) -> f32,

--- a/platform_windows.odin
+++ b/platform_windows.odin
@@ -18,6 +18,7 @@ PLATFORM_WINDOWS :: Platform_Interface {
 	get_window_scale = windows_get_window_scale,
 	set_window_mode = windows_set_window_mode,
 	set_cursor_visible = windows_set_cursor_visible,
+	get_clipboard_text = windows_get_clipboard_text,
 
 	is_gamepad_active = windows_is_gamepad_active,
 	get_gamepad_axis = windows_get_gamepad_axis,
@@ -472,6 +473,40 @@ windows_set_window_mode :: proc(window_mode: Window_Mode) {
 
 windows_set_cursor_visible :: proc(visible: bool) {
 	win32.ShowCursor(win32.BOOL(visible))
+}
+
+windows_get_clipboard_text :: proc(allocator: runtime.Allocator) -> (string, bool) {
+	format := u32(win32.CF_UNICODETEXT)
+
+	if !win32.IsClipboardFormatAvailable(format) {
+		return "", false
+	}
+
+	opened := win32.OpenClipboard(s.hwnd)
+	if !opened {
+		return "", false
+	}
+	defer win32.CloseClipboard()
+
+	handle := win32.GetClipboardData(format)	
+	if handle == nil {
+		return "", false
+	}
+
+	ptr := win32.GlobalLock((win32.HGLOBAL)(handle))
+	if ptr == nil {
+		return "", false
+	}
+	defer win32.GlobalUnlock((win32.HGLOBAL)(handle))
+
+	size := win32.GlobalSize(handle) / size_of(u16)
+	result, err := win32.utf16_to_utf8(([^]u16)(ptr)[:size], allocator)
+	if err != nil {
+		log.errorf("Couldn't get clipboard data in UTF8: %v", err)
+		return "", false
+	}
+
+	return result, true
 }
 
 s: ^Windows_State


### PR DESCRIPTION
only getting clipboard text for now, and just Windows, until we finalize the API.
I have questions about passing an explicit allocator... should we do that or use the `s.allocator`?
I found that being able to pass the `context.temp_allocator` is good because it's likely that the user will allocate a clone of the text themselves anyway. But I'm not sure.

---

## Rules Checklist

You can always submit a draft pull request. But when you make your Pull Request "ready for review", then please make sure these rules are followed (put an x between each [ ]):
- [x] Make sure that the code you submit is working and tested.
- [x] Do not submit "basic" or "rudimentary" code that needs further work to actually be finished. Finish the code to the best of your abilities.
- [x] Do not modify any code that is unrelated to your changes. That just makes reviewing your code harder: I'll have a hard time seeing what you actually did. Do not use auto formatters such as odinfmt.
- [x] If you used an LLM to generate any code, then make that you understand every single line. In other words: No form of "vibe coded" PRs are allowed.
- [x] If you commit changes that were unintended, just do additional commits that undo them. Don't worry about polluting the commit history: I will do a "squash merge" of your Pull Request. Just make sure that the diff in the "Files changed" tab looks tidy.
- [ ] If the GitHub testing action complain about the `karl2d.doc.odin` file being out-of-date, then please regenerate it by running `odin run tools/api_doc_builder`. This way you'll have an easier time seeing if you've made changes to the user-facing API.
- [x] Make sure that the code follows the same style as in `karl2d.odin`:
	- Please look through that file and pay attention to how characters such as `:` `=`, `(` `{` etc are placed.
	- Use tabs, not spaces.
	- Lines cannot be longer than 100 characters. See the `init` proc in `karl2d.odin` for an example of how to split up procedure signatures that are too long. That proc also shows how to write API comments. Use a ruler in your editor to make it easy to spot long lines.
