### PR TITLE
Clarify supported mouse buttons

### DIFF
--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -1482,8 +1482,8 @@ State :: struct {
 	mix_buffer_offset: int,
 }
 
-// Support for up to 255 mouse buttons. Cast an int to type `Mouse_Button` to use things outside the
-// options presented here.
+// Karl2D currently reports left, right, and middle mouse buttons.
+// `Max` defines the upper bound of the `Mouse_Button` enum.
 Mouse_Button :: enum {
 	Left,
 	Right,

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -4701,8 +4701,8 @@ State :: struct {
 }
 
 
-// Support for up to 255 mouse buttons. Cast an int to type `Mouse_Button` to use things outside the
-// options presented here.
+// Karl2D currently reports left, right, and middle mouse buttons.
+// `Max` defines the upper bound of the `Mouse_Button` enum.
 Mouse_Button :: enum {
 	Left,
 	Right,


### PR DESCRIPTION
Fixes #143

This updates the `Mouse_Button` docs to match current behavior.

The previous comment implied support for up to 255 mouse buttons, but the current platform backends only report left, right, and middle mouse buttons. This PR clarifies that wording and, `Max` is described as the upper bound of the `Mouse_Button` enum.

This is a docs-only change.