### PR TITLE
Add set_window_title API

### DIFF
--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -135,6 +135,9 @@ get_screen_height :: proc() -> int
 // Gets the screen width and height as a 2D vector.
 get_screen_size :: proc() -> Vec2
 
+// Change the window title.
+set_window_title :: proc(title: string)
+
 // Moves the window.
 //
 // This does nothing for web builds.

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -431,6 +431,11 @@ get_screen_size :: proc() -> Vec2 {
 	return { f32(pf.get_screen_width()), f32(pf.get_screen_height()) }
 }
 
+// Change the window title.
+set_window_title :: proc(title: string) {
+	pf.set_window_title(title)
+}
+
 // Moves the window.
 //
 // This does nothing for web builds.

--- a/platform_interface.odin
+++ b/platform_interface.odin
@@ -17,6 +17,7 @@ Platform_Interface :: struct #all_or_none {
 	shutdown: proc(),
 	get_window_render_glue: proc() -> Window_Render_Glue,
 	get_events: proc(events: ^[dynamic]Event),
+	set_window_title: proc(title: string),
 	set_window_position: proc(x: int, y: int),
 	set_screen_size: proc(w, h: int),
 	get_screen_width: proc() -> int,

--- a/platform_linux.odin
+++ b/platform_linux.odin
@@ -22,6 +22,7 @@ PLATFORM_LINUX :: Platform_Interface {
 	shutdown = linux_shutdown,
 	get_window_render_glue = linux_get_window_render_glue,
 	get_events = linux_get_events,
+	set_window_title = linux_set_window_title,
 	set_screen_size = set_screen_size,
 	get_screen_width = linux_get_screen_width,
 	get_screen_height = linux_get_screen_height,
@@ -160,6 +161,10 @@ linux_get_screen_width :: proc() -> int {
 
 linux_get_screen_height :: proc() -> int {
 	return s.win.get_screen_height()
+}
+
+linux_set_window_title :: proc(title: string) {
+	s.win.set_title(title)
 }
 
 linux_set_window_position :: proc(x: int, y: int) {
@@ -628,6 +633,7 @@ Linux_Window_Interface :: struct #all_or_none {
 	shutdown: proc(),
 	get_window_render_glue: proc() -> Window_Render_Glue,
 	get_events: proc(events: ^[dynamic]Event),
+	set_title: proc(title: string),
 	set_position: proc(x: int, y: int),
 	set_screen_size: proc(w, h: int),
 	get_screen_width: proc() -> int,

--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -8,6 +8,7 @@ LINUX_WINDOW_WAYLAND :: Linux_Window_Interface {
 	shutdown = wl_shutdown,
 	get_window_render_glue = wl_get_window_render_glue,
 	get_events = wl_get_events,
+	set_title = wl_set_title,
 	get_screen_width = wl_get_screen_width,
 	get_screen_height = wl_get_screen_height,
 	set_position = wl_set_position,
@@ -485,6 +486,10 @@ wl_get_events :: proc(events: ^[dynamic]Event) {
 	wl.display_dispatch_pending(s.display)
 	append(events, ..s.events[:])
 	runtime.clear(&s.events)
+}
+
+wl_set_title :: proc(title: string) {
+	wl.xdg_toplevel_set_title(s.toplevel, strings.clone_to_cstring(title, frame_allocator))
 }
 
 wl_get_screen_width :: proc() -> int {

--- a/platform_linux_window_x11.odin
+++ b/platform_linux_window_x11.odin
@@ -10,6 +10,7 @@ LINUX_WINDOW_X11 :: Linux_Window_Interface {
 	shutdown = x11_shutdown,
 	get_window_render_glue = x11_get_window_render_glue,
 	get_events = x11_get_events,
+	set_title = x11_set_title,
 	get_screen_width = x11_get_screen_width,
 	get_screen_height = x11_get_screen_height,
 	set_position = x11_set_position,
@@ -209,6 +210,10 @@ x11_get_events :: proc(events: ^[dynamic]Event) {
 			append(events, Event_Window_Unfocused{})
 		}
 	}
+}
+
+x11_set_title :: proc(title: string) {
+	X.StoreName(s.display, s.window, frame_cstring(title))
 }
 
 x11_get_screen_width :: proc() -> int {

--- a/platform_mac.odin
+++ b/platform_mac.odin
@@ -20,6 +20,7 @@ PLATFORM_MAC :: Platform_Interface {
 	shutdown = mac_shutdown,
 	get_window_render_glue = mac_get_window_render_glue,
 	get_events = mac_get_events,
+	set_window_title = mac_set_window_title,
 	set_screen_size = mac_set_screen_size,
 	get_screen_width = mac_get_screen_width,
 	get_screen_height = mac_get_screen_height,
@@ -400,6 +401,11 @@ mac_get_screen_width :: proc() -> int {
 
 mac_get_screen_height :: proc() -> int {
 	return s.screen_height
+}
+
+mac_set_window_title :: proc(title: string) {
+	title_str := NS.String_alloc()->initWithOdinString(title)
+	s.window->setTitle(title_str)
 }
 
 mac_set_window_position :: proc(x: int, y: int) {

--- a/platform_web.odin
+++ b/platform_web.odin
@@ -12,6 +12,7 @@ PLATFORM_WEB :: Platform_Interface {
 	shutdown = web_shutdown,
 	get_window_render_glue = web_get_window_render_glue,
 	get_events = web_get_events,
+	set_window_title = web_set_window_title,
 	set_screen_size = web_set_screen_size,
 	get_screen_width = web_get_screen_width,
 	get_screen_height = web_get_screen_height,
@@ -312,6 +313,10 @@ web_get_screen_height :: proc() -> int {
 
 web_clear_events :: proc() {
 	runtime.clear(&s.events)
+}
+
+web_set_window_title :: proc(title: string) {
+	js.set_document_title(title)
 }
 
 web_set_position :: proc(x: int, y: int) {

--- a/platform_windows.odin
+++ b/platform_windows.odin
@@ -11,6 +11,7 @@ PLATFORM_WINDOWS :: Platform_Interface {
 	shutdown = windows_shutdown,
 	get_window_render_glue = windows_get_window_render_glue,
 	get_events = windows_get_events,
+	set_window_title = windows_set_window_title,
 	get_screen_width = windows_get_screen_width,
 	get_screen_height = windows_get_screen_height,
 	set_window_position = windows_set_window_position,
@@ -245,6 +246,10 @@ windows_get_screen_width :: proc() -> int {
 
 windows_get_screen_height :: proc() -> int {
 	return s.screen_height
+}
+
+windows_set_window_title :: proc(title: string) {
+	win32.SetWindowTextW(s.hwnd, win32.utf8_to_wstring(title, frame_allocator))
 }
 
 // Because positions can be offset in Windows: There is an "inivisble border" on Windows. This makes


### PR DESCRIPTION
Fixes #168

This adds `k2.set_window_title(title: string)` so the window title can be changed at runtime.

- added `set_window_title` to the public API
- added `set_window_title` to `Platform_Interface`
- implemented it for Windows, macOS, web, X11, and Wayland
- updated `karl2d.doc.odin`

This is a small API addition. It does not change existing behavior unless the new function is called.

Also, here's a short demo showing the same running window repeatedly changing title between `Alpha` and `Bravo` using `k2.set_window_title(...)`.


https://github.com/user-attachments/assets/fb34c1a5-ad6c-40b9-a047-edd95ee5c5de





