### PR TITLE
Add get_window_position API

### DIFF
--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -143,6 +143,11 @@ set_window_title :: proc(title: string)
 // This does nothing for web builds.
 set_window_position :: proc(x: int, y: int)
 
+// Gets the window position in the same coordinate system used by `set_window_position`.
+//
+// This returns {} for web and Wayland builds.
+get_window_position :: proc() -> Vec2
+
 // Fetch the scale of the window. This usually comes from some DPI scaling setting in the OS.
 // 1 means 100% scale, 1.5 means 150% etc.
 //

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -447,6 +447,13 @@ set_window_position :: proc(x: int, y: int) {
 	pf.set_window_position(x, y)
 }
 
+// Gets the window position in the same coordinate system used by `set_window_position`.
+//
+// This returns {} for web and Wayland builds.
+get_window_position :: proc() -> Vec2 {
+	return pf.get_window_position()
+}
+
 // Fetch the scale of the window. This usually comes from some DPI scaling setting in the OS.
 // 1 means 100% scale, 1.5 means 150% etc.
 //

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -451,6 +451,7 @@ set_window_position :: proc(x: int, y: int) {
 //
 // This returns {} for web and Wayland builds.
 get_window_position :: proc() -> Vec2 {
+	assert_initialized()
 	return pf.get_window_position()
 }
 

--- a/platform_interface.odin
+++ b/platform_interface.odin
@@ -19,6 +19,7 @@ Platform_Interface :: struct #all_or_none {
 	get_events: proc(events: ^[dynamic]Event),
 	set_window_title: proc(title: string),
 	set_window_position: proc(x: int, y: int),
+	get_window_position: proc() -> Vec2,
 	set_screen_size: proc(w, h: int),
 	get_screen_width: proc() -> int,
 	get_screen_height: proc() -> int,

--- a/platform_linux.odin
+++ b/platform_linux.odin
@@ -27,6 +27,7 @@ PLATFORM_LINUX :: Platform_Interface {
 	get_screen_width = linux_get_screen_width,
 	get_screen_height = linux_get_screen_height,
 	set_window_position = linux_set_window_position,
+	get_window_position = linux_get_window_position,
 	get_window_scale = linux_get_window_scale,
 	set_window_mode = linux_set_window_mode,
 	set_cursor_hidden = linux_set_cursor_hidden,
@@ -172,6 +173,10 @@ linux_set_window_title :: proc(title: string) {
 
 linux_set_window_position :: proc(x: int, y: int) {
 	s.win.set_position(x, y)
+}
+
+linux_get_window_position :: proc() -> Vec2 {
+	return s.win.get_position()
 }
 
 set_screen_size :: proc(w, h: int) {
@@ -650,6 +655,7 @@ Linux_Window_Interface :: struct #all_or_none {
 	get_events: proc(events: ^[dynamic]Event),
 	set_title: proc(title: string),
 	set_position: proc(x: int, y: int),
+	get_position: proc() -> Vec2,
 	set_screen_size: proc(w, h: int),
 	get_screen_width: proc() -> int,
 	get_screen_height: proc() -> int,

--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -12,6 +12,7 @@ LINUX_WINDOW_WAYLAND :: Linux_Window_Interface {
 	get_screen_width = wl_get_screen_width,
 	get_screen_height = wl_get_screen_height,
 	set_position = wl_set_position,
+	get_position = wl_get_position,
 	set_screen_size = wl_set_screen_size,
 	get_window_scale = wl_get_window_scale,
 	set_window_mode = wl_set_window_mode,
@@ -543,6 +544,11 @@ wl_get_screen_height :: proc() -> int {
 
 wl_set_position :: proc(x: int, y: int) {
 	log.error("set_position not implemented when using wayland")
+}
+
+wl_get_position :: proc() -> Vec2 {
+	log.error("get_position not implemented when using wayland")
+	return {}
 }
 
 wl_set_screen_size :: proc(w, h: int) {

--- a/platform_linux_window_x11.odin
+++ b/platform_linux_window_x11.odin
@@ -14,6 +14,7 @@ LINUX_WINDOW_X11 :: Linux_Window_Interface {
 	get_screen_width = x11_get_screen_width,
 	get_screen_height = x11_get_screen_height,
 	set_position = x11_set_position,
+	get_position = x11_get_position,
 	set_screen_size = x11_set_screen_size,
 	get_window_scale = x11_get_window_scale,
 	set_window_mode = x11_set_window_mode,
@@ -251,6 +252,22 @@ x11_get_screen_height :: proc() -> int {
 
 x11_set_position :: proc(x: int, y: int) {
 	X.MoveWindow(s.display, s.window, i32(x), i32(y))
+}
+
+x11_get_position :: proc() -> Vec2 {
+	x, y: i32
+	child: X.Window
+	X.TranslateCoordinates(
+		s.display,
+		s.window,
+		X.DefaultRootWindow(s.display),
+		0,
+		0,
+		&x,
+		&y,
+		&child,
+	)
+	return {f32(x), f32(y)}
 }
 
 x11_set_screen_size :: proc(w, h: int) {

--- a/platform_mac.odin
+++ b/platform_mac.odin
@@ -25,6 +25,7 @@ PLATFORM_MAC :: Platform_Interface {
 	get_screen_width = mac_get_screen_width,
 	get_screen_height = mac_get_screen_height,
 	set_window_position = mac_set_window_position,
+	get_window_position = mac_get_window_position,
 	get_window_scale = mac_get_window_scale,
 	set_window_mode = mac_set_window_mode,
 	set_cursor_hidden = mac_set_cursor_hidden,
@@ -429,6 +430,12 @@ mac_set_window_position :: proc(x: int, y: int) {
 	// macOS uses bottom-left origin for screen coordinates
 	origin := NS.Point{NS.Float(x), NS.Float(y)}
 	s.window->setFrameOrigin(origin)
+}
+
+mac_get_window_position :: proc() -> Vec2 {
+	// macOS uses bottom-left origin for screen coordinates
+	origin := s.window->frame().origin
+	return {f32(origin.x), f32(origin.y)}
 }
 
 mac_set_screen_size :: proc(w, h: int) {

--- a/platform_web.odin
+++ b/platform_web.odin
@@ -17,6 +17,7 @@ PLATFORM_WEB :: Platform_Interface {
 	get_screen_width = web_get_screen_width,
 	get_screen_height = web_get_screen_height,
 	set_window_position = web_set_position,
+	get_window_position = web_get_position,
 	get_window_scale = web_get_window_scale,
 	set_window_mode = web_set_window_mode,
 	set_cursor_hidden = web_set_cursor_hidden,
@@ -334,6 +335,11 @@ web_set_window_title :: proc(title: string) {
 
 web_set_position :: proc(x: int, y: int) {
 	log.warn("set_window_position not implemented on web")
+}
+
+web_get_position :: proc() -> Vec2 {
+	log.warn("get_window_position not implemented on web")
+	return {}
 }
 
 web_set_screen_size :: proc(w, h: int) {

--- a/platform_windows.odin
+++ b/platform_windows.odin
@@ -15,6 +15,7 @@ PLATFORM_WINDOWS :: Platform_Interface {
 	get_screen_width = windows_get_screen_width,
 	get_screen_height = windows_get_screen_height,
 	set_window_position = windows_set_window_position,
+	get_window_position = windows_get_window_position,
 	set_screen_size = windows_set_screen_size,
 	get_window_scale = windows_get_window_scale,
 	set_window_mode = windows_set_window_mode,
@@ -279,6 +280,17 @@ windows_set_window_position :: proc(x: int, y: int) {
 		0,
 		win32.SWP_NOACTIVATE | win32.SWP_NOZORDER | win32.SWP_NOSIZE,
 	)
+}
+
+windows_get_window_position :: proc() -> Vec2 {
+	r: win32.RECT
+	win32.DwmGetWindowAttribute(
+		s.hwnd,
+		u32(win32.DWMWINDOWATTRIBUTE.DWMWA_EXTENDED_FRAME_BOUNDS),
+		&r,
+		size_of(win32.RECT),
+	)
+	return {f32(r.left), f32(r.top)}
 }
 
 windows_get_style :: proc(window_mode: Window_Mode) -> win32.DWORD {


### PR DESCRIPTION
## Summary

Adds `get_window_position()`.

Fixes #124

## Changes

- Added public `get_window_position() -> Vec2`.
- Added platform interface plumbing.
- Implemented supported platform behavior:
  - Windows returns the visible window position, matching the coordinate space used by `set_window_position`.
  - macOS returns the window frame origin, matching the bottom-left coordinate space used by `set_window_position`.
  - X11 returns the window position translated to root-window coordinates.
- Added unsupported stubs for Wayland and web that log and return `{}`.
- Regenerated `karl2d.doc.odin`.

## Notes

The intended API contract is that `get_window_position()` returns coordinates in the same coordinate system accepted by `set_window_position()` on platforms where window positioning is supported.

Wayland and web do not expose meaningful global window positioning in the same way, so they currently return `{}`.

## Manual Test

On Windows, this smoke test:

```odin
before := k2.get_window_position()
k2.set_window_position(200, 200)
after := k2.get_window_position()

fmt.printf("before: %v\n", before)
fmt.printf("after:  %v\n", after)
```

printed:

```text
before: [40, 32]
after:  [200, 200]
```
