### PR TITLE
Keep camera projection for render textures

### DIFF
--- a/karl2d.odin
+++ b/karl2d.odin
@@ -3996,7 +3996,10 @@ set_camera :: proc(camera: Maybe(Camera)) {
 
 	draw_current_batch()
 	s.batch_camera = camera
-	s.proj_matrix = make_default_projection(pf.get_screen_width(), pf.get_screen_height())
+
+	if s.batch_render_target == RENDER_TARGET_NONE {
+		s.proj_matrix = make_default_projection(pf.get_screen_width(), pf.get_screen_height())
+	}
 
 	if c, c_ok := camera.?; c_ok {
 		s.view_matrix = camera_view_matrix(c)


### PR DESCRIPTION
Fixes #139.

## Summary

`set_camera` always rebuilt `s.proj_matrix` from the window size. When called after `set_render_texture`, this overwrote the render texture projection, so camera transforms inside render textures were scaled as if they were rendering to the window.

This changes `set_camera` to only reset the projection to the window size when no render texture is active. Render texture projection remains owned by `set_render_texture`.

## Visual confirmation

Before fix:

<img width="895" height="558" alt="before_origin_master" src="https://github.com/user-attachments/assets/56583179-8f59-45a6-830d-71b8422b12a2" />

After fix:

<img width="895" height="558" alt="after_fix" src="https://github.com/user-attachments/assets/fcc338a7-a6f4-4a73-8332-e0146cc29864" />

The repro renders the same scene two ways:

- Left: `set_render_texture` then `set_camera`
- Right: `set_camera` then `set_render_texture`

Before the fix, the two panels differ. After the fix, both panels match.