### PR TITLE
Fix crash on Wayland tiling compositors when resize happens before window is created

### DIFF
--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -52,6 +52,7 @@ wl_init :: proc(
 	s.allocator = allocator
 	s.scale = 1
 	s.odin_ctx = context
+	s.window_mode = options.window_mode
 
 	s.display = wl.display_connect(nil)
 
@@ -102,6 +103,10 @@ wl_init :: proc(
 
 	unscaled_width := screen_width
 	unscaled_height := screen_height
+	if s.last_configure_width > 0 && s.last_configure_height > 0 {
+		unscaled_width = s.last_configure_width
+		unscaled_height = s.last_configure_height
+	}
 
 	scaled_width := int(f32(unscaled_width) * s.scale)
 	scaled_height := int(f32(unscaled_height) * s.scale)
@@ -290,8 +295,12 @@ toplevel_listener := wl.XDG_Toplevel_Listener {
 			s.last_configure_width = w
 			s.last_configure_height = h
 
-			wl.egl_window_resize(s.window, i32(s.screen_width), i32(s.screen_height), 0, 0)
-			wl.wp_viewport_set_destination(s.viewport, i32(w), i32(h))
+			if s.window != nil {
+				wl.egl_window_resize(s.window, i32(s.screen_width), i32(s.screen_height), 0, 0)
+			}
+			if s.viewport != nil {
+				wl.wp_viewport_set_destination(s.viewport, i32(w), i32(h))
+			}
 
 			append(&s.events, Event_Screen_Resize {
 				width = s.screen_width,
@@ -505,7 +514,9 @@ fractional_scale_listener := wl.WP_Fractional_Scale_V1_Listener {
 		s.scale = scl
 		s.screen_width = int(f32(s.last_configure_width) * s.scale)
 		s.screen_height = int(f32(s.last_configure_height) * s.scale)
-		wl.egl_window_resize(s.window, i32(s.screen_width), i32(s.screen_height), 0, 0)
+		if s.window != nil {
+			wl.egl_window_resize(s.window, i32(s.screen_width), i32(s.screen_height), 0, 0)
+		}
 
 		append(&s.events, Event_Window_Scale_Changed {
 			scale = scl,
@@ -746,4 +757,3 @@ WL_State :: struct {
 }
 
 s: ^WL_State
-


### PR DESCRIPTION
On certain Wayland compositors that use tiling, such as Hyprland, a resize event may occur before the window creation has completed as it forces the window into the tile size. This was causing a SIGSEGV crash in Karl2D on `wl.egl_window_resize`.

---

## Rules Checklist

You can always submit a draft pull request. But when you make your Pull Request "ready for review", then please make sure these rules are followed (put an x between each [ ]):
- [x] Make sure that the code you submit is working and tested.
- [x] Do not submit "basic" or "rudimentary" code that needs further work to actually be finished. Finish the code to the best of your abilities.
- [x] Do not modify any code that is unrelated to your changes. That just makes reviewing your code harder: I'll have a hard time seeing what you actually did. Do not use auto formatters such as odinfmt.
- [x] If you used an LLM to generate any code, then make that you understand every single line. In other words: No form of "vibe coded" PRs are allowed.
- [x] If you commit changes that were unintended, just do additional commits that undo them. Don't worry about polluting the commit history: I will do a "squash merge" of your Pull Request. Just make sure that the diff in the "Files changed" tab looks tidy.
- [x] If the GitHub testing action complain about the `karl2d.doc.odin` file being out-of-date, then please regenerate it by running `odin run tools/api_doc_builder`. This way you'll have an easier time seeing if you've made changes to the user-facing API.
- [x] Make sure that the code follows the same style as in `karl2d.odin`:
	- Please look through that file and pay attention to how characters such as `:` `=`, `(` `{` etc are placed.
	- Use tabs, not spaces.
	- Lines cannot be longer than 100 characters. See the `init` proc in `karl2d.odin` for an example of how to split up procedure signatures that are too long. That proc also shows how to write API comments. Use a ruler in your editor to make it easy to spot long lines.
