### PR TITLE
Added logic to capture keyboard inputs when game is inside of an iframe

### DIFF
--- a/build_web/web_entry_templates/index_template.html
+++ b/build_web/web_entry_templates/index_template.html
@@ -11,6 +11,10 @@
 		<script type="text/javascript" src="audio_backend_web_audio.js"></script>
 		<script type="text/javascript" src="odin.js"></script>
 		<script type="text/javascript">
+			if (window.parent !== window) {
+				// This prevents keyboard commands from triggering outside of the iframe.
+				document.getElementById('body').addEventListener('keydown', (ev) => ev.preventDefault());
+			}
 			async function run() {
 				const wasmMemoryInterface = new odin.WasmMemoryInterface();
 				wasmMemoryInterface.setIntSize(4);


### PR DESCRIPTION
I noticed that when making a web build of a karl2d game and embedding it somewhere like itch.io, the arrow keys and other keys can cause unwanted scrolling. While the canvas element has an event handler for preventing this, in the context of an iframe, the events still end up leaking out. I added some code to the index.html template that prevents this case by preventing keyboard events on the body element when the script detects that it's in an iframe.

Testing:
I made an html file that embeds the web build's html in an iframe, then added a bunch of text below it so the scrollbar appears. After clicking on the game, all keyboard inputs go to the game and not to the browser, and after clicking off of it, control of the hotkeys is restored to the browser.
I also tested visiting the index.html as a standalone page and ensured that keyboard inputs there worked as before.

---

## Rules Checklist

You can always submit a draft pull request. But when you make your Pull Request "ready for review", then please make sure these rules are followed (put an x between each [ ]):
- [x] Make sure that the code you submit is working and tested.
- [x] Do not submit "basic" or "rudimentary" code that needs further work to actually be finished. Finish the code to the best of your abilities.
- [x] Do not modify any code that is unrelated to your changes. That just makes reviewing your code harder: I'll have a hard time seeing what you actually did. Do not use auto formatters such as odinfmt.
- [x] If you used an LLM to generate any code, then make that you understand every single line. In other words: No form of "vibe coded" PRs are allowed.
- [x] If you commit changes that were unintended, just do additional commits that undo them. Don't worry about polluting the commit history: I will do a "squash merge" of your Pull Request. Just make sure that the diff in the "Files changed" tab looks tidy.
- [x] If the GitHub testing action complain about the `karl2d.doc.odin` file being out-of-date, then please regenerate it by running `odin run tools/api_doc_builder`. This way you'll have an easier time seeing if you've made changes to the user-facing API.
- [x] Make sure that the code follows the same style as in `karl2d.odin`:
	- Please look through that file and pay attention to how characters such as `:` `=`, `(` `{` etc are placed.
	- Use tabs, not spaces.
	- Lines cannot be longer than 100 characters. See the `init` proc in `karl2d.odin` for an example of how to split up procedure signatures that are too long. That proc also shows how to write API comments. Use a ruler in your editor to make it easy to spot long lines.
