### PR TITLE
Fix set_screen_size on HiDPI monitor

### DIFF
--- a/karl2d.odin
+++ b/karl2d.odin
@@ -432,7 +432,10 @@ get_time :: proc() -> f64 {
 set_screen_size :: proc(width: int, height: int) {
 	assert_initialized()
 	pf.set_screen_size(width, height)
-	rb.resize_swapchain(width, height)
+	pixel_width  := pf.get_screen_width()
+	pixel_height := pf.get_screen_height()
+	rb.resize_swapchain(pixel_width, pixel_height)
+	s.proj_matrix = make_default_projection(pixel_width, pixel_height)
 }
 
 // Gets the width of the drawing area within the window.

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -432,10 +432,7 @@ get_time :: proc() -> f64 {
 set_screen_size :: proc(width: int, height: int) {
 	assert_initialized()
 	pf.set_screen_size(width, height)
-	pixel_width  := pf.get_screen_width()
-	pixel_height := pf.get_screen_height()
-	rb.resize_swapchain(pixel_width, pixel_height)
-	s.proj_matrix = make_default_projection(pixel_width, pixel_height)
+	rb.resize_swapchain(pf.get_screen_width(), pf.get_screen_height())
 }
 
 // Gets the width of the drawing area within the window.


### PR DESCRIPTION
Fixing set_screen_size proc on HiDPI monitors like the MacBook have.

LLM explanation of the issue:
Originally it did rb.resize_swapchain(width, height) with the requested logical size (e.g. 1280×720). On Retina the GL surface/swapchain is actually 2× that in backing pixels, so drawing the logical-sized scene into a physical-sized framebuffer filled only the bottom-left corner.

The LLM also advised a `s.proj_matrix = make_default_projection(pixel_width, pixel_height)` but this messed up the non-HiDPI.

Master:
<img width="1092" height="218" alt="image" src="https://github.com/user-attachments/assets/95732953-e0d3-4518-9673-55973d073844" />

Fix:
<img width="1119" height="236" alt="image" src="https://github.com/user-attachments/assets/c8b244d1-b764-4782-a934-1cad634751e3" />


---

## Rules Checklist

You can always submit a draft pull request. But when you make your Pull Request "ready for review", then please make sure these rules are followed (put an x between each [ ]):
- [x] Make sure that the code you submit is working and tested.
- [x] Do not submit "basic" or "rudimentary" code that needs further work to actually be finished. Finish the code to the best of your abilities.
- [x] Do not modify any code that is unrelated to your changes. That just makes reviewing your code harder: I'll have a hard time seeing what you actually did. Do not use auto formatters such as odinfmt.
- [x] If you used an LLM to generate any code, then make that you understand every single line. In other words: No form of "vibe coded" PRs are allowed.
- [x] If you commit changes that were unintended, just do additional commits that undo them. Don't worry about polluting the commit history: I will do a "squash merge" of your Pull Request. Just make sure that the diff in the "Files changed" tab looks tidy.
- [ ] If the GitHub testing action complain about the `karl2d.doc.odin` file being out-of-date, then please regenerate it by running `odin run tools/api_doc_builder`. This way you'll have an easier time seeing if you've made changes to the user-facing API.
- [x] Make sure that the code follows the same style as in `karl2d.odin`:
	- Please look through that file and pay attention to how characters such as `:` `=`, `(` `{` etc are placed.
	- Use tabs, not spaces.
	- Lines cannot be longer than 100 characters. See the `init` proc in `karl2d.odin` for an example of how to split up procedure signatures that are too long. That proc also shows how to write API comments. Use a ruler in your editor to make it easy to spot long lines.
