### PR TITLE
Fix crash in alsa_shutdown when the feed thread was never created

### DIFF
--- a/audio_backend_alsa.odin
+++ b/audio_backend_alsa.odin
@@ -82,10 +82,11 @@ alsa_init :: proc(state: rawptr, allocator: runtime.Allocator) {
 		return
 	}
 
+	// Set the PCM before starting the thread: the thread uses it right away.
+	s.pcm = pcm
 	s.run_thread = true
 	s.feed_thread = thread.create(alsa_thread_proc)
 	thread.start(s.feed_thread)
-	s.pcm = pcm
 }
 
 alsa_thread_proc :: proc(t: ^thread.Thread) {
@@ -133,8 +134,14 @@ alsa_shutdown :: proc() {
 	log.debug("Shutdown audio backend alsa")
 
 	sync.atomic_store(&s.run_thread, false)
-	thread.join(s.feed_thread)
-	thread.destroy(s.feed_thread)
+
+	// The thread is only created if the whole of `alsa_init` succeeded. It may be nil if for
+	// example no ALSA device was available.
+	if s.feed_thread != nil {
+		thread.join(s.feed_thread)
+		thread.destroy(s.feed_thread)
+		s.feed_thread = nil
+	}
 
 	if s.pcm != nil {
 		alsa.pcm_close(s.pcm)


### PR DESCRIPTION
Fixes #195

## Problem

`alsa_init` has three early-return failure paths (`pcm_open`, `pcm_set_params`, `pcm_prepare`). All of them return before `s.feed_thread` is created, so it stays `nil`. `alsa_shutdown` then unconditionally called `thread.join(s.feed_thread)`, which segfaults:

```
thread_unix.odin: _join :: proc(t: ^Thread)
signal SIGSEGV: address not mapped to object (fault address=0x0)
```

The reporter hit this running inside a container with no ALSA `default` device, so `pcm_open` fails.

## Fix

Guard the join/destroy with a nil check. This matches how the rest of the backend already handles a failed init — `alsa_feed` and `alsa_remaining_samples` both bail out on `s.pcm == nil`, so the engine keeps running silently without audio, which is the intended behavior. Shutdown was just the one path that didn't check.

Also moved `s.pcm = pcm` to before `thread.start`, since the feed thread reads `s.pcm` immediately. In practice the thread sleeps 5 ms first and the buffer starts empty, so it wasn't biting, but the ordering was wrong.

## Testing

I can't reproduce the failing device locally (Windows), so this needs a test on Linux. `odin check . -target:linux_amd64 -vet` passes for this file.

The other half of the issue report — no title bar / close buttons — is a separate problem and isn't touched here; some of that may already be covered by the Wayland fixes in ae88cae.

🤖 Generated with [Claude Code](https://claude.com/claude-code)