### PR TITLE
Linux+X11: Implement HiDPI scaling

### DIFF
--- a/platform_linux_window_x11.odin
+++ b/platform_linux_window_x11.odin
@@ -109,12 +109,6 @@ x11_init :: proc(
 	s.delete_msg = X.InternAtom(s.display, "WM_DELETE_WINDOW", false)
 	X.SetWMProtocols(s.display, s.window, &s.delete_msg, 1)
 
-	// The X resource database lives in a property on the root window, so a DPI change shows up as
-	// a PropertyNotify on it. This is also how GTK and Qt notice. It means we see every other root
-	// property the window manager touches too, which is why x11_get_events checks the atom.
-	s.resource_manager = X.InternAtom(s.display, "RESOURCE_MANAGER", false)
-	X.SelectInput(s.display, X.DefaultRootWindow(s.display), {.PropertyChange})
-
 	// Detectable auto-repeat means a held-down key produces repeated KeyPress events without an
 	// interleaved KeyRelease between them, so we can tell an initial press from a repeat by
 	// tracking which keys are currently held (see `x11_get_events`). If unsupported, we fall back
@@ -138,6 +132,19 @@ x11_init :: proc(
 			cstring(nil),
 		)
 	}
+
+	// The X resource database lives in a property on the root window, so a DPI change shows up as
+	// a PropertyNotify on it. This is also how GTK and Qt notice. It means we see every other root
+	// property the window manager touches too, which is why x11_get_events checks the atom.
+	//
+	// SelectInput replaces our mask for a window rather than adding to it, and the input method
+	// above shares this display connection and may select on the root window too. So we run after
+	// it and keep whatever it asked for.
+	root := X.DefaultRootWindow(s.display)
+	root_attribs: X.XWindowAttributes
+	X.GetWindowAttributes(s.display, root, &root_attribs)
+	s.resource_manager = X.InternAtom(s.display, "RESOURCE_MANAGER", false)
+	X.SelectInput(s.display, root, root_attribs.your_event_mask | {.PropertyChange})
 
 	x11_set_window_mode(init_options.window_mode)
 

--- a/platform_linux_window_x11.odin
+++ b/platform_linux_window_x11.odin
@@ -33,18 +33,24 @@ import "base:runtime"
 import "log"
 import "core:fmt"
 import "core:slice"
+import "core:strconv"
 import hm "core:container/handle_map"
 
 _ :: log
 _ :: fmt
 
-// XDestroyIC and XCloseIM aren't bound by vendor:x11/xlib, so we bind them here ourselves.
+// XDestroyIC, XCloseIM and XrmDestroyDatabase aren't bound by vendor:x11/xlib, so we bind them
+// here ourselves.
 foreign import x11_extra "system:X11"
 
 foreign x11_extra {
 	XDestroyIC :: proc(ic: X.XIC) ---
 	XCloseIM :: proc(im: X.XIM) -> X.Status ---
+	XrmDestroyDatabase :: proc(db: X.XrmDatabase) ---
 }
+
+// The DPI that X11 and every toolkit on it treat as 100% scale.
+DEFAULT_DPI :: 96
 
 x11_state_size :: proc() -> int {
 	return size_of(X11_State)
@@ -60,17 +66,27 @@ x11_init :: proc(
 ) {
 	s = (^X11_State)(window_state)
 	s.allocator = allocator
-	s.screen_width = screen_width
-	s.screen_height = screen_height
-	s.display = X.OpenDisplay(nil)
 	s.events = make([dynamic]Event, allocator)
 	hm.dynamic_init(&s.custom_cursors, allocator)
+
+	// Xlib wants this before anything touches the resource database.
+	X.XrmInitialize()
+	s.display = X.OpenDisplay(nil)
+	s.window_scale = x11_fetch_window_scale()
+
+	if init_options.disable_auto_scale_hint {
+		s.screen_width = screen_width
+		s.screen_height = screen_height
+	} else {
+		s.screen_width = int(f32(screen_width) * s.window_scale)
+		s.screen_height = int(f32(screen_height) * s.window_scale)
+	}
 
 	s.window = X.CreateSimpleWindow(
 		s.display,
 		X.DefaultRootWindow(s.display),
 		0, 0,
-		u32(screen_width), u32(screen_height),
+		u32(s.screen_width), u32(s.screen_height),
 		0,
 		0,
 		0,
@@ -92,6 +108,12 @@ x11_init :: proc(
 
 	s.delete_msg = X.InternAtom(s.display, "WM_DELETE_WINDOW", false)
 	X.SetWMProtocols(s.display, s.window, &s.delete_msg, 1)
+
+	// The X resource database lives in a property on the root window, so a DPI change shows up as
+	// a PropertyNotify on it. This is also how GTK and Qt notice. It means we see every other root
+	// property the window manager touches too, which is why x11_get_events checks the atom.
+	s.resource_manager = X.InternAtom(s.display, "RESOURCE_MANAGER", false)
+	X.SelectInput(s.display, X.DefaultRootWindow(s.display), {.PropertyChange})
 
 	// Detectable auto-repeat means a held-down key produces repeated KeyPress events without an
 	// interleaved KeyRelease between them, so we can tell an initial press from a repeat by
@@ -322,6 +344,26 @@ x11_get_events :: proc(events: ^[dynamic]Event) {
 					height = h,
 				})
 			}
+
+		case .PropertyNotify:
+			is_resource_manager := event.xproperty.state == .PropertyNewValue &&
+				event.xproperty.window == X.DefaultRootWindow(s.display) &&
+				event.xproperty.atom == s.resource_manager
+
+			if is_resource_manager {
+				new_scale := x11_fetch_window_scale()
+
+				if new_scale != s.window_scale {
+					s.window_scale = new_scale
+
+					append(events, Event_Window_Scale_Changed {
+						scale = new_scale,
+						screen_width = s.screen_width,
+						screen_height = s.screen_height,
+					})
+				}
+			}
+
 		case .FocusIn:
 			if s.xic != nil {
 				X.SetICFocus(s.xic)
@@ -430,7 +472,42 @@ x11_set_screen_size :: proc(w, h: int) {
 }
 
 x11_get_window_scale :: proc() -> f32 {
-	return 1
+	return s.window_scale
+}
+
+// Reads the DPI scale from the X resource database. `Xft.dpi` is what GTK and Qt use, so this
+// matches the rest of the desktop. There is no per-monitor DPI in X11: one number covers
+// everything. Desktops that would set it to 96 tend to remove the entry instead, so a missing
+// entry means 100%.
+x11_fetch_window_scale :: proc() -> f32 {
+	rms := X.ResourceManagerString(s.display)
+
+	if rms == nil {
+		return 1
+	}
+
+	db := X.XrmGetStringDatabase(rms)
+
+	if db == nil {
+		return 1
+	}
+
+	scale: f32 = 1
+	res_type: cstring
+	res_value: X.XrmValue
+
+	found := bool(X.XrmGetResource(db, "Xft.dpi", "Xft.Dpi", &res_type, &res_value))
+
+	if found && res_type == "String" && res_value.addr != nil {
+		dpi, dpi_ok := strconv.parse_f32(string(cstring(res_value.addr)))
+
+		if dpi_ok && dpi > 0 {
+			scale = dpi/DEFAULT_DPI
+		}
+	}
+
+	XrmDestroyDatabase(db)
+	return scale
 }
 
 enter_borderless_fullscreen :: proc() {
@@ -725,6 +802,12 @@ X11_State :: struct {
 	last_configure_windowed_width: int,
 	last_configure_windowed_height: int,
 	
+	// The scale from the OS. 1 means 100%. See x11_fetch_window_scale.
+	window_scale: f32,
+
+	// The root window property holding the X resource database. We watch it to notice DPI changes.
+	resource_manager: X.Atom,
+
 	display: ^X.Display,
 	window: X.Window,
 	delete_msg: X.Atom,

--- a/platform_linux_window_x11.odin
+++ b/platform_linux_window_x11.odin
@@ -72,6 +72,10 @@ x11_init :: proc(
 	// Xlib wants this before anything touches the resource database.
 	X.XrmInitialize()
 	s.display = X.OpenDisplay(nil)
+
+	// The resource database, holding the DPI setting among other things, lives in this property on
+	// the root window. See x11_fetch_window_scale.
+	s.resource_manager = X.InternAtom(s.display, "RESOURCE_MANAGER", false)
 	s.window_scale = x11_fetch_window_scale()
 
 	if init_options.disable_auto_scale_hint {
@@ -133,9 +137,9 @@ x11_init :: proc(
 		)
 	}
 
-	// The X resource database lives in a property on the root window, so a DPI change shows up as
-	// a PropertyNotify on it. This is also how GTK and Qt notice. It means we see every other root
-	// property the window manager touches too, which is why x11_get_events checks the atom.
+	// A DPI change shows up as a PropertyNotify for the resource database on the root window. This
+	// is also how GTK and Qt notice. It means we see every other root property the window manager
+	// touches too, which is why x11_get_events checks the atom.
 	//
 	// SelectInput replaces our mask for a window rather than adding to it, and the input method
 	// above shares this display connection and may select on the root window too. So we run after
@@ -143,7 +147,6 @@ x11_init :: proc(
 	root := X.DefaultRootWindow(s.display)
 	root_attribs: X.XWindowAttributes
 	X.GetWindowAttributes(s.display, root, &root_attribs)
-	s.resource_manager = X.InternAtom(s.display, "RESOURCE_MANAGER", false)
 	X.SelectInput(s.display, root, root_attribs.your_event_mask | {.PropertyChange})
 
 	x11_set_window_mode(init_options.window_mode)
@@ -486,14 +489,44 @@ x11_get_window_scale :: proc() -> f32 {
 // matches the rest of the desktop. There is no per-monitor DPI in X11: one number covers
 // everything. Desktops that would set it to 96 tend to remove the entry instead, so a missing
 // entry means 100%.
+//
+// We fetch the root window property ourselves instead of calling XResourceManagerString. That one
+// returns the copy Xlib took when the display connection was opened, so it never reflects a change
+// made while the game is running.
 x11_fetch_window_scale :: proc() -> f32 {
-	rms := X.ResourceManagerString(s.display)
+	// A length in 32-bit units. The server sends only what is actually there, so this just has to
+	// be bigger than any real resource database.
+	MAX_RESOURCE_WORDS :: 1024 * 1024
 
-	if rms == nil {
+	actual_type: X.Atom
+	actual_format: i32
+	num_items: uint
+	bytes_after: uint
+	prop: rawptr
+
+	get_status := X.GetWindowProperty(
+		s.display,
+		X.DefaultRootWindow(s.display),
+		s.resource_manager,
+		0,
+		MAX_RESOURCE_WORDS,
+		false,
+		X.AnyPropertyType,
+		&actual_type,
+		&actual_format,
+		&num_items,
+		&bytes_after,
+		&prop,
+	)
+
+	if get_status != i32(X.Status.Success) || prop == nil {
 		return 1
 	}
 
-	db := X.XrmGetStringDatabase(rms)
+	// Xlib puts a zero byte after the data it hands back, so this is a valid cstring even though
+	// the property itself is not terminated.
+	db := X.XrmGetStringDatabase(cstring(prop))
+	X.Free(prop)
 
 	if db == nil {
 		return 1


### PR DESCRIPTION
## Summary
- `x11_get_window_scale` previously hardcoded `return 1`. This reads the real DPI scale from the X resource database (`Xft.dpi`, same source GTK/Qt use — `scale = dpi/96`, missing entry means 1) and applies it to the initial window size, mirroring how `platform_windows.odin` handles `s.window_scale`.
- Watches the root window's `RESOURCE_MANAGER` property for `PropertyNotify` and emits `Event_Window_Scale_Changed` when the DPI changes at runtime, without resizing the window itself (matching Windows' `WM_DPICHANGED` handling — X11 coordinates are already physical pixels, so no Wayland-style buffer/surface conversion is needed).
- Touches `platform_linux_window_x11.odin` plus `platform_bindings/linux/x11/x11.odin`, which gains the resource-database and window-property procs this needs (`XrmInitialize`, `XrmGetStringDatabase`, `XrmGetResource`, `XrmDestroyDatabase`, `XGetWindowProperty`, `XGetWindowAttributes`, `XFree`) and the `XPropertyEvent`/`XrmValue`/`XWindowAttributes` types. No public API change, so `karl2d.doc.odin` is untouched.

Closes #132

## Out of scope (see code comments for rationale)
- Reloading theme cursors on a runtime DPI change (libXcursor already sizes them correctly at startup from `Xft.dpi`; forcing a reload after the fact needs an extra binding and runtime X11 DPI changes are rare).
- Per-monitor DPI (X11 has one desktop-wide scale, no such thing) and `GDK_SCALE`/`QT_SCALE_FACTOR` env fallbacks (GLFW doesn't read them either).

## Test plan
Verified on Fedora / KDE Plasma, X11 via XWayland (`KARL2D_LINUX_WINDOWING=x11`), on a two-monitor setup with `Xft.dpi: 168` (175%):
- [x] `odin run tools/test_examples` builds clean on Linux
- [x] `odin run examples/basics` — window and contents come up scaled correctly on a HiDPI (e.g. 150%/200%) X11 session
- [x] `echo "Xft.dpi: 144" | xrdb -merge` while `examples/events` is running produces an `Event_Window_Scale_Changed` in the on-screen log; reverting it fires a second one
- [x] Behavior on a 100%-scale / no-`Xft.dpi` session is unchanged (scale = 1, no resize)

Also checked, beyond the original plan:
- `disable_auto_scale_hint` leaves the window at the requested size while still reporting the scale, matching `platform_windows.odin`.
- A `PropertyNotify` for an unrelated resource (`Xcursor.size`) produces no event, so the atom filter works.
- Moving between two monitors of different density never changes the reported scale and fires no spurious event — correct, since `Xft.dpi` is one desktop-wide value.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
