### PR TITLE
Draw our own window decorations on Wayland when the compositor won't (GNOME)

### DIFF
--- a/platform_bindings/linux/wayland/wayland_protocol.odin
+++ b/platform_bindings/linux/wayland/wayland_protocol.odin
@@ -124,6 +124,96 @@ compositor_interface := Interface {
 }
 
 
+Subcompositor :: struct {
+	using proxy: Proxy,
+}
+
+Subcompositor_Listener :: struct {}
+
+subcompositor_get_subsurface :: proc "c" (
+	subcompositor: ^Subcompositor,
+	surface: ^Surface,
+	parent: ^Surface,
+) -> ^Subsurface {
+	return (^Subsurface)(proxy_marshal_flags(
+		subcompositor,
+		1,
+		&subsurface_interface,
+		proxy_get_version(subcompositor),
+		0,
+		nil,
+		surface,
+		parent,
+	))
+}
+
+subcompositor_destroy :: proc "c" (subcompositor: ^Subcompositor) {
+	proxy_marshal_flags(subcompositor, 0, nil, proxy_get_version(subcompositor), MARSHAL_FLAG_DESTROY)
+}
+
+subcompositor_interface := Interface {
+	"wl_subcompositor",
+	1,
+	2,
+	raw_data([]Message {
+		{"destroy", "", raw_data([]^Interface{})},
+		{
+			"get_subsurface", "noo",
+			raw_data([]^Interface{&subsurface_interface, &surface_interface, &surface_interface}),
+		},
+	}),
+	0,
+	nil,
+}
+
+
+Subsurface :: struct {
+	using proxy: Proxy,
+}
+
+Subsurface_Listener :: struct {}
+
+subsurface_set_position :: proc "c" (subsurface: ^Subsurface, x: c.int32_t, y: c.int32_t) {
+	proxy_marshal_flags(subsurface, 1, nil, proxy_get_version(subsurface), 0, x, y)
+}
+
+subsurface_place_above :: proc "c" (subsurface: ^Subsurface, sibling: ^Surface) {
+	proxy_marshal_flags(subsurface, 2, nil, proxy_get_version(subsurface), 0, sibling)
+}
+
+subsurface_place_below :: proc "c" (subsurface: ^Subsurface, sibling: ^Surface) {
+	proxy_marshal_flags(subsurface, 3, nil, proxy_get_version(subsurface), 0, sibling)
+}
+
+subsurface_set_sync :: proc "c" (subsurface: ^Subsurface) {
+	proxy_marshal_flags(subsurface, 4, nil, proxy_get_version(subsurface), 0)
+}
+
+subsurface_set_desync :: proc "c" (subsurface: ^Subsurface) {
+	proxy_marshal_flags(subsurface, 5, nil, proxy_get_version(subsurface), 0)
+}
+
+subsurface_destroy :: proc "c" (subsurface: ^Subsurface) {
+	proxy_marshal_flags(subsurface, 0, nil, proxy_get_version(subsurface), MARSHAL_FLAG_DESTROY)
+}
+
+subsurface_interface := Interface {
+	"wl_subsurface",
+	1,
+	6,
+	raw_data([]Message {
+		{"destroy", "", raw_data([]^Interface{})},
+		{"set_position", "ii", raw_data([]^Interface{nil, nil})},
+		{"place_above", "o", raw_data([]^Interface{&surface_interface})},
+		{"place_below", "o", raw_data([]^Interface{&surface_interface})},
+		{"set_sync", "", raw_data([]^Interface{})},
+		{"set_desync", "", raw_data([]^Interface{})},
+	}),
+	0,
+	nil,
+}
+
+
 Buffer :: struct {
 	using proxy: Proxy,
 }

--- a/platform_bindings/linux/wayland/wayland_xdg_decorations.odin
+++ b/platform_bindings/linux/wayland/wayland_xdg_decorations.odin
@@ -9,8 +9,8 @@ ZXDG_Decoration_Manager_V1 :: struct {
 zxdg_decoration_manager_v1_get_toplevel_decoration :: proc "c" (
 	zxdg_decoration_manager_v1: ^ZXDG_Decoration_Manager_V1,
 	toplevel: ^XDG_Toplevel,
-) -> ^ZXDG_Decoration_Manager_V1 {
-	return (^ZXDG_Decoration_Manager_V1)(
+) -> ^ZXDG_Toplevel_Decoration_V1 {
+	return (^ZXDG_Toplevel_Decoration_V1)(
 		proxy_marshal_flags(
 		zxdg_decoration_manager_v1,
 		1,
@@ -42,8 +42,16 @@ ZXDG_Toplevel_Decoration_V1 :: struct {
 	using proxy: Proxy,
 }
 
+ZXDG_Toplevel_Decoration_V1_Listener :: struct {
+	configure: proc "c" (
+		data: rawptr,
+		zxdg_toplevel_decoration_v1: ^ZXDG_Toplevel_Decoration_V1,
+		mode: c.uint32_t,
+	),
+}
+
 zxdg_toplevel_decoration_v1_destroy :: proc "c" (
-	zxdg_toplevel_decoration_v1: ^ZXDG_Decoration_Manager_V1,
+	zxdg_toplevel_decoration_v1: ^ZXDG_Toplevel_Decoration_V1,
 ) {
 	proxy_marshal_flags(
 		zxdg_toplevel_decoration_v1,
@@ -55,7 +63,7 @@ zxdg_toplevel_decoration_v1_destroy :: proc "c" (
 }
 
 zxdg_toplevel_decoration_v1_set_mode :: proc "c" (
-	zxdg_toplevel_decoration_v1: ^ZXDG_Decoration_Manager_V1,
+	zxdg_toplevel_decoration_v1: ^ZXDG_Toplevel_Decoration_V1,
 	mode: c.uint32_t,
 ) {
 	proxy_marshal_flags(
@@ -69,7 +77,7 @@ zxdg_toplevel_decoration_v1_set_mode :: proc "c" (
 }
 
 zxdg_toplevel_decoration_v1_unset_mode :: proc "c" (
-	zxdg_toplevel_decoration_v1: ^ZXDG_Decoration_Manager_V1,
+	zxdg_toplevel_decoration_v1: ^ZXDG_Toplevel_Decoration_V1,
 ) {
 	proxy_marshal_flags(
 		zxdg_toplevel_decoration_v1,

--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -720,11 +720,13 @@ pointer_listener := wl.Pointer_Listener {
 		wl_frame_update_hover(role)
 		wl_apply_cursor()
 	},
+	// `t` rather than `time`, which would shadow the core:time package the double-click check
+	// below needs. Same reason key_handler names it that.
 	button = proc "c" (
 		data: rawptr,
 		pointer: ^wl.Pointer,
 		serial: c.uint32_t,
-		time: c.uint32_t,
+		t: c.uint32_t,
 		button: c.uint32_t,
 		state: c.uint32_t,
 	) {

--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -66,6 +66,13 @@ wl_init :: proc(
 	s.odin_ctx = context
 	hm.dynamic_init(&s.custom_cursors, allocator)
 
+	// wm_capabilities may never arrive on a compositor that doesn't send it, so default to
+	// everything being supported rather than nothing.
+	s.wm_can_window_menu = true
+	s.wm_can_maximize = true
+	s.wm_can_fullscreen = true
+	s.wm_can_minimize = true
+
 	s.xkb_context = xkb.context_new(.No_Flags)
 
 	s.display = wl.display_connect(nil)
@@ -92,23 +99,44 @@ wl_init :: proc(
 	
 	// Makes sure the window does "pings" that keeps it alive.
 	wl.add_listener(s.xdg_base, &wm_base_listener, nil)
-	xdg_surface := wl.xdg_wm_base_get_xdg_surface(s.xdg_base, s.surface)
+	s.xdg_surface = wl.xdg_wm_base_get_xdg_surface(s.xdg_base, s.surface)
 
 	// Top-level means an application at the top of the window hierarchy. The callback in the
 	// toplevel listener effecively creates a window handle.
-	s.toplevel = wl.xdg_surface_get_toplevel(xdg_surface)
+	s.toplevel = wl.xdg_surface_get_toplevel(s.xdg_surface)
 	wl.add_listener(s.toplevel, &toplevel_listener, nil)
-	wl.add_listener(xdg_surface, &window_listener, nil)
+	wl.add_listener(s.xdg_surface, &window_listener, nil)
 	wl.xdg_toplevel_set_title(s.toplevel, strings.clone_to_cstring(window_title, frame_allocator))
-
-	wl_set_window_mode(options.window_mode)
+	wl_frame_set_title(window_title)
 
 	if s.decoration_manager != nil {
-		decoration := wl.zxdg_decoration_manager_v1_get_toplevel_decoration(s.decoration_manager, s.toplevel)
+		s.decoration = wl.zxdg_decoration_manager_v1_get_toplevel_decoration(
+			s.decoration_manager,
+			s.toplevel,
+		)
+		wl.add_listener(s.decoration, &decoration_listener, nil)
 
-		// This adds titlebar and buttons to the window.
-		wl.zxdg_toplevel_decoration_v1_set_mode(decoration, wl.ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE)
+		// Asks for a titlebar and buttons. The compositor may refuse -- see decoration_listener,
+		// which records what it actually agreed to.
+		wl.zxdg_toplevel_decoration_v1_set_mode(
+			s.decoration,
+			wl.ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE,
+		)
+		// NOTE: decoration_listener may still flip decorations_are_client_side to true later,
+		// once the post-configure roundtrip below runs. wl_frame_create() below won't see that --
+		// it only fires for the common case of no manager at all (e.g. GNOME/Mutter). A compositor
+		// that advertises the manager and then refuses server-side decorations stays undecorated,
+		// same as before this feature existed.
+	} else {
+		// No manager means the compositor never intends to decorate us itself (e.g. GNOME/Mutter).
+		s.decorations_are_client_side = true
 	}
+
+	// Insets depend on whether we have a frame, so this has to run before the first
+	// wl_set_window_mode call below sizes the toplevel using them.
+	wl_frame_create()
+
+	wl_set_window_mode(options.window_mode)
 
 	if s.fractional_scale_manager != nil {
 		fractional_scale := wl.wp_fractional_scale_manager_get_fractional_scale(
@@ -152,6 +180,18 @@ wl_init :: proc(
 	}
 
 	log.ensure(s.window != nil, "Wayland compositor never sent an initial configure")
+
+	if s.decoration_manager != nil {
+		// The decoration's own configure event isn't guaranteed to land in the same dispatch batch
+		// as the toplevel's, so flush anything still queued before trusting the mode it settled on.
+		wl.display_roundtrip(s.display)
+	}
+
+	if s.decorations_are_client_side {
+		log.debug("Wayland compositor does not provide server-side decorations")
+	} else {
+		log.debug("Using server-side window decorations")
+	}
 
 	when RENDER_BACKEND_NAME == "gl" {
 		s.window_render_glue = make_linux_gl_wayland_glue(s.display, s.window, s.allocator)
@@ -265,6 +305,15 @@ registry_listener := wl.Registry_Listener {
 				&wl.wp_cursor_shape_manager_v1_interface,
 				version,
 			)
+
+		case wl.subcompositor_interface.name:
+			s.subcompositor = wl.registry_bind(
+				wl.Subcompositor,
+				registry,
+				name,
+				&wl.subcompositor_interface,
+				version,
+			)
 		}
 	},
 	global_remove = proc "c" (data: rawptr, registry: ^wl.Registry, name: u32) {},
@@ -315,6 +364,12 @@ seat_listener := wl.Seat_Listener {
 	name = proc "c" (data: rawptr, seat: ^wl.Seat, name: cstring) {},
 }
 
+// Views a wl.Array of packed u32 values. Used for xdg_toplevel's `states` and `wm_capabilities`
+// events, both of which are just an array with one enum value per u32.
+wl_array_as_u32s :: proc(arr: ^wl.Array) -> []u32 {
+	return ([^]u32)(arr.data)[:arr.size / size_of(u32)]
+}
+
 toplevel_listener := wl.XDG_Toplevel_Listener {
 	configure = proc "c" (
 		data: rawptr,
@@ -323,10 +378,25 @@ toplevel_listener := wl.XDG_Toplevel_Listener {
 		height: c.int32_t,
 		states: ^wl.Array,
 	) {
-		w := int(width)
-		h := int(height)
-
 		context = s.odin_ctx
+
+		s.maximized = false
+		s.fullscreen = false
+		s.activated = false
+
+		for state in wl_array_as_u32s(states) {
+			switch state {
+			case wl.XDG_TOPLEVEL_STATE_MAXIMIZED: s.maximized = true
+			case wl.XDG_TOPLEVEL_STATE_FULLSCREEN: s.fullscreen = true
+			case wl.XDG_TOPLEVEL_STATE_ACTIVATED: s.activated = true
+			}
+		}
+
+		// The compositor's width/height here is window geometry (content plus frame) once we've
+		// decorated ourselves, not just content -- see wl_frame_insets. Zero without a frame.
+		left, top, right, bottom := wl_frame_insets()
+		w := int(width) - left - right
+		h := int(height) - top - bottom
 
 		new_width: int
 		new_height: int
@@ -366,6 +436,15 @@ toplevel_listener := wl.XDG_Toplevel_Listener {
 				height = s.screen_height,
 			})
 		}
+
+		wl.xdg_surface_set_window_geometry(
+			s.xdg_surface,
+			i32(-left), i32(-top),
+			i32(new_width + left + right), i32(new_height + top + bottom),
+		)
+
+		wl_frame_layout(new_width, new_height)
+
 		s.configured = true
 	},
 	close = proc "c" (data: rawptr, xdg_toplevel: ^wl.XDG_Toplevel) {
@@ -373,7 +452,31 @@ toplevel_listener := wl.XDG_Toplevel_Listener {
 		append(&s.events, Event_Close_Window_Requested{})
 	},
 	configure_bounds = proc "c" (data: rawptr, xdg_toplevel: ^wl.XDG_Toplevel, width: c.int32_t, height: c.int32_t,) {},
-	wm_capabilities = proc "c" (data: rawptr, xdg_toplevel: ^wl.XDG_Toplevel, capabilities: ^wl.Array,) {},
+	wm_capabilities = proc "c" (
+		data: rawptr,
+		xdg_toplevel: ^wl.XDG_Toplevel,
+		capabilities: ^wl.Array,
+	) {
+		context = s.odin_ctx
+
+		s.wm_can_window_menu = false
+		s.wm_can_maximize = false
+		s.wm_can_fullscreen = false
+		s.wm_can_minimize = false
+
+		for cap in wl_array_as_u32s(capabilities) {
+			switch cap {
+			case wl.XDG_TOPLEVEL_WM_CAPABILITIES_WINDOW_MENU: s.wm_can_window_menu = true
+			case wl.XDG_TOPLEVEL_WM_CAPABILITIES_MAXIMIZE:    s.wm_can_maximize = true
+			case wl.XDG_TOPLEVEL_WM_CAPABILITIES_FULLSCREEN:  s.wm_can_fullscreen = true
+			case wl.XDG_TOPLEVEL_WM_CAPABILITIES_MINIMIZE:    s.wm_can_minimize = true
+			}
+		}
+
+		// Which buttons the titlebar draws depends on these, and this event is rare enough
+		// (usually once, if ever) that it isn't worth waiting for the next unrelated repaint.
+		wl_frame_layout(s.last_configure_width, s.last_configure_height)
+	},
 }
 
 
@@ -386,6 +489,17 @@ window_listener := wl.XDG_Surface_Listener {
 wm_base_listener := wl.XDG_WM_Base_Listener {
 	ping = proc "c" (data: rawptr, xdg_wm_base: ^wl.XDG_WM_Base, serial: c.uint32_t) {
 		wl.xdg_wm_base_pong(xdg_wm_base, serial)
+	},
+}
+
+decoration_listener := wl.ZXDG_Toplevel_Decoration_V1_Listener {
+	configure = proc "c" (
+		data: rawptr,
+		zxdg_toplevel_decoration_v1: ^wl.ZXDG_Toplevel_Decoration_V1,
+		mode: c.uint32_t,
+	) {
+		context = s.odin_ctx
+		s.decorations_are_client_side = mode == wl.ZXDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE
 	},
 }
 
@@ -553,6 +667,13 @@ pointer_listener := wl.Pointer_Listener {
 	) {
 		context = s.odin_ctx
 		s.pointer_enter_serial = u32(serial)
+		s.pointer_focus = surface
+		s.pointer_local = {f32(surface_x >> 8), f32(surface_y >> 8)}
+
+		if role := wl_frame_surface_role(surface); role != .None {
+			wl_frame_update_hover(role)
+		}
+
 		wl_apply_cursor()
 	},
 	leave = proc "c" (
@@ -561,7 +682,14 @@ pointer_listener := wl.Pointer_Listener {
 		serial: c.uint32_t,
 		surface: ^wl.Surface,
 	) {
+		context = s.odin_ctx
+		s.pointer_focus = nil
+		s.frame.pressed_button = .None
 
+		if s.frame.hovered_button != .None {
+			s.frame.hovered_button = .None
+			wl_frame_layout(s.last_configure_width, s.last_configure_height)
+		}
 	},
 	motion = proc "c" (
 		data: rawptr,
@@ -572,12 +700,23 @@ pointer_listener := wl.Pointer_Listener {
 	) {
 		context = s.odin_ctx
 
-		// surface_x and surface_y are fixed point 24.8 variables. 
-		// Just bitshift them to remove the decimal part and obtain 
-		// a screen coordinate
-		append(&s.events, Event_Mouse_Move {
-			position = { math.floor(f32(surface_x >> 8) * s.scale), math.floor(f32(surface_y >> 8) * s.scale) }, 
-		})
+		// surface_x and surface_y are fixed point 24.8 variables. Bitshift them to remove the
+		// decimal part and obtain a logical-pixel coordinate.
+		local_x := f32(surface_x >> 8)
+		local_y := f32(surface_y >> 8)
+
+		role := wl_frame_surface_role(s.pointer_focus)
+
+		if role == .None {
+			append(&s.events, Event_Mouse_Move {
+				position = { math.floor(local_x * s.scale), math.floor(local_y * s.scale) },
+			})
+			return
+		}
+
+		s.pointer_local = {local_x, local_y}
+		wl_frame_update_hover(role)
+		wl_apply_cursor()
 	},
 	button = proc "c" (
 		data: rawptr,
@@ -589,22 +728,80 @@ pointer_listener := wl.Pointer_Listener {
 	) {
 		context = s.odin_ctx
 
-		btn: Mouse_Button
-		switch button {
-		case wl.POINTER_BTN_LEFT: btn = .Left
-		case wl.POINTER_BTN_MIDDLE: btn = .Middle
-		case wl.POINTER_BTN_RIGHT: btn = .Right
+		role := wl_frame_surface_role(s.pointer_focus)
+
+		if role == .None {
+			btn: Mouse_Button
+			switch button {
+			case wl.POINTER_BTN_LEFT: btn = .Left
+			case wl.POINTER_BTN_MIDDLE: btn = .Middle
+			case wl.POINTER_BTN_RIGHT: btn = .Right
+			}
+
+			switch state {
+			case wl.POINTER_BUTTON_STATE_RELEASED:
+				append(&s.events, Event_Mouse_Button_Went_Up {
+					button = btn,
+				})
+			case wl.POINTER_BUTTON_STATE_PRESSED:
+				append(&s.events, Event_Mouse_Button_Went_Down {
+					button = btn,
+				})
+			}
+			return
 		}
-	
-		switch state {
-		case wl.POINTER_BUTTON_STATE_RELEASED:
-			append(&s.events, Event_Mouse_Button_Went_Up {
-				button = btn,
-			})
-		case wl.POINTER_BUTTON_STATE_PRESSED: 
-			append(&s.events, Event_Mouse_Button_Went_Down {
-				button = btn,
-			})
+
+		// A frame surface: this input is ours, never the game's.
+		hit := wl_frame_hit_test(role, s.pointer_local, wl_frame_window_width())
+
+		if state == wl.POINTER_BUTTON_STATE_RELEASED {
+			if hit.kind == .Button && hit.button == s.frame.pressed_button {
+				wl_frame_click_button(hit.button)
+			}
+			s.frame.pressed_button = .None
+			return
+		}
+
+		// state == PRESSED from here on.
+		if button == wl.POINTER_BTN_RIGHT {
+			if hit.kind == .Move {
+				wl.xdg_toplevel_show_window_menu(
+					s.toplevel, s.seat, serial, i32(s.pointer_local.x), i32(s.pointer_local.y),
+				)
+			}
+			return
+		}
+
+		if button != wl.POINTER_BTN_LEFT {
+			return
+		}
+
+		switch hit.kind {
+		case .Button:
+			s.frame.pressed_button = hit.button
+
+		case .Resize:
+			wl.xdg_toplevel_resize(s.toplevel, s.seat, serial, wl_frame_resize_edge_wire(hit.resize_edge))
+
+		case .Move:
+			now := time.tick_now()
+			is_double_click :=
+				s.frame.has_last_click &&
+				time.tick_diff(s.frame.last_click_tick, now) < FRAME_DOUBLE_CLICK_INTERVAL
+			s.frame.last_click_tick = now
+			s.frame.has_last_click = true
+
+			if is_double_click {
+				if s.maximized {
+					wl.xdg_toplevel_unset_maximized(s.toplevel)
+				} else if s.wm_can_maximize {
+					wl.xdg_toplevel_set_maximized(s.toplevel)
+				}
+			} else {
+				wl.xdg_toplevel_move(s.toplevel, s.seat, serial)
+			}
+
+		case .None:
 		}
 	},
 	axis = proc "c" (
@@ -616,10 +813,14 @@ pointer_listener := wl.Pointer_Listener {
 	) {
 		context = s.odin_ctx
 
+		if wl_frame_surface_role(s.pointer_focus) != .None {
+			return
+		}
+
 		// Vertical scroll
 		if axis == 0 {
 			event_direction: f32 = value > 0 ? -1 : 1
-			
+
 			append(&s.events, Event_Mouse_Wheel {
 				delta = event_direction,
 			})
@@ -693,6 +894,13 @@ fractional_scale_listener := wl.WP_Fractional_Scale_V1_Listener {
 }
 
 wl_shutdown :: proc() {
+	wl_frame_destroy()
+
+	if s.decoration != nil {
+		wl.zxdg_toplevel_decoration_v1_destroy(s.decoration)
+		s.decoration = nil
+	}
+
 	for it := hm.dynamic_iterator_make(&s.custom_cursors); cd, _ in hm.dynamic_iterate(&it) {
 		wl.wp_viewport_destroy(cd.viewport)
 		wl.surface_destroy(cd.surface)
@@ -785,6 +993,11 @@ wl_get_events :: proc(events: ^[dynamic]Event) {
 
 wl_set_title :: proc(title: string) {
 	wl.xdg_toplevel_set_title(s.toplevel, strings.clone_to_cstring(title, frame_allocator))
+	wl_frame_set_title(title)
+
+	// Nothing else drives a repaint here -- the next configure could be arbitrarily far off, or
+	// never come at all if nothing else about the window changes.
+	wl_frame_layout(s.last_configure_width, s.last_configure_height)
 }
 
 wl_get_screen_width :: proc() -> int {
@@ -832,8 +1045,12 @@ wl_set_window_mode :: proc(window_mode: Window_Mode) {
 	switch window_mode {
 	case .Windowed:
 		wl.xdg_toplevel_unset_fullscreen(s.toplevel)
-		w := i32(s.last_configure_windowed_width)
-		h := i32(s.last_configure_windowed_height)
+
+		// set_max_size/set_min_size are window geometry sizes, i.e. content plus frame, not just
+		// content -- see wl_frame_insets. Zero without a frame, so this is safe unconditionally.
+		left, top, right, bottom := wl_frame_insets()
+		w := i32(s.last_configure_windowed_width + left + right)
+		h := i32(s.last_configure_windowed_height + top + bottom)
 		wl.xdg_toplevel_set_max_size(s.toplevel, w, h)
 		wl.xdg_toplevel_set_min_size(s.toplevel, w, h)
 
@@ -949,28 +1166,36 @@ wl_apply_cursor :: proc() {
 		return
 	}
 
+	// Over our own frame, the resize/move cursor takes over entirely -- the game's cursor_hidden
+	// and current_cursor don't apply there, same as the compositor's own decorations would.
+	if role := wl_frame_surface_role(s.pointer_focus); role != .None {
+		wl_apply_standard_cursor(wl_frame_cursor(role))
+		return
+	}
+
 	if s.cursor_hidden {
 		wl.pointer_set_cursor(s.pointer, s.pointer_enter_serial, nil, 0, 0)
 		return
 	}
 
-	standard := Standard_Cursor.Default
-
 	switch cur in s.current_cursor {
 	case Standard_Cursor:
-		standard = cur
+		wl_apply_standard_cursor(cur)
 
 	case Custom_Cursor:
 		if cd := hm.get(&s.custom_cursors, cur); cd != nil {
 			wl_point_at_cursor(cd, s.pointer_enter_serial)
-			return
+		} else {
+			// Destroyed while on screen; fall back to the default cursor.
+			wl_apply_standard_cursor(.Default)
 		}
-		// Otherwise it was destroyed while on screen; fall through to the default cursor below.
 	}
+}
 
-	// A standard cursor. Prefer the cursor shape protocol, which lets the compositor render it at
-	// the correct size and DPI itself; the themed surface below is only a fallback for compositors
-	// that don't support it.
+// Displays `standard` as the OS cursor. Prefer the cursor shape protocol, which lets the
+// compositor render it at the correct size and DPI itself; the themed surface below is only a
+// fallback for compositors that don't support it.
+wl_apply_standard_cursor :: proc(standard: Standard_Cursor) {
 	if s.cursor_shape_device != nil {
 		wl.cursor_shape_device_set_shape(
 			s.cursor_shape_device,
@@ -1015,32 +1240,67 @@ wl_apply_cursor :: proc() {
 	wl.surface_commit(s.cursor_surface)
 }
 
-wl_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cursor {
-	stride := image.width * 4
-	size := stride * image.height
+// A writable shm-backed Wayland buffer of premultiplied ARGB8888 pixels, sized `width` x `height`
+// physical pixels. `data` points at `width * height` u32 pixels the caller fills in. The pool is
+// destroyed immediately after creating the buffer -- that's safe, the mapping stays alive until
+// every buffer made from the pool is destroyed, so nothing here needs to keep the pool around.
+WL_SHM_Buffer :: struct {
+	buffer:    ^wl.Buffer,
+	data:      rawptr,
+	data_size: int,
+}
 
-	fd, fd_err := linux.memfd_create("cursor", {})
+wl_create_shm_buffer :: proc(width: int, height: int) -> (buf: WL_SHM_Buffer, ok: bool) {
+	stride := width * 4
+	size := stride * height
+
+	fd, fd_err := linux.memfd_create("karl2d", {})
 	if fd_err != .NONE {
-		log.errorf("Failed to create Wayland cursor: memfd failed with %v", fd_err)
-		return {}
+		log.errorf("Failed to create Wayland shm buffer: memfd failed with %v", fd_err)
+		return {}, false
 	}
 
 	// The compositor dups the fd in shm_create_pool, so we don't have to keep ours around.
 	defer linux.close(fd)
 
 	if trunc_err := linux.ftruncate(fd, i64(size)); trunc_err != .NONE {
-		log.errorf("Failed to create Wayland cursor: ftruncate failed with %v", trunc_err)
-		return {}
+		log.errorf("Failed to create Wayland shm buffer: ftruncate failed with %v", trunc_err)
+		return {}, false
 	}
 
 	data, mmap_err := linux.mmap(0, uint(size), {.READ, .WRITE}, {.SHARED}, fd, 0)
 	if mmap_err != .NONE {
-		log.errorf("Failed to create Wayland cursor: mmap failed with %v", mmap_err)
+		log.errorf("Failed to create Wayland shm buffer: mmap failed with %v", mmap_err)
+		return {}, false
+	}
+
+	pool := wl.shm_create_pool(s.shm, c.int32_t(fd), c.int32_t(size))
+
+	buffer := wl.shm_pool_create_buffer(
+		pool, 0,
+		c.int32_t(width), c.int32_t(height), c.int32_t(stride),
+		wl.SHM_FORMAT_ARGB8888,
+	)
+
+	wl.shm_pool_destroy(pool)
+
+	return WL_SHM_Buffer{buffer = buffer, data = data, data_size = size}, true
+}
+
+// Frees the buffer's backing memory. The caller still owns `buf.buffer` itself and must
+// `wl.buffer_destroy` it separately once the compositor is done with it.
+wl_destroy_shm_buffer :: proc(buf: WL_SHM_Buffer) {
+	linux.munmap(buf.data, uint(buf.data_size))
+}
+
+wl_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cursor {
+	shm_buf, shm_buf_ok := wl_create_shm_buffer(image.width, image.height)
+	if !shm_buf_ok {
 		return {}
 	}
 
 	// Convert to ARGB and premultiply alpha
-	pixel_data := ([^]u32)(data)
+	pixel_data := ([^]u32)(shm_buf.data)
 	for i in 0..<len(image.pixels) {
 		col := image.pixels[i]
 		a := u32(col.a)
@@ -1050,29 +1310,17 @@ wl_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cursor 
 		pixel_data[i] = a << 24 | r << 16 | g << 8 | b
 	}
 
-	pool := wl.shm_create_pool(s.shm, c.int32_t(fd), c.int32_t(size))
-
-	buffer := wl.shm_pool_create_buffer(
-		pool, 0,
-		c.int32_t(image.width), c.int32_t(image.height), c.int32_t(stride),
-		wl.SHM_FORMAT_ARGB8888,
-	)
-
-	// The pool can go away immediately: the mapping stays alive until every buffer made from it
-	// has been destroyed.
-	wl.shm_pool_destroy(pool)
-
 	surface := wl.compositor_create_surface(s.compositor)
-	wl.surface_attach(surface, buffer, 0, 0)
+	wl.surface_attach(surface, shm_buf.buffer, 0, 0)
 
 	cursor := WL_Cursor {
 		surface   = surface,
 		hotspot   = hotspot,
 		width     = image.width,
 		height    = image.height,
-		buffer    = buffer,
-		data      = data,
-		data_size = size,
+		buffer    = shm_buf.buffer,
+		data      = shm_buf.data,
+		data_size = shm_buf.data_size,
 		viewport  = wl.wp_viewporter_get_viewport(s.viewporter, surface),
 	}
 
@@ -1085,7 +1333,7 @@ wl_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cursor 
 		wl.wp_viewport_destroy(cursor.viewport)
 		wl.surface_destroy(cursor.surface)
 		wl.buffer_destroy(cursor.buffer)
-		linux.munmap(cursor.data, uint(cursor.data_size))
+		wl_destroy_shm_buffer(shm_buf)
 		return {}
 	}
 
@@ -1233,11 +1481,38 @@ WL_State :: struct {
 	display: ^wl.Display,
 	surface: ^wl.Surface,
 	compositor: ^wl.Compositor,
+	subcompositor: ^wl.Subcompositor,
 	window: ^wl.EGL_Window,
+	xdg_surface: ^wl.XDG_Surface,
 	toplevel: ^wl.XDG_Toplevel,
 	viewporter: ^wl.WP_Viewporter,
 	viewport: ^wl.WP_Viewport,
 	decoration_manager: ^wl.ZXDG_Decoration_Manager_V1,
+	decoration: ^wl.ZXDG_Toplevel_Decoration_V1,
+
+	// True once we know the compositor won't draw our decorations for us: either it never offered
+	// zxdg_decoration_manager_v1 at all, or it offered one but answered CLIENT_SIDE. See
+	// decoration_listener. This is what tells us to draw our own frame.
+	decorations_are_client_side: bool,
+
+	// Toplevel state as reported by the compositor via toplevel_listener.configure's `states`.
+	maximized: bool,
+	fullscreen: bool,
+	activated: bool,
+
+	// What the compositor says it supports, from toplevel_listener.wm_capabilities. Default to
+	// true (see wl_init) since not every compositor sends this event.
+	wm_can_window_menu: bool,
+	wm_can_maximize: bool,
+	wm_can_fullscreen: bool,
+	wm_can_minimize: bool,
+
+	// Our own drawn window frame -- titlebar and border subsurfaces -- used when
+	// decorations_are_client_side. See platform_linux_window_wayland_frame.odin. Its own fields
+	// are the source of truth for whether it exists: frame.titlebar_surface == nil means it
+	// doesn't, and every wl_frame_* procedure checks that instead of decorations_are_client_side.
+	frame: WL_Frame,
+
 	fractional_scale_manager: ^wl.WP_Fractional_Scale_Manager_V1,
 
 	xdg_base: ^wl.XDG_WM_Base,
@@ -1247,6 +1522,16 @@ WL_State :: struct {
 	keyboard: ^wl.Keyboard,
 	pointer: ^wl.Pointer,
 	pointer_enter_serial: u32,
+
+	// The surface currently under the pointer -- s.surface (the game's content), one of the
+	// frame's own surfaces, or nil. Routes pointer events: content surfaces produce game events,
+	// frame surfaces are handled entirely by us and never reach the game.
+	pointer_focus: ^wl.Surface,
+
+	// Logical pixels, local to pointer_focus. Only meaningful (and only updated) while
+	// pointer_focus is a frame surface -- see wl_frame_hit_test.
+	pointer_local: Vec2,
+
 	cursor_hidden: bool,
 	shm: ^wl.SHM,
 	cursor_surface: ^wl.Surface,

--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -443,7 +443,9 @@ toplevel_listener := wl.XDG_Toplevel_Listener {
 			i32(new_width + left + right), i32(new_height + top + bottom),
 		)
 
-		wl_frame_layout(new_width, new_height)
+		// flush = false: the game's next render commits the parent surface with a content buffer at
+		// the new size, so the frame and the content resize together in one compositor frame.
+		wl_frame_layout(new_width, new_height, flush = false)
 
 		s.configured = true
 	},
@@ -885,6 +887,11 @@ fractional_scale_listener := wl.WP_Fractional_Scale_V1_Listener {
 		// theme cursor) happen instantly rather than waiting for the next pointer move.
 		wl_apply_cursor()
 
+		// The titlebar buffer is sized in physical pixels, so a scale change on its own -- with no
+		// resize to follow -- would otherwise leave the old buffer stretched by its viewport until
+		// something else happened to repaint it.
+		wl_frame_layout(s.last_configure_width, s.last_configure_height)
+
 		append(&s.events, Event_Window_Scale_Changed {
 			scale = scl,
 			screen_width = s.screen_width,
@@ -1033,6 +1040,21 @@ wl_set_screen_size :: proc(w, h: int) {
 	}
 
 	wl.wp_viewport_set_destination(s.viewport, i32(w), i32(h))
+
+	// The frame has to follow the content, and the compositor needs the outer size that goes with
+	// it. Insets are zero without a frame, so this is the same arithmetic either way.
+	left, top, right, bottom := wl_frame_insets()
+
+	wl.xdg_surface_set_window_geometry(
+		s.xdg_surface,
+		i32(-left), i32(-top),
+		i32(w + left + right), i32(h + top + bottom),
+	)
+
+	// flush = false for the same reason as in toplevel_listener.configure: the viewport change
+	// above is already waiting on the game's next render to commit the parent, and the frame
+	// should land in that same commit rather than a frame ahead of it.
+	wl_frame_layout(w, h, flush = false)
 }
 
 wl_get_window_scale :: proc() -> f32 {

--- a/platform_linux_window_wayland_frame.odin
+++ b/platform_linux_window_wayland_frame.odin
@@ -121,6 +121,7 @@ WL_Frame :: struct {
 	painted_width:          int,
 	painted_scale:          f32,
 	painted_activated:      bool,
+	painted_maximized:      bool,
 	painted_title_version:  int,
 	painted_hovered_button: WL_Frame_Button,
 
@@ -145,7 +146,7 @@ wl_frame_insets :: proc() -> (left, top, right, bottom: int) {
 		return
 	}
 
-	top = FRAME_TITLEBAR_HEIGHT + FRAME_BORDER
+	top = FRAME_TITLEBAR_HEIGHT + wl_frame_top_border()
 
 	if !s.maximized {
 		// A maximized window has no resize edges, so GNOME (and we) drop the borders. The
@@ -156,6 +157,13 @@ wl_frame_insets :: proc() -> (left, top, right, bottom: int) {
 	}
 
 	return
+}
+
+// Thickness of the border strip drawn above the titlebar, in logical pixels. Zero when maximized,
+// for the same reason the side borders go away: there is no resize edge up there to grab, and a
+// dark line pinned to the top of the screen just looks like a mistake.
+wl_frame_top_border :: proc() -> int {
+	return s.maximized ? 0 : FRAME_BORDER
 }
 
 //--------------------//
@@ -208,6 +216,13 @@ wl_frame_create_strip :: proc(strip: ^WL_Frame_Strip, parent: ^wl.Surface) {
 }
 
 wl_frame_destroy :: proc() {
+	// Freed before the guard below: wl_frame_set_title keeps the title whether or not a frame was
+	// ever created, so on a server-side-decorated compositor this is the only thing to clean up.
+	if s.frame.title != "" {
+		delete(s.frame.title, s.allocator)
+		s.frame.title = ""
+	}
+
 	if s.frame.titlebar_surface == nil {
 		return
 	}
@@ -228,10 +243,6 @@ wl_frame_destroy :: proc() {
 	wl_frame_destroy_strip(&s.frame.left)
 	wl_frame_destroy_strip(&s.frame.right)
 	wl_frame_destroy_strip(&s.frame.bottom)
-
-	if s.frame.title != "" {
-		delete(s.frame.title, s.allocator)
-	}
 
 	s.frame = {}
 }
@@ -264,10 +275,15 @@ wl_frame_set_title :: proc(title: string) {
 
 // Repositions and resizes the frame's subsurfaces for a `content_width` x `content_height`
 // content area, hides the border strips when maximized, hides everything when fullscreen, and
-// repaints the titlebar if anything that would change its look has changed. Called from
-// toplevel_listener.configure on every configure, and from wl_set_title so a title change doesn't
-// have to wait for one.
-wl_frame_layout :: proc(content_width: int, content_height: int) {
+// repaints the titlebar if anything that would change its look has changed.
+//
+// Subsurfaces are synchronized, so none of this is visible until the *parent* surface commits.
+// `flush` decides who does that. Pass false from the configure handler: the game's next render
+// commits the parent along with a content buffer at the new size, so the frame and the content
+// resize in the same compositor frame. Committing here instead would move the frame immediately
+// while the content buffer is still the old size, which tears visibly during a resize drag.
+// Everything else (title, hover, focus, scale) has no render to piggyback on and needs flush.
+wl_frame_layout :: proc(content_width: int, content_height: int, flush := true) {
 	if s.frame.titlebar_surface == nil {
 		return
 	}
@@ -278,7 +294,10 @@ wl_frame_layout :: proc(content_width: int, content_height: int) {
 		wl_frame_set_strip_visible(&s.frame.left, false)
 		wl_frame_set_strip_visible(&s.frame.right, false)
 		wl_frame_set_strip_visible(&s.frame.bottom, false)
-		wl.surface_commit(s.surface)
+
+		if flush {
+			wl.surface_commit(s.surface)
+		}
 		return
 	}
 
@@ -305,10 +324,9 @@ wl_frame_layout :: proc(content_width: int, content_height: int) {
 		wl.wp_viewport_set_destination(s.frame.bottom.viewport, i32(window_width), i32(bottom))
 	}
 
-	// Subsurfaces are synchronized: none of the position/size/visibility/buffer changes above are
-	// visible until the parent surface commits. The game's own render loop does that every frame,
-	// but a change made outside of rendering (focus, maximize, title) needs its own flush.
-	wl.surface_commit(s.surface)
+	if flush {
+		wl.surface_commit(s.surface)
+	}
 }
 
 wl_frame_set_strip_visible :: proc(strip: ^WL_Frame_Strip, visible: bool) {
@@ -333,6 +351,7 @@ wl_frame_repaint_titlebar :: proc(window_width: int) {
 		window_width != s.frame.painted_width ||
 		s.scale != s.frame.painted_scale ||
 		s.activated != s.frame.painted_activated ||
+		s.maximized != s.frame.painted_maximized ||
 		s.frame.title_version != s.frame.painted_title_version ||
 		s.frame.hovered_button != s.frame.painted_hovered_button
 
@@ -340,22 +359,29 @@ wl_frame_repaint_titlebar :: proc(window_width: int) {
 		return
 	}
 
-	wl_frame_paint_titlebar(window_width)
+	// Only record what we painted if we actually painted it, so a failed buffer allocation gets
+	// retried on the next layout instead of being remembered as done.
+	if !wl_frame_paint_titlebar(window_width) {
+		return
+	}
 
 	s.frame.painted_width = window_width
 	s.frame.painted_scale = s.scale
 	s.frame.painted_activated = s.activated
+	s.frame.painted_maximized = s.maximized
 	s.frame.painted_title_version = s.frame.title_version
 	s.frame.painted_hovered_button = s.frame.hovered_button
 }
 
-wl_frame_paint_titlebar :: proc(window_width: int) {
+wl_frame_paint_titlebar :: proc(window_width: int) -> bool {
+	top_border := wl_frame_top_border()
+
 	physical_w := max(1, int(math.round(f32(window_width) * s.scale)))
-	physical_h := max(1, int(math.round(f32(FRAME_TITLEBAR_HEIGHT + FRAME_BORDER) * s.scale)))
+	physical_h := max(1, int(math.round(f32(FRAME_TITLEBAR_HEIGHT + top_border) * s.scale)))
 
 	shm_buf, shm_buf_ok := wl_create_shm_buffer(physical_w, physical_h)
 	if !shm_buf_ok {
-		return
+		return false
 	}
 
 	colors := make([]Color, physical_w * physical_h, frame_allocator)
@@ -365,7 +391,7 @@ wl_frame_paint_titlebar :: proc(window_width: int) {
 		col = bg
 	}
 
-	border_px := min(int(math.round(f32(FRAME_BORDER) * s.scale)), physical_h)
+	border_px := min(int(math.round(f32(top_border) * s.scale)), physical_h)
 	for y in 0..<border_px {
 		for x in 0..<physical_w {
 			colors[y * physical_w + x] = FRAME_COLOR_BORDER
@@ -414,7 +440,7 @@ wl_frame_paint_titlebar :: proc(window_width: int) {
 	pixel_data := ([^]u32)(shm_buf.data)
 	for y in 0..<physical_h {
 		for x in 0..<physical_w {
-			coverage := wl_frame_corner_coverage(x, y, physical_w, physical_h, corner_radius_px)
+			coverage := wl_frame_corner_coverage(x, y, physical_w, corner_radius_px)
 			pixel_data[y * physical_w + x] = wl_frame_pack_color(colors[y * physical_w + x], coverage)
 		}
 	}
@@ -433,6 +459,7 @@ wl_frame_paint_titlebar :: proc(window_width: int) {
 	wl.add_listener(s.frame.titlebar_buffer.buffer, &titlebar_buffer_listener, nil)
 	wl.surface_attach(s.frame.titlebar_surface, s.frame.titlebar_buffer.buffer, 0, 0)
 	wl.surface_commit(s.frame.titlebar_surface)
+	return true
 }
 
 // The previous titlebar buffer stays alive until the compositor confirms it's done reading from
@@ -489,7 +516,7 @@ wl_frame_button_rect :: proc(button: WL_Frame_Button, window_width: int) -> (x, 
 	right_edge := window_width - FRAME_BUTTON_MARGIN - (from_right - 1) * step
 
 	x = right_edge - FRAME_BUTTON_HIT_SIZE
-	y = FRAME_BORDER + (FRAME_TITLEBAR_HEIGHT - FRAME_BUTTON_HIT_SIZE) / 2
+	y = wl_frame_top_border() + (FRAME_TITLEBAR_HEIGHT - FRAME_BUTTON_HIT_SIZE) / 2
 	w = FRAME_BUTTON_HIT_SIZE
 	h = FRAME_BUTTON_HIT_SIZE
 	return
@@ -539,7 +566,8 @@ wl_frame_hit_test :: proc(role: WL_Frame_Surface, local: Vec2, window_width: int
 			}
 		}
 
-		if local.y < FRAME_BORDER {
+		// Zero-height when maximized, so this whole block falls through to .Move there.
+		if local.y < f32(wl_frame_top_border()) {
 			if local.x < FRAME_BORDER {
 				return {kind = .Resize, resize_edge = .Top_Left}
 			}
@@ -677,6 +705,8 @@ wl_frame_paint_button_icon :: proc(
 	case .Minimize:
 		segments[0] = {-icon_half, icon_half, icon_half, icon_half}
 		seg_count = 1
+	case .None:
+		return
 	}
 
 	stroke := max(f32(1), s.scale)
@@ -849,10 +879,10 @@ wl_frame_line_coverage :: proc(px, py, x0, y0, x1, y1, thickness: f32) -> f32 {
 	return half + 0.5 - dist
 }
 
-// Anti-aliased coverage (0..1) for whether the pixel at (px,py) in a `w` x `h` buffer falls
-// inside a rounded top corner. 1 (fully opaque) everywhere except within `radius` physical
-// pixels of a top corner; only the top corners round, matching GNOME's own windows.
-wl_frame_corner_coverage :: proc(px, py, w, h, radius: int) -> f32 {
+// Anti-aliased coverage (0..1) for whether the pixel at (px,py) in a buffer `w` wide falls inside
+// a rounded top corner. 1 (fully opaque) everywhere except within `radius` physical pixels of a
+// top corner; only the top corners round, matching GNOME's own windows.
+wl_frame_corner_coverage :: proc(px, py, w, radius: int) -> f32 {
 	if radius <= 0 {
 		return 1
 	}

--- a/platform_linux_window_wayland_frame.odin
+++ b/platform_linux_window_wayland_frame.odin
@@ -1,0 +1,911 @@
+#+build linux
+package karl2d
+
+// Draws our own window decorations for Wayland compositors that won't do it for us (GNOME/Mutter,
+// primarily -- see decorations_are_client_side in platform_linux_window_wayland.odin). No external
+// dependencies: four wl_subsurfaces (a painted titlebar, three 1x1-pixel-stretched border strips)
+// sit outside the content surface and never overlap it, so this is purely additive.
+//
+// Every procedure here is safe to call unconditionally, on any Wayland compositor, at any point:
+// they all check `s.frame.titlebar_surface == nil` (or, for wl_frame_insets, the same condition)
+// and return immediately if there's no frame. That's what keeps this additive instead of a second
+// window implementation living inside platform_linux_window_wayland.odin -- see that file's
+// toplevel_listener.configure and wl_set_window_mode for the two call sites that use insets.
+
+import "core:c"
+import "core:math"
+import "core:strings"
+import "core:time"
+import stbtt "vendor:stb/truetype"
+
+import "log"
+import wl "platform_bindings/linux/wayland"
+
+// Logical pixels.
+FRAME_TITLEBAR_HEIGHT :: 32
+FRAME_BORDER          :: 4  // also the resize grab margin -- see wl_frame_hit_test
+FRAME_CORNER_RADIUS   :: 9  // only the top corners are rounded
+
+FRAME_BUTTON_HIT_SIZE  :: 28 // logical px, the square area a button occupies
+FRAME_BUTTON_ICON_SIZE :: 10 // logical px, the glyph drawn inside that area
+FRAME_BUTTON_GAP       :: 2
+FRAME_BUTTON_MARGIN    :: 6  // gap from the titlebar's right edge to the first button
+
+FRAME_TEXT_SIZE   :: 14 // logical px
+FRAME_TEXT_MARGIN :: 8  // gap from the titlebar's left edge to the title text
+
+FRAME_COLOR_TITLEBAR_ACTIVE   :: Color{50, 50, 54, 255}
+FRAME_COLOR_TITLEBAR_INACTIVE :: Color{38, 38, 41, 255}
+FRAME_COLOR_BORDER            :: Color{20, 20, 22, 255}
+FRAME_COLOR_TEXT_ACTIVE       :: Color{235, 235, 235, 255}
+FRAME_COLOR_TEXT_INACTIVE     :: Color{140, 140, 140, 255}
+FRAME_COLOR_BUTTON_HOVER      :: Color{255, 255, 255, 35}
+FRAME_COLOR_CLOSE_HOVER       :: Color{196, 43, 28, 255}
+
+FRAME_DOUBLE_CLICK_INTERVAL :: 400 * time.Millisecond
+
+// .None is the zero value, meaning "no button" -- see the handle-like-zero-value convention this
+// codebase uses instead of Maybe (agent.md). Used both for "nothing hovered/pressed" and as
+// WL_Frame_Hit.button when the hit isn't a button at all.
+WL_Frame_Button :: enum {
+	None,
+	Minimize,
+	Maximize,
+	Close,
+}
+
+// Which of the frame's own surfaces (if any) a wl_surface pointer refers to.
+WL_Frame_Surface :: enum {
+	None,
+	Titlebar,
+	Left,
+	Right,
+	Bottom,
+}
+
+WL_Frame_Resize_Edge :: enum {
+	None,
+	Top,
+	Bottom,
+	Left,
+	Right,
+	Top_Left,
+	Top_Right,
+	Bottom_Left,
+	Bottom_Right,
+}
+
+WL_Frame_Hit_Kind :: enum {
+	None,
+	Move,   // titlebar, not over a button -- drag to move, double-click to maximize, right-click menu
+	Button,
+	Resize,
+}
+
+WL_Frame_Hit :: struct {
+	kind:        WL_Frame_Hit_Kind,
+	button:      WL_Frame_Button,        // valid when kind == .Button
+	resize_edge: WL_Frame_Resize_Edge,   // valid when kind == .Resize
+}
+
+// One border strip: a 1x1-pixel shm buffer stretched over its whole area by a viewport, so it
+// never needs repainting, only repositioning and resizing.
+WL_Frame_Strip :: struct {
+	surface:    ^wl.Surface,
+	subsurface: ^wl.Subsurface,
+	viewport:   ^wl.WP_Viewport,
+	shm_buf:    WL_SHM_Buffer,
+}
+
+WL_Frame :: struct {
+	titlebar_surface:    ^wl.Surface,
+	titlebar_subsurface: ^wl.Subsurface,
+	titlebar_viewport:   ^wl.WP_Viewport,
+	titlebar_buffer:     WL_SHM_Buffer,
+
+	// The compositor may still be reading this one when a repaint replaces it -- see
+	// titlebar_buffer_listener. Freed once its `release` event fires.
+	titlebar_buffer_old: WL_SHM_Buffer,
+
+	left:   WL_Frame_Strip,
+	right:  WL_Frame_Strip,
+	bottom: WL_Frame_Strip,
+
+	// Owned copy of the window title, for the titlebar to paint. title_version is bumped whenever
+	// it changes; wl_frame_repaint_titlebar compares it against painted_title_version.
+	title:         string,
+	title_version: int,
+
+	// What's currently painted into titlebar_buffer, so repaints can be skipped when nothing that
+	// would change the result has changed.
+	painted_width:          int,
+	painted_scale:          f32,
+	painted_activated:      bool,
+	painted_title_version:  int,
+	painted_hovered_button: WL_Frame_Button,
+
+	// Input state -- see pointer_listener in platform_linux_window_wayland.odin.
+	hovered_button:  WL_Frame_Button,
+	pressed_button:  WL_Frame_Button,
+	last_click_tick: time.Tick,
+	has_last_click:  bool,
+
+	font:    stbtt.fontinfo,
+	font_ok: bool,
+}
+
+//---------------//
+// FRAME EXTENTS //
+//---------------//
+
+// Logical-pixel insets the frame adds around the content surface. All zero when there's no frame
+// (or it's hidden for fullscreen), so callers can use this unconditionally.
+wl_frame_insets :: proc() -> (left, top, right, bottom: int) {
+	if s.frame.titlebar_surface == nil || s.fullscreen {
+		return
+	}
+
+	top = FRAME_TITLEBAR_HEIGHT + FRAME_BORDER
+
+	if !s.maximized {
+		// A maximized window has no resize edges, so GNOME (and we) drop the borders. The
+		// titlebar stays.
+		left = FRAME_BORDER
+		right = FRAME_BORDER
+		bottom = FRAME_BORDER
+	}
+
+	return
+}
+
+//--------------------//
+// CREATE AND DESTROY //
+//--------------------//
+
+wl_frame_create :: proc() {
+	if !s.decorations_are_client_side || s.subcompositor == nil {
+		return
+	}
+
+	font_offset := stbtt.GetFontOffsetForIndex(raw_data(DEFAULT_FONT_DATA), 0)
+	s.frame.font_ok = bool(stbtt.InitFont(&s.frame.font, raw_data(DEFAULT_FONT_DATA), font_offset))
+
+	if !s.frame.font_ok {
+		log.error("Failed loading the default font for window decorations; titlebar will have no text")
+	}
+
+	s.frame.titlebar_surface = wl.compositor_create_surface(s.compositor)
+	s.frame.titlebar_subsurface = wl.subcompositor_get_subsurface(
+		s.subcompositor,
+		s.frame.titlebar_surface,
+		s.surface,
+	)
+	s.frame.titlebar_viewport = wl.wp_viewporter_get_viewport(s.viewporter, s.frame.titlebar_surface)
+	wl.subsurface_place_below(s.frame.titlebar_subsurface, s.surface)
+
+	wl_frame_create_strip(&s.frame.left, s.surface)
+	wl_frame_create_strip(&s.frame.right, s.surface)
+	wl_frame_create_strip(&s.frame.bottom, s.surface)
+}
+
+wl_frame_create_strip :: proc(strip: ^WL_Frame_Strip, parent: ^wl.Surface) {
+	strip.surface = wl.compositor_create_surface(s.compositor)
+	strip.subsurface = wl.subcompositor_get_subsurface(s.subcompositor, strip.surface, parent)
+	strip.viewport = wl.wp_viewporter_get_viewport(s.viewporter, strip.surface)
+	wl.subsurface_place_below(strip.subsurface, s.surface)
+
+	shm_buf, shm_buf_ok := wl_create_shm_buffer(1, 1)
+	if !shm_buf_ok {
+		return
+	}
+
+	strip.shm_buf = shm_buf
+	pixel_data := ([^]u32)(strip.shm_buf.data)
+	pixel_data[0] = wl_frame_pack_color(FRAME_COLOR_BORDER, 1)
+
+	wl.surface_attach(strip.surface, strip.shm_buf.buffer, 0, 0)
+	wl.surface_commit(strip.surface)
+}
+
+wl_frame_destroy :: proc() {
+	if s.frame.titlebar_surface == nil {
+		return
+	}
+
+	if s.frame.titlebar_buffer.buffer != nil {
+		wl.buffer_destroy(s.frame.titlebar_buffer.buffer)
+		wl_destroy_shm_buffer(s.frame.titlebar_buffer)
+	}
+	if s.frame.titlebar_buffer_old.buffer != nil {
+		wl.buffer_destroy(s.frame.titlebar_buffer_old.buffer)
+		wl_destroy_shm_buffer(s.frame.titlebar_buffer_old)
+	}
+
+	wl.wp_viewport_destroy(s.frame.titlebar_viewport)
+	wl.subsurface_destroy(s.frame.titlebar_subsurface)
+	wl.surface_destroy(s.frame.titlebar_surface)
+
+	wl_frame_destroy_strip(&s.frame.left)
+	wl_frame_destroy_strip(&s.frame.right)
+	wl_frame_destroy_strip(&s.frame.bottom)
+
+	if s.frame.title != "" {
+		delete(s.frame.title, s.allocator)
+	}
+
+	s.frame = {}
+}
+
+wl_frame_destroy_strip :: proc(strip: ^WL_Frame_Strip) {
+	if strip.shm_buf.buffer != nil {
+		wl.buffer_destroy(strip.shm_buf.buffer)
+		wl_destroy_shm_buffer(strip.shm_buf)
+	}
+
+	wl.wp_viewport_destroy(strip.viewport)
+	wl.subsurface_destroy(strip.subsurface)
+	wl.surface_destroy(strip.surface)
+}
+
+// Updates the owned copy of the title. Safe to call before the frame exists (e.g. from wl_init,
+// before wl_frame_create has run) -- it just won't have anything to paint yet.
+wl_frame_set_title :: proc(title: string) {
+	if s.frame.title != "" {
+		delete(s.frame.title, s.allocator)
+	}
+
+	s.frame.title = strings.clone(title, s.allocator)
+	s.frame.title_version += 1
+}
+
+//--------//
+// LAYOUT //
+//--------//
+
+// Repositions and resizes the frame's subsurfaces for a `content_width` x `content_height`
+// content area, hides the border strips when maximized, hides everything when fullscreen, and
+// repaints the titlebar if anything that would change its look has changed. Called from
+// toplevel_listener.configure on every configure, and from wl_set_title so a title change doesn't
+// have to wait for one.
+wl_frame_layout :: proc(content_width: int, content_height: int) {
+	if s.frame.titlebar_surface == nil {
+		return
+	}
+
+	if s.fullscreen {
+		wl.surface_attach(s.frame.titlebar_surface, nil, 0, 0)
+		wl.surface_commit(s.frame.titlebar_surface)
+		wl_frame_set_strip_visible(&s.frame.left, false)
+		wl_frame_set_strip_visible(&s.frame.right, false)
+		wl_frame_set_strip_visible(&s.frame.bottom, false)
+		wl.surface_commit(s.surface)
+		return
+	}
+
+	left, top, right, bottom := wl_frame_insets()
+	window_width := content_width + left + right
+
+	wl.subsurface_set_position(s.frame.titlebar_subsurface, i32(-left), i32(-top))
+	wl.wp_viewport_set_destination(s.frame.titlebar_viewport, i32(window_width), i32(top))
+	wl_frame_repaint_titlebar(window_width)
+
+	borders_visible := !s.maximized
+	wl_frame_set_strip_visible(&s.frame.left, borders_visible)
+	wl_frame_set_strip_visible(&s.frame.right, borders_visible)
+	wl_frame_set_strip_visible(&s.frame.bottom, borders_visible)
+
+	if borders_visible {
+		wl.subsurface_set_position(s.frame.left.subsurface, i32(-left), 0)
+		wl.wp_viewport_set_destination(s.frame.left.viewport, i32(left), i32(content_height))
+
+		wl.subsurface_set_position(s.frame.right.subsurface, i32(content_width), 0)
+		wl.wp_viewport_set_destination(s.frame.right.viewport, i32(right), i32(content_height))
+
+		wl.subsurface_set_position(s.frame.bottom.subsurface, i32(-left), i32(content_height))
+		wl.wp_viewport_set_destination(s.frame.bottom.viewport, i32(window_width), i32(bottom))
+	}
+
+	// Subsurfaces are synchronized: none of the position/size/visibility/buffer changes above are
+	// visible until the parent surface commits. The game's own render loop does that every frame,
+	// but a change made outside of rendering (focus, maximize, title) needs its own flush.
+	wl.surface_commit(s.surface)
+}
+
+wl_frame_set_strip_visible :: proc(strip: ^WL_Frame_Strip, visible: bool) {
+	if visible {
+		if strip.shm_buf.buffer != nil {
+			wl.surface_attach(strip.surface, strip.shm_buf.buffer, 0, 0)
+			wl.surface_commit(strip.surface)
+		}
+	} else {
+		// Attaching no buffer unmaps a wl_surface -- there's no dedicated "hide" request.
+		wl.surface_attach(strip.surface, nil, 0, 0)
+		wl.surface_commit(strip.surface)
+	}
+}
+
+//--------------------//
+// TITLEBAR REPAINTING //
+//--------------------//
+
+wl_frame_repaint_titlebar :: proc(window_width: int) {
+	needs_repaint :=
+		window_width != s.frame.painted_width ||
+		s.scale != s.frame.painted_scale ||
+		s.activated != s.frame.painted_activated ||
+		s.frame.title_version != s.frame.painted_title_version ||
+		s.frame.hovered_button != s.frame.painted_hovered_button
+
+	if !needs_repaint {
+		return
+	}
+
+	wl_frame_paint_titlebar(window_width)
+
+	s.frame.painted_width = window_width
+	s.frame.painted_scale = s.scale
+	s.frame.painted_activated = s.activated
+	s.frame.painted_title_version = s.frame.title_version
+	s.frame.painted_hovered_button = s.frame.hovered_button
+}
+
+wl_frame_paint_titlebar :: proc(window_width: int) {
+	physical_w := max(1, int(math.round(f32(window_width) * s.scale)))
+	physical_h := max(1, int(math.round(f32(FRAME_TITLEBAR_HEIGHT + FRAME_BORDER) * s.scale)))
+
+	shm_buf, shm_buf_ok := wl_create_shm_buffer(physical_w, physical_h)
+	if !shm_buf_ok {
+		return
+	}
+
+	colors := make([]Color, physical_w * physical_h, frame_allocator)
+
+	bg := s.activated ? FRAME_COLOR_TITLEBAR_ACTIVE : FRAME_COLOR_TITLEBAR_INACTIVE
+	for &col in colors {
+		col = bg
+	}
+
+	border_px := min(int(math.round(f32(FRAME_BORDER) * s.scale)), physical_h)
+	for y in 0..<border_px {
+		for x in 0..<physical_w {
+			colors[y * physical_w + x] = FRAME_COLOR_BORDER
+		}
+	}
+
+	text_color := s.activated ? FRAME_COLOR_TEXT_ACTIVE : FRAME_COLOR_TEXT_INACTIVE
+
+	buttons, button_count := wl_frame_visible_buttons()
+	leftmost_button_px := physical_w
+
+	for button in buttons[:button_count] {
+		bx, by, bw, bh := wl_frame_button_rect(button, window_width)
+
+		px := int(math.round(f32(bx) * s.scale))
+		py := int(math.round(f32(by) * s.scale))
+		pw := int(math.round(f32(bw) * s.scale))
+		ph := int(math.round(f32(bh) * s.scale))
+
+		leftmost_button_px = min(leftmost_button_px, px)
+
+		icon_color := text_color
+
+		if s.frame.hovered_button == button {
+			if button == .Close {
+				wl_frame_fill_rect(colors, physical_w, physical_h, px, py, pw, ph, FRAME_COLOR_CLOSE_HOVER, 1)
+				icon_color = FRAME_COLOR_TEXT_ACTIVE
+			} else {
+				wl_frame_fill_rect(colors, physical_w, physical_h, px, py, pw, ph, FRAME_COLOR_BUTTON_HOVER, 1)
+			}
+		}
+
+		center_x := f32(px) + f32(pw) / 2
+		center_y := f32(py) + f32(ph) / 2
+		icon_half := f32(FRAME_BUTTON_ICON_SIZE) * s.scale / 2
+
+		wl_frame_paint_button_icon(
+			colors, physical_w, physical_h, button, center_x, center_y, icon_half, icon_color,
+		)
+	}
+
+	wl_frame_draw_text(colors, physical_w, physical_h, s.frame.title, leftmost_button_px, text_color)
+
+	corner_radius_px := int(math.round(f32(FRAME_CORNER_RADIUS) * s.scale))
+
+	pixel_data := ([^]u32)(shm_buf.data)
+	for y in 0..<physical_h {
+		for x in 0..<physical_w {
+			coverage := wl_frame_corner_coverage(x, y, physical_w, physical_h, corner_radius_px)
+			pixel_data[y * physical_w + x] = wl_frame_pack_color(colors[y * physical_w + x], coverage)
+		}
+	}
+
+	if s.frame.titlebar_buffer_old.buffer != nil {
+		// A repaint landed again before the previous one's release event fired (a fast resize
+		// drag). Free it immediately rather than queue it -- worst case a single frame tears,
+		// which is preferable to an unbounded queue of pending buffers.
+		wl.buffer_destroy(s.frame.titlebar_buffer_old.buffer)
+		wl_destroy_shm_buffer(s.frame.titlebar_buffer_old)
+	}
+
+	s.frame.titlebar_buffer_old = s.frame.titlebar_buffer
+	s.frame.titlebar_buffer = shm_buf
+
+	wl.add_listener(s.frame.titlebar_buffer.buffer, &titlebar_buffer_listener, nil)
+	wl.surface_attach(s.frame.titlebar_surface, s.frame.titlebar_buffer.buffer, 0, 0)
+	wl.surface_commit(s.frame.titlebar_surface)
+}
+
+// The previous titlebar buffer stays alive until the compositor confirms it's done reading from
+// it, since we can't safely free memory it might still be compositing from.
+titlebar_buffer_listener := wl.Buffer_Listener {
+	release = proc "c" (data: rawptr, buffer: ^wl.Buffer) {
+		context = s.odin_ctx
+
+		if buffer == s.frame.titlebar_buffer_old.buffer {
+			wl.buffer_destroy(buffer)
+			wl_destroy_shm_buffer(s.frame.titlebar_buffer_old)
+			s.frame.titlebar_buffer_old = {}
+		}
+	},
+}
+
+//---------//
+// BUTTONS //
+//---------//
+
+wl_frame_visible_buttons :: proc() -> (buttons: [3]WL_Frame_Button, count: int) {
+	if s.wm_can_minimize {
+		buttons[count] = .Minimize
+		count += 1
+	}
+	if s.wm_can_maximize {
+		buttons[count] = .Maximize
+		count += 1
+	}
+	buttons[count] = .Close
+	count += 1
+	return
+}
+
+// Logical-pixel hit rect for `button`, relative to the titlebar surface's own top-left (so `y`
+// already accounts for the top border strip). Shared between painting and wl_frame_hit_test below,
+// so the two can never disagree about where a button actually is.
+wl_frame_button_rect :: proc(button: WL_Frame_Button, window_width: int) -> (x, y, w, h: int) {
+	buttons, count := wl_frame_visible_buttons()
+
+	index := -1
+	for b, i in buttons[:count] {
+		if b == button {
+			index = i
+		}
+	}
+
+	if index == -1 {
+		return
+	}
+
+	from_right := count - index
+	step := FRAME_BUTTON_HIT_SIZE + FRAME_BUTTON_GAP
+	right_edge := window_width - FRAME_BUTTON_MARGIN - (from_right - 1) * step
+
+	x = right_edge - FRAME_BUTTON_HIT_SIZE
+	y = FRAME_BORDER + (FRAME_TITLEBAR_HEIGHT - FRAME_BUTTON_HIT_SIZE) / 2
+	w = FRAME_BUTTON_HIT_SIZE
+	h = FRAME_BUTTON_HIT_SIZE
+	return
+}
+
+//-------//
+// INPUT //
+//-------//
+
+// Which frame surface (if any) `surface` is. Used to route pointer events -- see pointer_listener
+// in platform_linux_window_wayland.odin.
+wl_frame_surface_role :: proc(surface: ^wl.Surface) -> WL_Frame_Surface {
+	if surface == nil {
+		return .None
+	}
+
+	switch surface {
+	case s.frame.titlebar_surface: return .Titlebar
+	case s.frame.left.surface:     return .Left
+	case s.frame.right.surface:    return .Right
+	case s.frame.bottom.surface:   return .Bottom
+	}
+
+	return .None
+}
+
+// The full window's logical-pixel width (content plus left/right insets), which is what frame
+// hit-testing and cursor decisions are expressed in.
+wl_frame_window_width :: proc() -> int {
+	left, _, right, _ := wl_frame_insets()
+	return s.last_configure_width + left + right
+}
+
+// What's under `local` (logical pixels, relative to whichever frame surface `role` names) --
+// a button, a resize edge (with corners near the ends of the titlebar and bottom strips), or the
+// titlebar's plain move/menu area. wl_frame_button_rect is the single source of truth for where
+// buttons are, so this and the painting code can never disagree.
+wl_frame_hit_test :: proc(role: WL_Frame_Surface, local: Vec2, window_width: int) -> WL_Frame_Hit {
+	switch role {
+	case .Titlebar:
+		buttons, count := wl_frame_visible_buttons()
+
+		for button in buttons[:count] {
+			bx, by, bw, bh := wl_frame_button_rect(button, window_width)
+			if local.x >= f32(bx) && local.x < f32(bx + bw) && local.y >= f32(by) && local.y < f32(by + bh) {
+				return {kind = .Button, button = button}
+			}
+		}
+
+		if local.y < FRAME_BORDER {
+			if local.x < FRAME_BORDER {
+				return {kind = .Resize, resize_edge = .Top_Left}
+			}
+			if local.x >= f32(window_width - FRAME_BORDER) {
+				return {kind = .Resize, resize_edge = .Top_Right}
+			}
+			return {kind = .Resize, resize_edge = .Top}
+		}
+
+		return {kind = .Move}
+
+	case .Left:
+		return {kind = .Resize, resize_edge = .Left}
+
+	case .Right:
+		return {kind = .Resize, resize_edge = .Right}
+
+	case .Bottom:
+		if local.x < FRAME_BORDER {
+			return {kind = .Resize, resize_edge = .Bottom_Left}
+		}
+		if local.x >= f32(window_width - FRAME_BORDER) {
+			return {kind = .Resize, resize_edge = .Bottom_Right}
+		}
+		return {kind = .Resize, resize_edge = .Bottom}
+
+	case .None:
+	}
+
+	return {}
+}
+
+wl_frame_resize_edge_wire :: proc(edge: WL_Frame_Resize_Edge) -> c.uint32_t {
+	switch edge {
+	case .Top:          return wl.XDG_TOPLEVEL_RESIZE_EDGE_TOP
+	case .Bottom:       return wl.XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM
+	case .Left:         return wl.XDG_TOPLEVEL_RESIZE_EDGE_LEFT
+	case .Right:        return wl.XDG_TOPLEVEL_RESIZE_EDGE_RIGHT
+	case .Top_Left:     return wl.XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT
+	case .Top_Right:    return wl.XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT
+	case .Bottom_Left:  return wl.XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT
+	case .Bottom_Right: return wl.XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT
+	case .None:
+	}
+	return wl.XDG_TOPLEVEL_RESIZE_EDGE_NONE
+}
+
+wl_frame_resize_edge_cursor :: proc(edge: WL_Frame_Resize_Edge) -> Standard_Cursor {
+	switch edge {
+	case .Top, .Bottom:            return .Resize_NS
+	case .Left, .Right:            return .Resize_EW
+	case .Top_Left, .Bottom_Right: return .Resize_NWSE
+	case .Top_Right, .Bottom_Left: return .Resize_NESW
+	case .None:
+	}
+	return .Default
+}
+
+// What cursor to show for the pointer's current position over a frame surface.
+wl_frame_cursor :: proc(role: WL_Frame_Surface) -> Standard_Cursor {
+	hit := wl_frame_hit_test(role, s.pointer_local, wl_frame_window_width())
+
+	if hit.kind != .Resize {
+		return .Default
+	}
+
+	return wl_frame_resize_edge_cursor(hit.resize_edge)
+}
+
+// Updates which button (if any) is hovered, and repaints the titlebar if that changed. Called
+// from pointer_listener.motion while over the titlebar.
+wl_frame_update_hover :: proc(role: WL_Frame_Surface) {
+	hit := wl_frame_hit_test(role, s.pointer_local, wl_frame_window_width())
+
+	new_hover := WL_Frame_Button.None
+	if hit.kind == .Button {
+		new_hover = hit.button
+	}
+
+	if new_hover == s.frame.hovered_button {
+		return
+	}
+
+	s.frame.hovered_button = new_hover
+	wl_frame_layout(s.last_configure_width, s.last_configure_height)
+}
+
+// Runs the effect of clicking `button` -- called on release, once pointer_listener has confirmed
+// the press and release both landed on the same button.
+wl_frame_click_button :: proc(button: WL_Frame_Button) {
+	switch button {
+	case .Close:
+		append(&s.events, Event_Close_Window_Requested{})
+
+	case .Maximize:
+		if s.maximized {
+			wl.xdg_toplevel_unset_maximized(s.toplevel)
+		} else {
+			wl.xdg_toplevel_set_maximized(s.toplevel)
+		}
+
+	case .Minimize:
+		wl.xdg_toplevel_set_minimized(s.toplevel)
+
+	case .None:
+	}
+}
+
+// Paints a button's icon (an X, a square outline, or a bar) as anti-aliased strokes centered at
+// (center_x, center_y), all in physical pixels.
+wl_frame_paint_button_icon :: proc(
+	colors: []Color,
+	buf_w: int,
+	buf_h: int,
+	button: WL_Frame_Button,
+	center_x: f32,
+	center_y: f32,
+	icon_half: f32,
+	color: Color,
+) {
+	segments: [4][4]f32
+	seg_count := 0
+
+	switch button {
+	case .Close:
+		segments[0] = {-icon_half, -icon_half, icon_half, icon_half}
+		segments[1] = {-icon_half, icon_half, icon_half, -icon_half}
+		seg_count = 2
+	case .Maximize:
+		segments[0] = {-icon_half, -icon_half, icon_half, -icon_half}
+		segments[1] = {icon_half, -icon_half, icon_half, icon_half}
+		segments[2] = {icon_half, icon_half, -icon_half, icon_half}
+		segments[3] = {-icon_half, icon_half, -icon_half, -icon_half}
+		seg_count = 4
+	case .Minimize:
+		segments[0] = {-icon_half, icon_half, icon_half, icon_half}
+		seg_count = 1
+	}
+
+	stroke := max(f32(1), s.scale)
+
+	min_x := max(0, int(center_x - icon_half - stroke))
+	max_x := min(buf_w - 1, int(center_x + icon_half + stroke))
+	min_y := max(0, int(center_y - icon_half - stroke))
+	max_y := min(buf_h - 1, int(center_y + icon_half + stroke))
+
+	for y in min_y..=max_y {
+		for x in min_x..=max_x {
+			coverage: f32 = 0
+
+			for i in 0..<seg_count {
+				seg := segments[i]
+				seg_coverage := wl_frame_line_coverage(
+					f32(x) - center_x, f32(y) - center_y,
+					seg[0], seg[1], seg[2], seg[3],
+					stroke,
+				)
+				coverage = max(coverage, seg_coverage)
+			}
+
+			if coverage > 0 {
+				idx := y * buf_w + x
+				colors[idx] = wl_frame_blend(colors[idx], color, coverage)
+			}
+		}
+	}
+}
+
+//------//
+// TEXT //
+//------//
+
+wl_frame_draw_text :: proc(
+	colors: []Color,
+	buf_w: int,
+	buf_h: int,
+	title: string,
+	right_limit_px: int,
+	color: Color,
+) {
+	if !s.frame.font_ok || right_limit_px <= 0 {
+		return
+	}
+
+	pixel_height := f32(FRAME_TEXT_SIZE) * s.scale
+	scale := stbtt.ScaleForPixelHeight(&s.frame.font, pixel_height)
+
+	ascent, descent, line_gap: i32
+	stbtt.GetFontVMetrics(&s.frame.font, &ascent, &descent, &line_gap)
+
+	total_width: f32 = 0
+	for r in title {
+		idx := stbtt.FindGlyphIndex(&s.frame.font, r)
+		if idx <= 0 {
+			continue
+		}
+		advance: i32
+		stbtt.GetGlyphHMetrics(&s.frame.font, idx, &advance, nil)
+		total_width += f32(advance) * scale
+	}
+
+	available_left := f32(int(math.round(f32(FRAME_TEXT_MARGIN) * s.scale)))
+	available_width := f32(right_limit_px) - available_left
+
+	if available_width <= 0 {
+		return
+	}
+
+	pen_x := available_left + max(0, (available_width - total_width) / 2)
+	titlebar_top_px := f32(int(math.round(f32(FRAME_BORDER) * s.scale)))
+	baseline_y :=
+		titlebar_top_px + f32(FRAME_TITLEBAR_HEIGHT) * s.scale / 2 + f32(ascent + descent) * scale / 2
+
+	for r in title {
+		if pen_x >= f32(right_limit_px) {
+			break // Out of room -- simplest form of clipping a too-long title.
+		}
+
+		idx := stbtt.FindGlyphIndex(&s.frame.font, r)
+		if idx <= 0 {
+			continue
+		}
+
+		advance: i32
+		stbtt.GetGlyphHMetrics(&s.frame.font, idx, &advance, nil)
+
+		w, h, xoff, yoff: c.int
+		bitmap := stbtt.GetGlyphBitmap(&s.frame.font, scale, scale, idx, &w, &h, &xoff, &yoff)
+
+		if bitmap != nil {
+			for by in 0..<int(h) {
+				for bx in 0..<int(w) {
+					dst_x := int(pen_x) + int(xoff) + bx
+					dst_y := int(baseline_y) + int(yoff) + by
+
+					if dst_x < 0 || dst_x >= buf_w || dst_y < 0 || dst_y >= buf_h || dst_x >= right_limit_px {
+						continue
+					}
+
+					coverage := f32(bitmap[by * int(w) + bx]) / 255
+					if coverage <= 0 {
+						continue
+					}
+
+					dst_idx := dst_y * buf_w + dst_x
+					colors[dst_idx] = wl_frame_blend(colors[dst_idx], color, coverage)
+				}
+			}
+
+			stbtt.FreeBitmap(bitmap, nil)
+		}
+
+		pen_x += f32(advance) * scale
+	}
+}
+
+//----------------//
+// PIXEL HELPERS //
+//----------------//
+
+// Blends `color` at `coverage` over every pixel in the `w` x `h` rect at (x,y), clipped to the
+// buffer. Used for button hover backgrounds.
+wl_frame_fill_rect :: proc(
+	colors: []Color,
+	buf_w: int,
+	buf_h: int,
+	x, y, w, h: int,
+	color: Color,
+	coverage: f32,
+) {
+	min_x := max(0, x)
+	max_x := min(buf_w - 1, x + w - 1)
+	min_y := max(0, y)
+	max_y := min(buf_h - 1, y + h - 1)
+
+	for py in min_y..=max_y {
+		for px in min_x..=max_x {
+			idx := py * buf_w + px
+			colors[idx] = wl_frame_blend(colors[idx], color, coverage)
+		}
+	}
+}
+
+// Anti-aliased coverage (0..1) for how much a stroke of `thickness` along the segment
+// (x0,y0)-(x1,y1) covers the point (px,py). All in the same space (physical pixels here).
+wl_frame_line_coverage :: proc(px, py, x0, y0, x1, y1, thickness: f32) -> f32 {
+	dx := x1 - x0
+	dy := y1 - y0
+	len_sq := dx*dx + dy*dy
+
+	t: f32 = 0
+	if len_sq > 0 {
+		t = clamp(((px - x0) * dx + (py - y0) * dy) / len_sq, 0, 1)
+	}
+
+	cx := x0 + t*dx
+	cy := y0 + t*dy
+	dist := math.sqrt((px - cx) * (px - cx) + (py - cy) * (py - cy))
+
+	half := thickness / 2
+	if dist <= half - 0.5 {
+		return 1
+	}
+	if dist >= half + 0.5 {
+		return 0
+	}
+	return half + 0.5 - dist
+}
+
+// Anti-aliased coverage (0..1) for whether the pixel at (px,py) in a `w` x `h` buffer falls
+// inside a rounded top corner. 1 (fully opaque) everywhere except within `radius` physical
+// pixels of a top corner; only the top corners round, matching GNOME's own windows.
+wl_frame_corner_coverage :: proc(px, py, w, h, radius: int) -> f32 {
+	if radius <= 0 {
+		return 1
+	}
+
+	cx, cy: int
+	corner := false
+
+	if px < radius && py < radius {
+		cx, cy = radius, radius
+		corner = true
+	} else if px >= w - radius && py < radius {
+		cx, cy = w - radius - 1, radius
+		corner = true
+	}
+
+	if !corner {
+		return 1
+	}
+
+	dx := f32(px - cx)
+	dy := f32(py - cy)
+	dist := math.sqrt(dx*dx + dy*dy)
+	r := f32(radius)
+
+	if dist <= r - 0.5 {
+		return 1
+	}
+	if dist >= r + 0.5 {
+		return 0
+	}
+	return r + 0.5 - dist
+}
+
+// Blends `fg` over the opaque `bg` at `coverage` (0..1), scaled by fg's own alpha. Every frame
+// color is fully opaque, so this always returns a fully opaque result -- true transparency (the
+// rounded corners) is applied once, separately, in wl_frame_pack_color.
+wl_frame_blend :: proc(bg: Color, fg: Color, coverage: f32) -> Color {
+	t := coverage * f32(fg.a) / 255
+	return {
+		u8(f32(bg.r) + (f32(fg.r) - f32(bg.r)) * t),
+		u8(f32(bg.g) + (f32(fg.g) - f32(bg.g)) * t),
+		u8(f32(bg.b) + (f32(fg.b) - f32(bg.b)) * t),
+		255,
+	}
+}
+
+// Packs a straight color into a premultiplied ARGB8888 u32, with its own alpha additionally
+// scaled by `coverage` -- used to carve the transparent rounded corners out of an otherwise
+// opaque buffer.
+wl_frame_pack_color :: proc(col: Color, coverage: f32) -> u32 {
+	a := f32(col.a) * coverage
+	r := f32(col.r) * a / 255
+	g := f32(col.g) * a / 255
+	b := f32(col.b) * a / 255
+	return u32(a) << 24 | u32(r) << 16 | u32(g) << 8 | u32(b)
+}


### PR DESCRIPTION
Fixes the missing window borders and titlebar on GNOME/Wayland.

## What was wrong

We already ask for server-side decorations via `zxdg_decoration_manager_v1`, which is why KDE and sway are fine. GNOME's Mutter does not implement that protocol and never advertises the global, so `s.decoration_manager` stayed `nil` and we got nothing at all there: no titlebar, no borders, no resize edges, no window menu.

## What this does

Draws the frame ourselves when the compositor won't. No new dependencies — libdecor was considered and rejected, since it would take over `xdg_surface`/`xdg_toplevel` creation and pull GTK into the game process.

Four `wl_subsurface`s sit *outside* the content surface, placed below it: a painted titlebar plus three border strips. The content surface is untouched, so the game still sees the same screen size and the same surface-local mouse coordinates. **No API change, no `karl2d.doc.odin` regeneration.**

- The three border strips are 1x1 pixel shm buffers stretched by a `wp_viewport`, so they never repaint on resize.
- Only the titlebar holds a real painted buffer, and it repaints only when its width, scale, focus, maximized state, title or hovered button actually change.
- Title text is rasterized with `stb_truetype` straight into the shm buffer, using the already-embedded default font. This file is `package karl2d`, so `DEFAULT_FONT_DATA` is directly reachable — no fontstash, no atlas, no core→platform plumbing.
- Top corners are rounded, since square ones are the giveaway that a window is foreign on GNOME.
- Drag to move, double-click to maximize, right-click for GNOME's window menu, all borders and corners resize with the right cursor, and minimize/maximize/close buttons (only the ones `wm_capabilities` says the compositor supports).

## On the structure

The frame is additive rather than a second window implementation living behind `if` statements. `wl_frame_insets()` returns all zeros when there is no frame, so the window-geometry arithmetic in `toplevel_listener.configure`, `wl_set_window_mode` and `wl_set_screen_size` is identical either way, and every `wl_frame_*` procedure no-ops when the frame does not exist. The only genuine branches are in pointer routing, where frame surfaces do have to be told apart from the game's content surface.

All frame code is in the new `platform_linux_window_wayland_frame.odin`.

## Drive-by fixes

Three pre-existing bugs in the decoration protocol handling, all needed to know whether to draw a frame at all:

- `get_toplevel_decoration` and friends were typed against `ZXDG_Decoration_Manager_V1` instead of `ZXDG_Toplevel_Decoration_V1`.
- We never listened for the decoration's `configure` event, even though `set_mode` is only a request a compositor may refuse.
- The decoration object was never destroyed.

The toplevel `states` array and `wm_capabilities` were also being discarded; both are needed to know when to hide the borders and which buttons to draw.

## Testing status — needs a real run

**I could not build or run this.** It was written on Windows: no WSL, and the vendored STB libraries ship no `linux_amd64` build, so the `karl2d` package hits a compile-time `#panic` unrelated to this change.

What I did verify:
- `platform_bindings/linux/wayland` type-checks clean under `-vet -strict-style -vet-tabs`.
- The whole of `platform_linux_window_wayland_frame.odin` compiles clean under the same flags against a stub harness (stub `karl2d` symbols + a stub `stbtt` with signatures copied verbatim from the real binding). That caught a real compile error — a non-exhaustive switch — plus several logic bugs, all fixed in the second commit.
- `platform_linux_window_wayland.odin` itself is **only reviewed by hand**, not compiled. That is the main risk in this PR.

Still to check on real hardware, per the plan:

- [ ] GNOME: titlebar with correct centred text; drag moves; double-click maximizes and restores; all three buttons; every border and corner resizes with the right cursor; right-click window menu; close button and the compositor's own close both quit cleanly
- [ ] Long title clips instead of overlapping the buttons
- [ ] `.Windowed` fixed size cannot be resized and does not drift across maximize/restore; `.Borderless_Fullscreen` covers the output with no frame and restores correctly
- [ ] HiDPI at 100/125/150/200%, and dragging between monitors of different scale
- [ ] Game input unaffected: mouse position at the top row of the content area is 0, no phantom clicks crossing the frame, `examples/cursors` still works, mouse locking still works
- [ ] KDE and sway still server-side decorated and visually unchanged
- [ ] X11 unchanged
- [ ] `odin run tools/test_examples`

## Known limitations

- **No drop shadow.** GNOME's windows have one; ours looks flatter. A shadow needs an alpha gradient in the border buffers, which kills the cheap 1x1-stretch trick.
- **Not Adwaita.** It is Karl2D's own titlebar, not the user's GTK theme.
- We still never call `set_app_id`, which GNOME uses to match a `.desktop` file for the window icon. Natural follow-up now that there is a titlebar to put an icon in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
