### PR TITLE
Audio buses

### DIFF
--- a/examples/audio_bus/audio_bus.odin
+++ b/examples/audio_bus/audio_bus.odin
@@ -1,0 +1,236 @@
+// Shows how to use audio buses. A bus is a group of sounds that are mixed together before they
+// reach the master bus. You can set the volume and the pan of the whole group at once, and you can
+// run your own effect on it.
+//
+// This example puts some sound effects on a bus and leaves a tone on the master bus, so you can
+// hear that the bus volume only affects the things routed to it.
+//
+// Compile using command-line by going to the Karl2D repository root folder and executing:
+// `odin run build_web -- examples/audio_bus`
+package karl2d_audio_bus_example
+
+import k2 "../.."
+import "core:math"
+import "core:math/rand"
+import "core:mem"
+import "core:fmt"
+import "core:slice"
+
+sfx_bus: k2.Audio_Bus
+sfx_bus_destroyed: bool
+
+// Played as one-shots on the sfx bus. Several of these can overlap.
+blip: k2.Audio_Buffer
+
+// A drone on the sfx bus, so you can hear the bus volume and pan without pressing anything.
+drone: k2.Sound
+drone_buffer: k2.Audio_Buffer
+
+// This one stays on the master bus. It is what the sfx bus volume does NOT affect.
+tone: k2.Sound
+tone_buffer: k2.Audio_Buffer
+
+sfx_volume: f32 = 1
+sfx_pan: f32
+master_volume: f32 = 1
+filter_enabled: bool
+
+// The filter needs to remember the previous output to do its job. That is what `user_data` is for:
+// the effect is called once per mixed chunk, so anything it wants to carry across the chunks has to
+// live outside of it.
+Low_Pass :: struct {
+	prev: [2]f32,
+}
+
+low_pass: Low_Pass
+
+// A one pole low pass filter. Each output sample is nudged from the previous output towards the
+// input, which smooths the waveform out and takes the high frequencies with it.
+low_pass_effect :: proc(samples: [][2]k2.Audio_Sample, user_data: rawptr) {
+	lp := (^Low_Pass)(user_data)
+
+	// How much of the way to the input we move each sample. Lower value, darker sound.
+	CUTOFF :: 0.05
+
+	for &samp in samples {
+		lp.prev += (samp - lp.prev) * CUTOFF
+		samp = lp.prev
+	}
+}
+
+init :: proc() {
+	k2.init(1280, 720, "Karl2D Audio Bus")
+
+	sfx_bus = k2.create_audio_bus()
+
+	// A sound doesn't own the audio buffer it was created from, so we hang on to the buffers and
+	// destroy them ourselves further down.
+	blip = make_sine_wave(600, 0.12, 44100)
+	drone_buffer = make_sine_wave(80, 1, 44100)
+	tone_buffer = make_sine_wave(220, 1, 44100)
+	drone = k2.create_sound_from_audio_buffer(drone_buffer)
+	tone = k2.create_sound_from_audio_buffer(tone_buffer)
+
+	// The drone goes on the sfx bus. The tone is left alone, so it plays on the master bus.
+	k2.set_sound_bus(drone, sfx_bus)
+	k2.set_sound_volume(drone, 0.3)
+	k2.set_sound_loop(drone, true)
+	k2.play_sound(drone)
+
+	k2.set_sound_volume(tone, 0.15)
+	k2.set_sound_loop(tone, true)
+	k2.play_sound(tone)
+}
+
+// Makes a sine wave that is a whole number of periods long, so that it loops cleanly.
+make_sine_wave :: proc(freq: int, min_length: f32, sample_rate: int) -> k2.Audio_Buffer {
+	period_num_samples := f32(sample_rate) / f32(freq)
+	num_periods := math.ceil(f32(sample_rate) * min_length)
+	sine_data := make([]k2.Audio_Sample, int(num_periods), allocator = context.temp_allocator)
+	inc := (2.0*math.PI) / period_num_samples
+
+	for &samp, i in sine_data {
+		samp = math.sin(f32(i) * inc) * 0.25
+	}
+
+	bytes := slice.reinterpret([]u8, sine_data)
+	return k2.load_audio_buffer_from_bytes_raw(bytes, .Float32, sample_rate, .Mono)
+}
+
+step :: proc() -> bool {
+	if !k2.update() {
+		return false
+	}
+
+	// SOUNDS
+
+	// Each press starts a separate playback, so pressing quickly overlaps them. The pitch is
+	// randomized to make that easier to hear.
+	if k2.key_went_down(.Space) {
+		k2.play_audio_buffer(blip, pitch = rand.float32_range(0.8, 1.6), bus = sfx_bus)
+	}
+
+	// BUS SETTINGS
+
+	if k2.key_is_held(.Up) {
+		sfx_volume += k2.get_frame_time()
+	}
+
+	if k2.key_is_held(.Down) {
+		sfx_volume -= k2.get_frame_time()
+	}
+
+	if k2.key_is_held(.Left) {
+		sfx_pan -= k2.get_frame_time()
+	}
+
+	if k2.key_is_held(.Right) {
+		sfx_pan += k2.get_frame_time()
+	}
+
+	if k2.key_is_held(.W) {
+		master_volume += k2.get_frame_time()
+	}
+
+	if k2.key_is_held(.S) {
+		master_volume -= k2.get_frame_time()
+	}
+
+	sfx_volume = clamp(sfx_volume, 0, 1)
+	sfx_pan = clamp(sfx_pan, -1, 1)
+	master_volume = clamp(master_volume, 0, 1)
+
+	k2.set_audio_bus_volume(sfx_bus, sfx_volume)
+	k2.set_audio_bus_pan(sfx_bus, sfx_pan)
+
+	// The master bus is just a bus like the others. This is how you make a master volume slider.
+	k2.set_audio_bus_volume(k2.AUDIO_BUS_MASTER, master_volume)
+
+	if k2.key_went_down(.F) {
+		filter_enabled = !filter_enabled
+
+		if filter_enabled {
+			k2.set_audio_bus_effect(sfx_bus, low_pass_effect, &low_pass)
+		} else {
+			k2.set_audio_bus_effect(sfx_bus, nil)
+		}
+	}
+
+	// Destroying a bus moves everything on it back to the master bus. The drone keeps playing, it
+	// just stops listening to the sfx volume. Note that we point our own handle at the master bus
+	// afterwards, since the old one is dead.
+	if k2.key_went_down(.D) && !sfx_bus_destroyed {
+		k2.destroy_audio_bus(sfx_bus)
+		sfx_bus = k2.AUDIO_BUS_MASTER
+		sfx_bus_destroyed = true
+	}
+
+	// DRAW
+
+	k2.clear(k2.WHITE)
+
+	bus_label := "The drone and the blips are on the sfx bus."
+
+	if sfx_bus_destroyed {
+		bus_label = "The sfx bus is destroyed. Everything is on the master bus now."
+	}
+
+	k2.draw_text(
+		fmt.tprintf(
+			"%s\n" +
+			"Sfx bus volume: %.2f (up/down)\n" +
+			"Sfx bus pan: %.2f (left/right)\n" +
+			"Master volume: %.2f (W/S)\n" +
+			"Sfx bus filter: %v (F to toggle)",
+			bus_label,
+			sfx_volume,
+			sfx_pan,
+			master_volume,
+			filter_enabled ? "on" : "off",
+		),
+		{20, 20},
+		36,
+		k2.BLACK,
+	)
+
+	k2.draw_text("Press Space to play a blip on the sfx bus.", {20, 240}, 36, k2.BLACK)
+	k2.draw_text("Press D to destroy the sfx bus.", {20, 280}, 36, k2.BLACK)
+	k2.draw_text("The 220 hz tone stays on the master bus the whole time.", {20, 320}, 36, k2.BLACK)
+	k2.present()
+	free_all(context.temp_allocator)
+
+	return true
+}
+
+shutdown :: proc() {
+	k2.destroy_sound(drone)
+	k2.destroy_sound(tone)
+	k2.destroy_audio_buffer(blip)
+	k2.destroy_audio_buffer(drone_buffer)
+	k2.destroy_audio_buffer(tone_buffer)
+
+	if !sfx_bus_destroyed {
+		k2.destroy_audio_bus(sfx_bus)
+	}
+
+	k2.shutdown()
+}
+
+// This is not run by the web version, but it makes this program also work on non-web!
+main :: proc() {
+	track: mem.Tracking_Allocator
+	mem.tracking_allocator_init(&track, context.allocator)
+	context.allocator = mem.tracking_allocator(&track)
+
+	init()
+	for step() {}
+	shutdown()
+
+	if len(track.allocation_map) > 0 {
+		fmt.eprintf("=== %v allocations not freed: ===\n", len(track.allocation_map))
+		for _, entry in track.allocation_map {
+			fmt.eprintf("- %v bytes @ %v\n", entry.size, entry.location)
+		}
+	}
+	mem.tracking_allocator_destroy(&track)
+}

--- a/examples/audio_bus/audio_bus.odin
+++ b/examples/audio_bus/audio_bus.odin
@@ -140,29 +140,36 @@ step :: proc() -> bool {
 	sfx_pan = clamp(sfx_pan, -1, 1)
 	master_volume = clamp(master_volume, 0, 1)
 
-	k2.set_audio_bus_volume(sfx_bus, sfx_volume)
-	k2.set_audio_bus_pan(sfx_bus, sfx_pan)
+	// After the sfx bus is destroyed, `sfx_bus` points at the master bus, so these setters would
+	// start controlling the master bus. Not what the sfx keys are for, hence the guard.
+	if !sfx_bus_destroyed {
+		k2.set_audio_bus_volume(sfx_bus, sfx_volume)
+		k2.set_audio_bus_pan(sfx_bus, sfx_pan)
+
+		if k2.key_went_down(.F) {
+			filter_enabled = !filter_enabled
+
+			if filter_enabled {
+				k2.set_audio_bus_effect(sfx_bus, low_pass_effect, &low_pass)
+			} else {
+				k2.set_audio_bus_effect(sfx_bus, nil)
+			}
+		}
+	}
 
 	// The master bus is just a bus like the others. This is how you make a master volume slider.
 	k2.set_audio_bus_volume(k2.AUDIO_BUS_MASTER, master_volume)
 
-	if k2.key_went_down(.F) {
-		filter_enabled = !filter_enabled
-
-		if filter_enabled {
-			k2.set_audio_bus_effect(sfx_bus, low_pass_effect, &low_pass)
-		} else {
-			k2.set_audio_bus_effect(sfx_bus, nil)
-		}
-	}
-
 	// Destroying a bus moves everything on it back to the master bus. The drone keeps playing, it
-	// just stops listening to the sfx volume. Note that we point our own handle at the master bus
-	// afterwards, since the old one is dead.
+	// just stops listening to the sfx volume. We point our own handle at the master bus afterwards,
+	// since the old one is dead. That keeps the blips playable.
 	if k2.key_went_down(.D) && !sfx_bus_destroyed {
 		k2.destroy_audio_bus(sfx_bus)
 		sfx_bus = k2.AUDIO_BUS_MASTER
 		sfx_bus_destroyed = true
+
+		// The effect died with the bus.
+		filter_enabled = false
 	}
 
 	// DRAW

--- a/examples/space_cat/space_cat.odin
+++ b/examples/space_cat/space_cat.odin
@@ -115,8 +115,8 @@ bg_object_textures: [6]k2.Texture
 fg_object_textures: [7]k2.Texture
 plasma_ball_textures: [3]k2.Texture
 
-// We play these audio buffers directly using `play_audio_buffer`. This way multiple sounds can be
-// played at once.
+// We play these audio buffers directly using `play_audio_buffer`. That's good for these kind of
+// "one-shot" sounds that just need some initial playback settings.
 ab_shoot: k2.Audio_Buffer
 ab_pickup: k2.Audio_Buffer
 ab_hit: k2.Audio_Buffer

--- a/examples/space_cat/space_cat.odin
+++ b/examples/space_cat/space_cat.odin
@@ -115,12 +115,11 @@ bg_object_textures: [6]k2.Texture
 fg_object_textures: [7]k2.Texture
 plasma_ball_textures: [3]k2.Texture
 
-// We use audio buffers from which we create sounds when needed. This way multiple sounds can be
+// We play these audio buffers directly using `play_audio_buffer`. This way multiple sounds can be
 // played at once.
 ab_shoot: k2.Audio_Buffer
 ab_pickup: k2.Audio_Buffer
 ab_hit: k2.Audio_Buffer
-playing_sounds: [dynamic]k2.Sound
 
 // For making a texture appear on the screen for a short period.
 flash_texture: k2.Texture
@@ -352,11 +351,6 @@ shutdown :: proc() {
 		k2.destroy_texture(t)	
 	}
 
-	for ps in playing_sounds {
-		k2.destroy_sound(ps)
-	}
-
-	delete(playing_sounds)
 	k2.destroy_audio_buffer(ab_hit)
 	k2.destroy_audio_buffer(ab_pickup)
 	k2.destroy_audio_buffer(ab_shoot)
@@ -398,14 +392,6 @@ update :: proc() {
 		}
 
 		return
-	}
-
-	for ps_idx := 0; ps_idx < len(playing_sounds); ps_idx += 1 {
-		if !k2.sound_is_playing(playing_sounds[ps_idx]) {
-			k2.destroy_sound(playing_sounds[ps_idx])
-			unordered_remove(&playing_sounds, ps_idx)
-			ps_idx -= 1
-		}
 	}
 
 	movement: Vec2
@@ -530,13 +516,12 @@ update :: proc() {
 		})
 
 		// The shoot sound has pitch randomization and spatial panning.
-		shoot_snd := k2.create_sound_from_audio_buffer(ab_shoot)
-		k2.set_sound_pitch(shoot_snd, rand.float32_range(0.8, 1.2))
-		pan := math.remap_clamped(player.pos.x, 0, SCREEN_WIDTH, -0.5, 0.5)
-		k2.set_sound_pan(shoot_snd, pan)
-		k2.set_sound_volume(shoot_snd, rand.float32_range(0.7, 0.9))
-		k2.play_sound(shoot_snd)
-		append(&playing_sounds, shoot_snd)
+		k2.play_audio_buffer(
+			ab_shoot,
+			volume = rand.float32_range(0.7, 0.9),
+			pan = math.remap_clamped(player.pos.x, 0, SCREEN_WIDTH, -0.5, 0.5),
+			pitch = rand.float32_range(0.8, 1.2),
+		)
 	}
 
 	// Make stars twinkle. It's just a timer that makes a single star, picked at random, twinkle.
@@ -606,9 +591,7 @@ update :: proc() {
 					flash_texture_timer = 0.2
 					flash_texture_pos = p.pos
 					pidx -= 1
-					hit_snd := k2.create_sound_from_audio_buffer(ab_hit)
-					k2.play_sound(hit_snd)
-					append(&playing_sounds, hit_snd)
+					k2.play_audio_buffer(ab_hit)
 				}
 			}
 
@@ -617,9 +600,7 @@ update :: proc() {
 				unordered_remove(&current_room.interactables, inter_idx)
 				inter_idx -= 1
 				has_key = true
-				pickup_snd := k2.create_sound_from_audio_buffer(ab_pickup)
-				k2.play_sound(pickup_snd)
-				append(&playing_sounds, pickup_snd)
+				k2.play_audio_buffer(ab_pickup)
 			}
 
 		case .Wall:

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -526,6 +526,16 @@ set_texture_filter_ex :: proc(
 // The sound will be mixed when `update_audio_mixer` runs, which happens as part of `update`.
 play_sound :: proc(sound: Sound)
 
+// Play an audio buffer once, using the playback settings you pass in. This is a shortcut for
+// one-shot sounds such as gunshots and footsteps: You don't need to create a `Sound` for the
+// buffer, and each call starts a separate playback, so repeated calls overlap instead of
+// restarting each other.
+//
+// You get nothing back, so there is no way to stop or modify the playback once it has started.
+// Create a `Sound` using `create_sound_from_audio_buffer` when you need that control. That is also
+// why there is no looping here: A looping playback that nothing can stop would play forever.
+play_audio_buffer :: proc(ab: Audio_Buffer, volume: f32 = 1, pan: f32 = 0, pitch: f32 = 1)
+
 // Stop a sound. Rewinds it to the start.
 stop_sound :: proc(sound: Sound)
 

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -526,13 +526,12 @@ set_texture_filter_ex :: proc(
 // The sound will be mixed when `update_audio_mixer` runs, which happens as part of `update`.
 play_sound :: proc(sound: Sound)
 
-// Play an audio buffer once, using the playback settings you pass in. This is good for doing playing
-// sounds once. Multiple instances of the same audio buffer can play at the same time, so it is use-
-// ful for stuff like footsteps etc.
+// Play an audio buffer, using the playback settings you pass in. The playback does not loop. Good
+// for playing one-off sound effects such as footsteps. You can play the same Audio_Buffer multiple
+// times simultaneously, without one stopping the another.
 //
-// This procedure returns nothing, so you cannot stop the playback. If you need stoppable playback,
-// then create a `Sound` using `create_sound_from_audio_buffer`. You also cannot loop these sounds,
-// for that, also use `Sound`.
+// The difference between using this and a `Sound` is that the `Sound` remembers its playback
+// settings, can be stopped and looped.
 //
 // Pass `bus` to play the sound on an audio bus. It plays on the master bus by default.
 play_audio_buffer :: proc(

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -526,14 +526,13 @@ set_texture_filter_ex :: proc(
 // The sound will be mixed when `update_audio_mixer` runs, which happens as part of `update`.
 play_sound :: proc(sound: Sound)
 
-// Play an audio buffer once, using the playback settings you pass in. This is a shortcut for
-// one-shot sounds such as gunshots and footsteps: You don't need to create a `Sound` for the
-// buffer, and each call starts a separate playback, so repeated calls overlap instead of
-// restarting each other.
+// Play an audio buffer once, using the playback settings you pass in. This is good for doing playing
+// sounds once. Multiple instances of the same audio buffer can play at the same time, so it is use-
+// ful for stuff like footsteps etc.
 //
-// You get nothing back, so there is no way to stop or modify the playback once it has started.
-// Create a `Sound` using `create_sound_from_audio_buffer` when you need that control. That is also
-// why there is no looping here: A looping playback that nothing can stop would play forever.
+// This procedure returns nothing, so you cannot stop the playback. If you need stoppable playback,
+// then create a `Sound` using `create_sound_from_audio_buffer`. You also cannot loop these sounds,
+// for that, also use `Sound`.
 //
 // Pass `bus` to play the sound on an audio bus. It plays on the master bus by default.
 play_audio_buffer :: proc(
@@ -570,10 +569,10 @@ set_sound_pitch :: proc(sound: Sound, pitch: f32)
 set_sound_loop :: proc(sound: Sound, loop: bool)
 
 // Route a sound into an audio bus. The sound is then mixed into that bus instead of straight into
-// the master bus, letting you control it together with everything else on the bus.
+// the master bus. You can set the volume and pan of the whole bus, making it possible to control
+// whole categories of sounds.
 //
-// You can set this before playing but also while playing the sound. Pass `AUDIO_BUS_MASTER` to put
-// the sound back on the master bus.
+// Pass `AUDIO_BUS_MASTER` to route the sound to the master bus.
 set_sound_bus :: proc(sound: Sound, bus: Audio_Bus)
 
 // Load a WAV file from disk. Returns a `Sound` which can be used with `play_sound`. If you need to
@@ -768,7 +767,7 @@ set_audio_stream_bus :: proc(stream: Audio_Stream, bus: Audio_Bus)
 create_audio_bus :: proc() -> Audio_Bus
 
 // Destroy an audio bus. Everything routed to it goes back to the master bus, including sounds that
-// are playing right now. Those keep playing, they just play on the master bus from here on.
+// are playing right now.
 destroy_audio_bus :: proc(bus: Audio_Bus)
 
 // Set the volume of an audio bus. Range: 0 to 1. Everything mixed into the bus is scaled by this.
@@ -1640,11 +1639,8 @@ Playing_Audio_Buffer :: struct {
 // `bus` parameter of `play_audio_buffer`.
 Audio_Bus :: distinct Handle
 
-// The master bus. Everything ends up here and this is what the audio backend is fed.
-//
-// Note that this is the zero value, not an `AUDIO_BUS_NONE`: Anything that has not been routed
-// anywhere plays on the master bus, so code that doesn't care about buses gets the master bus
-// without doing anything. A sound always plays somewhere, so "no bus" is not a thing.
+// All other buses are mixed into the master bus, as well as sounds that play directly on the master
+// bus. This is the default bus of all sounds, audio streams and playing audio buffers.
 //
 // You can use this with `set_audio_bus_volume`, `set_audio_bus_pan` and `set_audio_bus_effect`.
 // That's how you set the master volume of your game.
@@ -1657,8 +1653,8 @@ AUDIO_BUS_MASTER :: Audio_Bus {}
 // your effect needs in `user_data`: You get called once per mixed chunk, so anything you want to
 // carry between the chunks needs to live there.
 //
-// This runs on the main thread today, from within `update_audio_mixer`. Don't allocate and don't
-// log in here. The mixer may move to a separate thread later.
+// This runs on the main thread today, but keep in mind that it may move to a separate thread in the
+// future.
 Audio_Effect_Proc :: proc(samples: [][2]Audio_Sample, user_data: rawptr)
 
 Audio_Bus_Settings :: struct {

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -534,7 +534,15 @@ play_sound :: proc(sound: Sound)
 // You get nothing back, so there is no way to stop or modify the playback once it has started.
 // Create a `Sound` using `create_sound_from_audio_buffer` when you need that control. That is also
 // why there is no looping here: A looping playback that nothing can stop would play forever.
-play_audio_buffer :: proc(ab: Audio_Buffer, volume: f32 = 1, pan: f32 = 0, pitch: f32 = 1)
+//
+// Pass `bus` to play the sound on an audio bus. It plays on the master bus by default.
+play_audio_buffer :: proc(
+	ab: Audio_Buffer,
+	volume: f32 = 1,
+	pan: f32 = 0,
+	pitch: f32 = 1,
+	bus: Audio_Bus = AUDIO_BUS_MASTER,
+)
 
 // Stop a sound. Rewinds it to the start.
 stop_sound :: proc(sound: Sound)
@@ -560,6 +568,13 @@ set_sound_pitch :: proc(sound: Sound, pitch: f32)
 // Makes a sound loop when it reaches the end. You can set this before playing but also while
 // playing the sound.
 set_sound_loop :: proc(sound: Sound, loop: bool)
+
+// Route a sound into an audio bus. The sound is then mixed into that bus instead of straight into
+// the master bus, letting you control it together with everything else on the bus.
+//
+// You can set this before playing but also while playing the sound. Pass `AUDIO_BUS_MASTER` to put
+// the sound back on the master bus.
+set_sound_bus :: proc(sound: Sound, bus: Audio_Bus)
 
 // Load a WAV file from disk. Returns a `Sound` which can be used with `play_sound`. If you need to
 // play a sound multiple times simultaneously, then use `load_audio_buffer_from_file` followed by
@@ -735,6 +750,49 @@ set_audio_stream_pitch :: proc(stream: Audio_Stream, pitch: f32)
 // Set the audio stream to loop when it reaches the end of the stream. You can set this before
 // playing the stream. You can also modify the loop state of an already playing stream.
 set_audio_stream_loop :: proc(stream: Audio_Stream, loop: bool)
+
+// Route an audio stream into an audio bus. The stream is then mixed into that bus instead of
+// straight into the master bus. Handy for putting your music on its own bus, so the player can
+// turn the music down without turning the sound effects down.
+//
+// You can use this both with a playing and non-playing stream. If it's already playing, then this
+// will affect the playing stream. Pass `AUDIO_BUS_MASTER` to put it back on the master bus.
+set_audio_stream_bus :: proc(stream: Audio_Stream, bus: Audio_Bus)
+
+// Create an audio bus: A group of sounds that are mixed together before they reach the master bus.
+// Route sounds into it using `set_sound_bus`, `set_audio_stream_bus`, or the `bus` parameter of
+// `play_audio_buffer`.
+//
+// A new bus has volume 1, pan 0 and no effect. That makes it a passthrough: Playing a sound on a
+// fresh bus sounds exactly like playing it on the master bus, until you change something.
+create_audio_bus :: proc() -> Audio_Bus
+
+// Destroy an audio bus. Everything routed to it goes back to the master bus, including sounds that
+// are playing right now. Those keep playing, they just play on the master bus from here on.
+destroy_audio_bus :: proc(bus: Audio_Bus)
+
+// Set the volume of an audio bus. Range: 0 to 1. Everything mixed into the bus is scaled by this.
+//
+// This works on `AUDIO_BUS_MASTER` as well, which is how you set the master volume of your game.
+set_audio_bus_volume :: proc(bus: Audio_Bus, volume: f32)
+
+// Set the pan of an audio bus. Range: -1 to 1, where -1 is full left, 0 is center and 1 is full
+// right.
+//
+// This is a balance control: It turns the opposite side down. That's different from the pan of a
+// sound, which uses a constant-power curve to place a source in the stereo field. A bus is already
+// a finished stereo mix, and a bus at pan 0 has to leave it exactly as it is.
+set_audio_bus_pan :: proc(bus: Audio_Bus, pan: f32)
+
+// Set an effect to run on everything that is mixed into the bus. This is how you apply your own
+// audio processing, such as a filter, to a whole group of sounds at once.
+//
+// `user_data` is handed to the effect when it runs. Put whatever state your effect needs there:
+// The effect is called once per mixed chunk, so anything it wants to remember between the chunks
+// has to live in `user_data`. Pass `nil` as `effect` to remove the effect.
+//
+// See `Audio_Effect_Proc` for what the effect is given and what it is allowed to do.
+set_audio_bus_effect :: proc(bus: Audio_Bus, effect: Audio_Effect_Proc, user_data: rawptr = nil)
 
 // Update the audio mixer and feed more audio data into the audio backend. This is done
 // automatically when `update` runs, so you normally don't need to call this manually.
@@ -1449,6 +1507,10 @@ Sound_Object :: struct {
 	// If true, then the playing sound will be set up as "looping" when `play_sound` is called. Set
 	// using `set_sound_loop`.
 	loop: bool,
+
+	// The bus the sound is mixed into when it plays. The zero value is the master bus. Set using
+	// `set_sound_bus`.
+	bus: Audio_Bus,
 }
 
 Audio_Stream :: distinct Handle
@@ -1484,6 +1546,10 @@ Audio_Stream_Data :: struct {
 	buffer_write_pos: int,
 
 	playback_settings: Audio_Buffer_Playback_Settings,
+
+	// The bus the stream is mixed into when it plays. The zero value is the master bus. Set using
+	// `set_audio_stream_bus`.
+	bus: Audio_Bus,
 
 	// Different from `loop` in `Playing_Audio_Buffer`. This says if the whole stream should loop
 	// when it reaches end-of-file. The `loop` in `Playing_Audio_Buffer` just says to loop the
@@ -1563,6 +1629,63 @@ Playing_Audio_Buffer :: struct {
 	offset_fraction: f32,
 
 	loop: bool,
+
+	// The bus this is mixed into. The zero value is the master bus.
+	bus: Audio_Bus,
+}
+
+// A bus is a group of sounds that are mixed together before they reach the master bus. You can set
+// the volume and the pan of the whole group, and you can run an effect on it. Create one using
+// `create_audio_bus` and route sounds into it using `set_sound_bus`, `set_audio_stream_bus` or the
+// `bus` parameter of `play_audio_buffer`.
+Audio_Bus :: distinct Handle
+
+// The master bus. Everything ends up here and this is what the audio backend is fed.
+//
+// Note that this is the zero value, not an `AUDIO_BUS_NONE`: Anything that has not been routed
+// anywhere plays on the master bus, so code that doesn't care about buses gets the master bus
+// without doing anything. A sound always plays somewhere, so "no bus" is not a thing.
+//
+// You can use this with `set_audio_bus_volume`, `set_audio_bus_pan` and `set_audio_bus_effect`.
+// That's how you set the master volume of your game.
+AUDIO_BUS_MASTER :: Audio_Bus {}
+
+// Runs on the mixed samples of a whole bus, before the bus is mixed into the master bus. Modify
+// `samples` in place. This is how you write your own audio effects, such as a filter or an echo.
+//
+// `samples` is `AUDIO_MIX_CHUNK_SIZE` stereo samples at `AUDIO_MIX_SAMPLE_RATE`. Keep any state
+// your effect needs in `user_data`: You get called once per mixed chunk, so anything you want to
+// carry between the chunks needs to live there.
+//
+// This runs on the main thread today, from within `update_audio_mixer`. Don't allocate and don't
+// log in here. The mixer may move to a separate thread later.
+Audio_Effect_Proc :: proc(samples: [][2]Audio_Sample, user_data: rawptr)
+
+Audio_Bus_Settings :: struct {
+	volume: f32,
+	pan: f32,
+}
+
+Audio_Bus_Object :: struct {
+	handle: Audio_Bus,
+
+	// Same idea as in `Playing_Audio_Buffer`: The current settings move towards the target
+	// settings a bit at a time, so that changing the volume of a bus doesn't click.
+	target_settings: Audio_Bus_Settings,
+	current_settings: Audio_Bus_Settings,
+
+	effect: Audio_Effect_Proc,
+	effect_user_data: rawptr,
+
+	// The sounds routed to this bus are mixed in here. The bus effect runs on this. Then this is
+	// mixed into the master bus. Unused for the master bus itself: That one is mixed straight into
+	// `mix_buffer`.
+	chunk: [AUDIO_MIX_CHUNK_SIZE][2]Audio_Sample,
+}
+
+DEFAULT_AUDIO_BUS_SETTINGS :: Audio_Bus_Settings {
+	volume = 1,
+	pan = 0,
 }
 
 // This keeps track of the internal state of the library. Usually, you do not need to poke at it.
@@ -1665,6 +1788,12 @@ State :: struct {
 	playing_audio_buffers: hm.Dynamic_Handle_Map(Playing_Audio_Buffer, Playing_Audio_Buffer_Handle),
 
 	audio_streams: hm.Dynamic_Handle_Map(Audio_Stream_Data, Audio_Stream),
+
+	audio_buses: hm.Dynamic_Handle_Map(Audio_Bus_Object, Audio_Bus),
+
+	// The master bus is not in `audio_buses`. It is identified by the zero handle, which the handle
+	// map can't store, and it needs to exist without anyone creating it.
+	master_bus: Audio_Bus_Object,
 
 	// Mixer will never mix in more than 1.5 * AUDIO_MIX_CHUNK_SIZE. So 10 times the chunk size is
 	// ample.

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -194,6 +194,9 @@ init :: proc(
 		hm.dynamic_init(&s.audio_buffers, s.allocator)
 		hm.dynamic_init(&s.sounds, s.allocator)
 		hm.dynamic_init(&s.audio_streams, s.allocator)
+		hm.dynamic_init(&s.audio_buses, s.allocator)
+		s.master_bus.target_settings = DEFAULT_AUDIO_BUS_SETTINGS
+		s.master_bus.current_settings = DEFAULT_AUDIO_BUS_SETTINGS
 	}
 
 	return s
@@ -254,6 +257,7 @@ shutdown :: proc() {
 		hm.dynamic_destroy(&s.playing_audio_buffers)
 		hm.dynamic_destroy(&s.sounds)
 		hm.dynamic_destroy(&s.audio_buffers)
+		hm.dynamic_destroy(&s.audio_buses)
 		free(s.audio_backend_state, s.allocator)
 	}
 
@@ -1847,6 +1851,7 @@ play_sound :: proc(sound: Sound) {
 		target_settings = sound_object.playback_settings,
 		current_settings = sound_object.playback_settings,
 		loop = sound_object.loop,
+		bus = sound_object.bus,
 	}
 
 	add_err: runtime.Allocator_Error
@@ -1865,11 +1870,24 @@ play_sound :: proc(sound: Sound) {
 // You get nothing back, so there is no way to stop or modify the playback once it has started.
 // Create a `Sound` using `create_sound_from_audio_buffer` when you need that control. That is also
 // why there is no looping here: A looping playback that nothing can stop would play forever.
-play_audio_buffer :: proc(ab: Audio_Buffer, volume: f32 = 1, pan: f32 = 0, pitch: f32 = 1) {
+//
+// Pass `bus` to play the sound on an audio bus. It plays on the master bus by default.
+play_audio_buffer :: proc(
+	ab: Audio_Buffer,
+	volume: f32 = 1,
+	pan: f32 = 0,
+	pitch: f32 = 1,
+	bus: Audio_Bus = AUDIO_BUS_MASTER,
+) {
 	audio_buffer_object := hm.get(&s.audio_buffers, ab)
 
 	if audio_buffer_object == nil {
 		log.error("Cannot play audio buffer, audio buffer does not exist.")
+		return
+	}
+
+	if bus != AUDIO_BUS_MASTER && hm.get(&s.audio_buses, bus) == nil {
+		log.error("Cannot play audio buffer, audio bus does not exist.")
 		return
 	}
 
@@ -1883,6 +1901,7 @@ play_audio_buffer :: proc(ab: Audio_Buffer, volume: f32 = 1, pan: f32 = 0, pitch
 		audio_buffer = ab,
 		target_settings = playback_settings,
 		current_settings = playback_settings,
+		bus = bus,
 	}
 
 	_, add_err := hm.add(&s.playing_audio_buffers, playing_audio_buffer)
@@ -1994,6 +2013,31 @@ set_sound_loop :: proc(sound: Sound, loop: bool) {
 	}
 	
 	sound_object.loop = loop
+}
+
+// Route a sound into an audio bus. The sound is then mixed into that bus instead of straight into
+// the master bus, letting you control it together with everything else on the bus.
+//
+// You can set this before playing but also while playing the sound. Pass `AUDIO_BUS_MASTER` to put
+// the sound back on the master bus.
+set_sound_bus :: proc(sound: Sound, bus: Audio_Bus) {
+	sound_object := hm.get(&s.sounds, sound)
+
+	if sound_object == nil {
+		log.error("Cannot set bus, sound does not exist.")
+		return
+	}
+
+	if bus != AUDIO_BUS_MASTER && hm.get(&s.audio_buses, bus) == nil {
+		log.error("Cannot set bus, audio bus does not exist.")
+		return
+	}
+
+	if playing := hm.get(&s.playing_audio_buffers, sound_object.playing_buffer_handle); playing != nil {
+		playing.bus = bus
+	}
+
+	sound_object.bus = bus
 }
 
 // Load a WAV file from disk. Returns a `Sound` which can be used with `play_sound`. If you need to
@@ -2913,6 +2957,7 @@ play_audio_stream :: proc(stream: Audio_Stream) {
 		audio_buffer = sd.buffer,
 		target_settings = sd.playback_settings,
 		current_settings = sd.playback_settings,
+		bus = sd.bus,
 
 		// This means that we are looping the buffer itself. We will use this buffer as a circular
 		// buffer, filling it with samples as we stream in more. Thus it needs to be looped to not
@@ -3068,6 +3113,145 @@ set_audio_stream_loop :: proc(stream: Audio_Stream, loop: bool) {
 	sd.loop = loop
 }
 
+// Route an audio stream into an audio bus. The stream is then mixed into that bus instead of
+// straight into the master bus. Handy for putting your music on its own bus, so the player can
+// turn the music down without turning the sound effects down.
+//
+// You can use this both with a playing and non-playing stream. If it's already playing, then this
+// will affect the playing stream. Pass `AUDIO_BUS_MASTER` to put it back on the master bus.
+set_audio_stream_bus :: proc(stream: Audio_Stream, bus: Audio_Bus) {
+	sd := hm.get(&s.audio_streams, stream)
+
+	if sd == nil {
+		log.error("Cannot set audio stream bus, stream does not exist.")
+		return
+	}
+
+	if bus != AUDIO_BUS_MASTER && hm.get(&s.audio_buses, bus) == nil {
+		log.error("Cannot set audio stream bus, audio bus does not exist.")
+		return
+	}
+
+	if playing := hm.get(&s.playing_audio_buffers, sd.playing_buffer_handle); playing != nil {
+		playing.bus = bus
+	}
+
+	sd.bus = bus
+}
+
+// Create an audio bus: A group of sounds that are mixed together before they reach the master bus.
+// Route sounds into it using `set_sound_bus`, `set_audio_stream_bus`, or the `bus` parameter of
+// `play_audio_buffer`.
+//
+// A new bus has volume 1, pan 0 and no effect. That makes it a passthrough: Playing a sound on a
+// fresh bus sounds exactly like playing it on the master bus, until you change something.
+create_audio_bus :: proc() -> Audio_Bus {
+	bus_object := Audio_Bus_Object {
+		target_settings = DEFAULT_AUDIO_BUS_SETTINGS,
+		current_settings = DEFAULT_AUDIO_BUS_SETTINGS,
+	}
+
+	bus, add_err := hm.add(&s.audio_buses, bus_object)
+
+	if add_err != nil {
+		log.errorf("Failed creating audio bus. Error: %v", add_err)
+
+		// The master bus always exists, so anything routed to this handle still plays.
+		return AUDIO_BUS_MASTER
+	}
+
+	return bus
+}
+
+// Destroy an audio bus. Everything routed to it goes back to the master bus, including sounds that
+// are playing right now. Those keep playing, they just play on the master bus from here on.
+destroy_audio_bus :: proc(bus: Audio_Bus) {
+	if bus == AUDIO_BUS_MASTER {
+		log.error("Cannot destroy audio bus, the master bus cannot be destroyed.")
+		return
+	}
+
+	if hm.get(&s.audio_buses, bus) == nil {
+		log.error("Cannot destroy audio bus, audio bus does not exist.")
+		return
+	}
+
+	// Move everything that points at this bus over to the master bus. We do it here, and not by
+	// letting the mixer notice that the bus is gone, so that the mixer never has to deal with a bus
+	// handle that doesn't resolve.
+
+	for it := hm.dynamic_iterator_make(&s.sounds); sound_object, _ in hm.dynamic_iterate(&it) {
+		if sound_object.bus == bus {
+			sound_object.bus = AUDIO_BUS_MASTER
+		}
+	}
+
+	for it := hm.dynamic_iterator_make(&s.audio_streams); sd, _ in hm.dynamic_iterate(&it) {
+		if sd.bus == bus {
+			sd.bus = AUDIO_BUS_MASTER
+		}
+	}
+
+	for it := hm.dynamic_iterator_make(&s.playing_audio_buffers); ps, _ in hm.dynamic_iterate(&it) {
+		if ps.bus == bus {
+			ps.bus = AUDIO_BUS_MASTER
+		}
+	}
+
+	hm.remove(&s.audio_buses, bus)
+}
+
+// Set the volume of an audio bus. Range: 0 to 1. Everything mixed into the bus is scaled by this.
+//
+// This works on `AUDIO_BUS_MASTER` as well, which is how you set the master volume of your game.
+set_audio_bus_volume :: proc(bus: Audio_Bus, volume: f32) {
+	bus_object := bus == AUDIO_BUS_MASTER ? &s.master_bus : hm.get(&s.audio_buses, bus)
+
+	if bus_object == nil {
+		log.error("Cannot set audio bus volume, audio bus does not exist.")
+		return
+	}
+
+	bus_object.target_settings.volume = clamp(volume, 0, 1)
+}
+
+// Set the pan of an audio bus. Range: -1 to 1, where -1 is full left, 0 is center and 1 is full
+// right.
+//
+// This is a balance control: It turns the opposite side down. That's different from the pan of a
+// sound, which uses a constant-power curve to place a source in the stereo field. A bus is already
+// a finished stereo mix, and a bus at pan 0 has to leave it exactly as it is.
+set_audio_bus_pan :: proc(bus: Audio_Bus, pan: f32) {
+	bus_object := bus == AUDIO_BUS_MASTER ? &s.master_bus : hm.get(&s.audio_buses, bus)
+
+	if bus_object == nil {
+		log.error("Cannot set audio bus pan, audio bus does not exist.")
+		return
+	}
+
+	bus_object.target_settings.pan = clamp(pan, -1, 1)
+}
+
+// Set an effect to run on everything that is mixed into the bus. This is how you apply your own
+// audio processing, such as a filter, to a whole group of sounds at once.
+//
+// `user_data` is handed to the effect when it runs. Put whatever state your effect needs there:
+// The effect is called once per mixed chunk, so anything it wants to remember between the chunks
+// has to live in `user_data`. Pass `nil` as `effect` to remove the effect.
+//
+// See `Audio_Effect_Proc` for what the effect is given and what it is allowed to do.
+set_audio_bus_effect :: proc(bus: Audio_Bus, effect: Audio_Effect_Proc, user_data: rawptr = nil) {
+	bus_object := bus == AUDIO_BUS_MASTER ? &s.master_bus : hm.get(&s.audio_buses, bus)
+
+	if bus_object == nil {
+		log.error("Cannot set audio bus effect, audio bus does not exist.")
+		return
+	}
+
+	bus_object.effect = effect
+	bus_object.effect_user_data = user_data
+}
+
 // Update the audio mixer and feed more audio data into the audio backend. This is done
 // automatically when `update` runs, so you normally don't need to call this manually.
 //
@@ -3098,6 +3282,12 @@ update_audio_mixer :: proc() {
 	// Zero out old mixed data from buffer (the buffer is "circular", there may be old stuff in
 	// the `out` slice).
 	slice.zero(out)
+
+	// The buses have a chunk each, which the sounds routed to that bus are mixed into. Those hold
+	// the previous chunk's mix, so they need zeroing too.
+	for it := hm.dynamic_iterator_make(&s.audio_buses); bus, _ in hm.dynamic_iterate(&it) {
+		slice.zero(bus.chunk[:])
+	}
 
 	audio_mix :: proc(
 		dest: [][2]Audio_Sample,
@@ -3228,6 +3418,23 @@ update_audio_mixer :: proc() {
 		return 0
 	}
 
+	// Used for the smooth adjustment of volume, pan and pitch, both for the playing sounds below
+	// and for the buses further down.
+
+	calc_adjust_parameter_delta :: proc(sample_rate: int, pitch: f32) -> f32 {
+		RAMP_TIME :: 0.03
+		ramp_samples := RAMP_TIME * f32(sample_rate) * pitch
+		return AUDIO_MIX_CHUNK_SIZE / ramp_samples
+	}
+
+	move_towards :: proc(current: f32, target: f32, delta: f32) -> f32 {
+		if abs(target - current) < delta {
+			return target
+		}
+
+		dir := math.sign(target - current)
+		return current + dir * delta
+	}
 
 	for ps_iter := hm.dynamic_iterator_make(&s.playing_audio_buffers); ps, ps_handle in hm.dynamic_iterate(&ps_iter) {
 		data := hm.get(&s.audio_buffers, ps.audio_buffer)
@@ -3238,26 +3445,23 @@ update_audio_mixer :: proc() {
 			continue
 		}
 
+		// Where this sound is mixed into: The chunk of the bus it is routed to, or the output
+		// itself, which is the master bus. `destroy_audio_bus` moves everything back to the master
+		// bus, so a bus that doesn't resolve shouldn't happen. Fall back to the master bus if it
+		// does anyway, without logging: We'd log it 31 times a second.
+		dest := out
+
+		if ps.bus != AUDIO_BUS_MASTER {
+			if bus := hm.get(&s.audio_buses, ps.bus); bus != nil {
+				dest = bus.chunk[:]
+			}
+		}
+
 		// Before we get to the mixing we smoothly adjust pitch, volume and pan. We do this to avoid
 		// clicks in the audio. The clicks happen because abrupt changes cause discontinuities in
 		// the audio waveform. Understand: Sound does not happen because the waveform has a high
 		// value, it happens because there is a sudden change in the waveform. Bigger change, bigger
 		// sound.
-
-		calc_adjust_parameter_delta :: proc(sample_rate: int, pitch: f32) -> f32 {
-			RAMP_TIME :: 0.03
-			ramp_samples := RAMP_TIME * f32(sample_rate) * pitch
-			return AUDIO_MIX_CHUNK_SIZE / ramp_samples
-		}
-
-		move_towards :: proc(current: f32, target: f32, delta: f32) -> f32 {
-			if abs(target - current) < delta {
-				return target
-			}
-
-			dir := math.sign(target - current)
-			return current + dir * delta
-		}
 
 		settings := &ps.current_settings
 		target_settings := &ps.target_settings
@@ -3311,7 +3515,7 @@ update_audio_mixer :: proc() {
 		}
 
 		num_mixed := audio_mix(
-			s.mix_buffer[s.mix_buffer_offset:],
+			dest,
 			data.samples[ps.offset:],
 			data.channels,
 			interpolate,
@@ -3349,7 +3553,7 @@ update_audio_mixer :: proc() {
 				overflow := AUDIO_MIX_CHUNK_SIZE - num_mixed
 
 				num_mixed = audio_mix(
-					s.mix_buffer[s.mix_buffer_offset + num_mixed:],
+					dest[num_mixed:],
 					data.samples[ps.offset:],
 					data.channels,
 					interpolate,
@@ -3379,6 +3583,90 @@ update_audio_mixer :: proc() {
 				hm.remove(&s.playing_audio_buffers, ps_handle)
 				continue
 			}
+		}
+	}
+
+	// BUSES
+	//
+	// The sounds routed to a bus have been mixed into that bus's chunk. Now run the effect of each
+	// bus on its chunk and mix the chunk into the master bus, which is the `out` slice.
+
+	// The buses run at the mixer's sample rate and are never pitched, so the ramp is the same for
+	// all of them.
+	bus_adjust_delta := calc_adjust_parameter_delta(AUDIO_MIX_SAMPLE_RATE, 1)
+
+	for it := hm.dynamic_iterator_make(&s.audio_buses); bus, _ in hm.dynamic_iterate(&it) {
+		// The effect runs even when the bus is silent. Effects tend to keep state, such as a filter
+		// or an echo. Skipping them while silent would leave that state behind, and it would jump
+		// once the bus is turned back up.
+		if bus.effect != nil {
+			bus.effect(bus.chunk[:], bus.effect_user_data)
+		}
+
+		volume_start := bus.current_settings.volume
+		volume_end := move_towards(volume_start, bus.target_settings.volume, bus_adjust_delta)
+		bus.current_settings.volume = volume_end
+
+		pan_start := bus.current_settings.pan
+		pan_end := move_towards(pan_start, bus.target_settings.pan, bus_adjust_delta)
+		bus.current_settings.pan = pan_end
+
+		if volume_start == 0 && volume_end == 0 {
+			continue
+		}
+
+		// The pan of a bus is a balance: It turns the opposite side down. The playing sounds use a
+		// constant-power curve instead, but that curve scales both channels by 0.707 in the middle.
+		// A bus that has not been touched has to leave the mix exactly as it is.
+		gain_start := [2]f32 {
+			volume_start * min(1, 1 - pan_start),
+			volume_start * min(1, 1 + pan_start),
+		}
+
+		gain_end := [2]f32 {
+			volume_end * min(1, 1 - pan_end),
+			volume_end * min(1, 1 + pan_end),
+		}
+
+		for samp_idx in 0..<AUDIO_MIX_CHUNK_SIZE {
+			t := f32(samp_idx) / f32(AUDIO_MIX_CHUNK_SIZE)
+			out[samp_idx] += bus.chunk[samp_idx] * linalg.lerp(gain_start, gain_end, t)
+		}
+	}
+
+	// MASTER BUS
+	//
+	// Everything is in `out` now. The master effect, volume and pan apply to the whole mix.
+
+	master := &s.master_bus
+
+	if master.effect != nil {
+		master.effect(out, master.effect_user_data)
+	}
+
+	volume_start := master.current_settings.volume
+	volume_end := move_towards(volume_start, master.target_settings.volume, bus_adjust_delta)
+	master.current_settings.volume = volume_end
+
+	pan_start := master.current_settings.pan
+	pan_end := move_towards(pan_start, master.target_settings.pan, bus_adjust_delta)
+	master.current_settings.pan = pan_end
+
+	// A game that never touches the master bus shouldn't pay for it.
+	if volume_start != 1 || volume_end != 1 || pan_start != 0 || pan_end != 0 {
+		gain_start := [2]f32 {
+			volume_start * min(1, 1 - pan_start),
+			volume_start * min(1, 1 + pan_start),
+		}
+
+		gain_end := [2]f32 {
+			volume_end * min(1, 1 - pan_end),
+			volume_end * min(1, 1 + pan_end),
+		}
+
+		for samp_idx in 0..<AUDIO_MIX_CHUNK_SIZE {
+			t := f32(samp_idx) / f32(AUDIO_MIX_CHUNK_SIZE)
+			out[samp_idx] *= linalg.lerp(gain_start, gain_end, t)
 		}
 	}
 
@@ -4930,6 +5218,10 @@ Sound_Object :: struct {
 	// If true, then the playing sound will be set up as "looping" when `play_sound` is called. Set
 	// using `set_sound_loop`.
 	loop: bool,
+
+	// The bus the sound is mixed into when it plays. The zero value is the master bus. Set using
+	// `set_sound_bus`.
+	bus: Audio_Bus,
 }
 
 Audio_Stream :: distinct Handle
@@ -4965,6 +5257,10 @@ Audio_Stream_Data :: struct {
 	buffer_write_pos: int,
 
 	playback_settings: Audio_Buffer_Playback_Settings,
+
+	// The bus the stream is mixed into when it plays. The zero value is the master bus. Set using
+	// `set_audio_stream_bus`.
+	bus: Audio_Bus,
 
 	// Different from `loop` in `Playing_Audio_Buffer`. This says if the whole stream should loop
 	// when it reaches end-of-file. The `loop` in `Playing_Audio_Buffer` just says to loop the
@@ -5044,6 +5340,63 @@ Playing_Audio_Buffer :: struct {
 	offset_fraction: f32,
 
 	loop: bool,
+
+	// The bus this is mixed into. The zero value is the master bus.
+	bus: Audio_Bus,
+}
+
+// A bus is a group of sounds that are mixed together before they reach the master bus. You can set
+// the volume and the pan of the whole group, and you can run an effect on it. Create one using
+// `create_audio_bus` and route sounds into it using `set_sound_bus`, `set_audio_stream_bus` or the
+// `bus` parameter of `play_audio_buffer`.
+Audio_Bus :: distinct Handle
+
+// The master bus. Everything ends up here and this is what the audio backend is fed.
+//
+// Note that this is the zero value, not an `AUDIO_BUS_NONE`: Anything that has not been routed
+// anywhere plays on the master bus, so code that doesn't care about buses gets the master bus
+// without doing anything. A sound always plays somewhere, so "no bus" is not a thing.
+//
+// You can use this with `set_audio_bus_volume`, `set_audio_bus_pan` and `set_audio_bus_effect`.
+// That's how you set the master volume of your game.
+AUDIO_BUS_MASTER :: Audio_Bus {}
+
+// Runs on the mixed samples of a whole bus, before the bus is mixed into the master bus. Modify
+// `samples` in place. This is how you write your own audio effects, such as a filter or an echo.
+//
+// `samples` is `AUDIO_MIX_CHUNK_SIZE` stereo samples at `AUDIO_MIX_SAMPLE_RATE`. Keep any state
+// your effect needs in `user_data`: You get called once per mixed chunk, so anything you want to
+// carry between the chunks needs to live there.
+//
+// This runs on the main thread today, from within `update_audio_mixer`. Don't allocate and don't
+// log in here. The mixer may move to a separate thread later.
+Audio_Effect_Proc :: proc(samples: [][2]Audio_Sample, user_data: rawptr)
+
+Audio_Bus_Settings :: struct {
+	volume: f32,
+	pan: f32,
+}
+
+Audio_Bus_Object :: struct {
+	handle: Audio_Bus,
+
+	// Same idea as in `Playing_Audio_Buffer`: The current settings move towards the target
+	// settings a bit at a time, so that changing the volume of a bus doesn't click.
+	target_settings: Audio_Bus_Settings,
+	current_settings: Audio_Bus_Settings,
+
+	effect: Audio_Effect_Proc,
+	effect_user_data: rawptr,
+
+	// The sounds routed to this bus are mixed in here. The bus effect runs on this. Then this is
+	// mixed into the master bus. Unused for the master bus itself: That one is mixed straight into
+	// `mix_buffer`.
+	chunk: [AUDIO_MIX_CHUNK_SIZE][2]Audio_Sample,
+}
+
+DEFAULT_AUDIO_BUS_SETTINGS :: Audio_Bus_Settings {
+	volume = 1,
+	pan = 0,
 }
 
 // This keeps track of the internal state of the library. Usually, you do not need to poke at it.
@@ -5146,6 +5499,12 @@ State :: struct {
 	playing_audio_buffers: hm.Dynamic_Handle_Map(Playing_Audio_Buffer, Playing_Audio_Buffer_Handle),
 
 	audio_streams: hm.Dynamic_Handle_Map(Audio_Stream_Data, Audio_Stream),
+
+	audio_buses: hm.Dynamic_Handle_Map(Audio_Bus_Object, Audio_Bus),
+
+	// The master bus is not in `audio_buses`. It is identified by the zero handle, which the handle
+	// map can't store, and it needs to exist without anyone creating it.
+	master_bus: Audio_Bus_Object,
 
 	// Mixer will never mix in more than 1.5 * AUDIO_MIX_CHUNK_SIZE. So 10 times the chunk size is
 	// ample.

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1862,14 +1862,13 @@ play_sound :: proc(sound: Sound) {
 	}
 }
 
-// Play an audio buffer once, using the playback settings you pass in. This is a shortcut for
-// one-shot sounds such as gunshots and footsteps: You don't need to create a `Sound` for the
-// buffer, and each call starts a separate playback, so repeated calls overlap instead of
-// restarting each other.
+// Play an audio buffer once, using the playback settings you pass in. This is good for doing playing
+// sounds once. Multiple instances of the same audio buffer can play at the same time, so it is use-
+// ful for stuff like footsteps etc.
 //
-// You get nothing back, so there is no way to stop or modify the playback once it has started.
-// Create a `Sound` using `create_sound_from_audio_buffer` when you need that control. That is also
-// why there is no looping here: A looping playback that nothing can stop would play forever.
+// This procedure returns nothing, so you cannot stop the playback. If you need stoppable playback,
+// then create a `Sound` using `create_sound_from_audio_buffer`. You also cannot loop these sounds,
+// for that, also use `Sound`.
 //
 // Pass `bus` to play the sound on an audio bus. It plays on the master bus by default.
 play_audio_buffer :: proc(
@@ -1904,6 +1903,7 @@ play_audio_buffer :: proc(
 		bus = bus,
 	}
 
+	// The playing audio buffer will be removed when mixer is finished playing it.
 	_, add_err := hm.add(&s.playing_audio_buffers, playing_audio_buffer)
 
 	if add_err != nil {
@@ -2016,10 +2016,10 @@ set_sound_loop :: proc(sound: Sound, loop: bool) {
 }
 
 // Route a sound into an audio bus. The sound is then mixed into that bus instead of straight into
-// the master bus, letting you control it together with everything else on the bus.
+// the master bus. You can set the volume and pan of the whole bus, making it possible to control
+// whole categories of sounds.
 //
-// You can set this before playing but also while playing the sound. Pass `AUDIO_BUS_MASTER` to put
-// the sound back on the master bus.
+// Pass `AUDIO_BUS_MASTER` to route the sound to the master bus.
 set_sound_bus :: proc(sound: Sound, bus: Audio_Bus) {
 	sound_object := hm.get(&s.sounds, sound)
 
@@ -3164,7 +3164,7 @@ create_audio_bus :: proc() -> Audio_Bus {
 }
 
 // Destroy an audio bus. Everything routed to it goes back to the master bus, including sounds that
-// are playing right now. Those keep playing, they just play on the master bus from here on.
+// are playing right now.
 destroy_audio_bus :: proc(bus: Audio_Bus) {
 	if bus == AUDIO_BUS_MASTER {
 		log.error("Cannot destroy audio bus, the master bus cannot be destroyed.")
@@ -5351,11 +5351,8 @@ Playing_Audio_Buffer :: struct {
 // `bus` parameter of `play_audio_buffer`.
 Audio_Bus :: distinct Handle
 
-// The master bus. Everything ends up here and this is what the audio backend is fed.
-//
-// Note that this is the zero value, not an `AUDIO_BUS_NONE`: Anything that has not been routed
-// anywhere plays on the master bus, so code that doesn't care about buses gets the master bus
-// without doing anything. A sound always plays somewhere, so "no bus" is not a thing.
+// All other buses are mixed into the master bus, as well as sounds that play directly on the master
+// bus. This is the default bus of all sounds, audio streams and playing audio buffers.
 //
 // You can use this with `set_audio_bus_volume`, `set_audio_bus_pan` and `set_audio_bus_effect`.
 // That's how you set the master volume of your game.
@@ -5368,8 +5365,8 @@ AUDIO_BUS_MASTER :: Audio_Bus {}
 // your effect needs in `user_data`: You get called once per mixed chunk, so anything you want to
 // carry between the chunks needs to live there.
 //
-// This runs on the main thread today, from within `update_audio_mixer`. Don't allocate and don't
-// log in here. The mixer may move to a separate thread later.
+// This runs on the main thread today, but keep in mind that it may move to a separate thread in the
+// future.
 Audio_Effect_Proc :: proc(samples: [][2]Audio_Sample, user_data: rawptr)
 
 Audio_Bus_Settings :: struct {

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1857,6 +1857,41 @@ play_sound :: proc(sound: Sound) {
 	}
 }
 
+// Play an audio buffer once, using the playback settings you pass in. This is a shortcut for
+// one-shot sounds such as gunshots and footsteps: You don't need to create a `Sound` for the
+// buffer, and each call starts a separate playback, so repeated calls overlap instead of
+// restarting each other.
+//
+// You get nothing back, so there is no way to stop or modify the playback once it has started.
+// Create a `Sound` using `create_sound_from_audio_buffer` when you need that control. That is also
+// why there is no looping here: A looping playback that nothing can stop would play forever.
+play_audio_buffer :: proc(ab: Audio_Buffer, volume: f32 = 1, pan: f32 = 0, pitch: f32 = 1) {
+	audio_buffer_object := hm.get(&s.audio_buffers, ab)
+
+	if audio_buffer_object == nil {
+		log.error("Cannot play audio buffer, audio buffer does not exist.")
+		return
+	}
+
+	playback_settings := Audio_Buffer_Playback_Settings {
+		volume = clamp(volume, 0, 1),
+		pan = clamp(pan, -1, 1),
+		pitch = max(pitch, 0.01),
+	}
+
+	playing_audio_buffer := Playing_Audio_Buffer {
+		audio_buffer = ab,
+		target_settings = playback_settings,
+		current_settings = playback_settings,
+	}
+
+	_, add_err := hm.add(&s.playing_audio_buffers, playing_audio_buffer)
+
+	if add_err != nil {
+		log.errorf("Failed playing audio buffer. Error: %v", add_err)
+	}
+}
+
 // Stop a sound. Rewinds it to the start.
 stop_sound :: proc(sound: Sound) {
 	sound_object := hm.get(&s.sounds, sound)

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1862,13 +1862,12 @@ play_sound :: proc(sound: Sound) {
 	}
 }
 
-// Play an audio buffer once, using the playback settings you pass in. This is good for doing playing
-// sounds once. Multiple instances of the same audio buffer can play at the same time, so it is use-
-// ful for stuff like footsteps etc.
+// Play an audio buffer, using the playback settings you pass in. The playback does not loop. Good
+// for playing one-off sound effects such as footsteps. You can play the same Audio_Buffer multiple
+// times simultaneously, without one stopping the another.
 //
-// This procedure returns nothing, so you cannot stop the playback. If you need stoppable playback,
-// then create a `Sound` using `create_sound_from_audio_buffer`. You also cannot loop these sounds,
-// for that, also use `Sound`.
+// The difference between using this and a `Sound` is that the `Sound` remembers its playback
+// settings, can be stopped and looped.
 //
 // Pass `bus` to play the sound on an audio bus. It plays on the master bus by default.
 play_audio_buffer :: proc(


### PR DESCRIPTION
Implements #110. Also adds `play_audio_buffer`, superseding #152.

A bus is a group of sounds that are mixed together before they reach the master bus. You can set the volume and pan of the whole group and run your own effect proc on it.

- The master bus is the zero value of `Audio_Bus`. Anything not routed anywhere plays on it, so code that never touches buses is unaffected. `set_audio_bus_volume(AUDIO_BUS_MASTER, x)` is the master volume.
- New procs: `create_audio_bus`, `destroy_audio_bus` (moves everything back to master), `set_audio_bus_volume/pan/effect`, `set_sound_bus`, `set_audio_stream_bus`, `play_audio_buffer` (one-shots, overlap on repeated calls, no loop parameter since nothing could stop it).
- Bus pan is a balance control, not the constant-power curve sounds use: an untouched bus is a bit-exact passthrough.
- Bus volume/pan changes ramp over ~30 ms like sound settings, so no clicks. Effects keep running while a bus is silent, so stateful effects don't jump when turned back up.
- New example: `examples/audio_bus` (drone + overlapping blips on an sfx bus, low-pass effect toggle, master volume, destroying the bus mid-playback).

Mixer output for existing code paths is byte-identical to master, verified by diffing `mix_buffer` dumps between branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
