### PR TITLE
Use math.sign to correctly handle wheel delta on wayland

### DIFF
--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -620,12 +620,12 @@ pointer_listener := wl.Pointer_Listener {
 		switch axis {
 		case wl.POINTER_AXIS_VERTICAL_SCROLL:
 			append(&s.events, Event_Mouse_Wheel {
-				delta = value > 0 ? -1 : 1,
+				delta = f32(math.sign(value)) * -1,
 			})
 
 		case wl.POINTER_AXIS_HORIZONTAL_SCROLL:
 			append(&s.events, Event_Mouse_Wheel_Horizontal {
-				delta = value > 0 ? 1 : -1,
+				delta = f32(math.sign(value)),
 			})
 		}
 	},


### PR DESCRIPTION
Previous `delta = value > 0 ? -1 : 1` meant that value=0 would be delta=1, causing mouse scrolling to be jittered—go up and down for no reason.