### PR TITLE
Audio API redesign

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See `agent.md` for claude instructions.

--- a/agent.md
+++ b/agent.md
@@ -20,7 +20,8 @@ Conventions for writing code, writing documentation, and collaborating on this p
 - Draft Pull Requests are always welcome and do not need to follow strict rules. A _ready for review_ PR must contain working, tested, complete code that follows the style below.
 
 ## Commit messages
-- Keep commit messages very factual. As short as possible, so people can actually read them. Use as short sentences as possible. Prefer the period over any other form of punctuation. Only put in a short overview of what changed. If people want to see the details, then they study the code. The short overview will lead people to the code, not replace them looking at it.
+
+Write them like a tweet, max 180 characters. Only simple sentences. Only allowed punctuation is the period. If possible, keep them to 3-4 words. Use more words if really needed.
 
 ## Verifying Your Work
 - Build and test through the examples in `examples/`. Prefer the existing VS Code build tasks; they already include `-vet -strict-style -vet-tabs` and come in three variants: default (D3D11 on Windows), `(GL)`, and `(web)`. Use the same `-vet -strict-style -vet-tabs` flags when running `odin` directly.
@@ -62,10 +63,9 @@ Conventions for writing code, writing documentation, and collaborating on this p
 - Do not write or change any public API comments (stuff that ends up in karl2d.doc.odin). They are written manually. Check their factualness and make changes to them during the final audit of a PR.
 
 ### Comments inside implementations
-- Writing comments inside implementations is allowed.
+- Writing comments inside implementations is allowed. That means anything that does not end up in `karl2d.doc.odin`.
 - Use short sentences. Prefer a period over all other forms of punctuation
-- Never write about how something used to work, or about what a change improved. The reader has only ever seen the current version. That story belongs in the commit message.
-- Never warn the reader away from a mistake you made while writing the change. A comment explaining why some other code is *not* there is a note to yourself, not an insight about the code that is. Read it as a diff: if it only makes sense to someone who watched you get it wrong, delete it. The commit message is where that goes, if anywhere.
+- Never write about how something used to work, or about what a change improved. The reader has only ever seen the current version.
 - Don't duplicate information on a procedure and on a struct that the procedure uses. Put it on the procedure if unsure where to put it.
 
 ### File organization

--- a/agent.md
+++ b/agent.md
@@ -59,11 +59,7 @@ Write them like a tweet, max 180 characters. Only simple sentences. Only allowed
 - Procs that implement the platform interface carry the platform prefix (`mac_set_cursor`). Internal helpers may skip the prefix when the file is `#+private file` (`apply_cursor_state`).
 - Log messages follow "Failed <doing> <thing>. Error: %v" or "Cannot <verb>, <thing> does not exist.". In platform backends it is also fine to name the failing OS call: "CreateIconIndirect failed with %v".
 
-### Comment on public APIs (karl2d.doc.odin)
-- Do not write or change any public API comments (stuff that ends up in karl2d.doc.odin). They are written manually. Check their factualness and make changes to them during the final audit of a PR.
-
-### Comments inside implementations
-- Writing comments inside implementations is allowed. That means anything that does not end up in `karl2d.doc.odin`.
+### Comments
 - Use short sentences. Prefer a period over all other forms of punctuation
 - Never write about how something used to work, or about what a change improved. The reader has only ever seen the current version.
 - Don't duplicate information on a procedure and on a struct that the procedure uses. Put it on the procedure if unsure where to put it.

--- a/examples/audio/audio.odin
+++ b/examples/audio/audio.odin
@@ -7,11 +7,11 @@ import "core:fmt"
 import "core:slice"
 
 pos: k2.Vec2
-snd: k2.Audio_Clip
-snd_sound: k2.Sound
-snd2: k2.Audio_Clip
-snd3: k2.Audio_Clip
-wav: k2.Audio_Clip
+sine_clip_200: k2.Audio_Clip
+sine_sound: k2.Sound
+sine_clip_440: k2.Audio_Clip
+sine_clip_700: k2.Audio_Clip
+chord_clip: k2.Audio_Clip
 
 music: k2.Audio_Stream
 music_sound: k2.Sound
@@ -25,12 +25,12 @@ HAS_MUSIC :: #exists(MUSIC_FILE)
 init :: proc() {
 	k2.init(1280, 720, "Karl2D Audio")
 
-	snd = make_sine_wave(200, 0.5, 44100)
+	sine_clip_200 = make_sine_wave(200, 0.5, 44100)
 	snd_volume = 1
 	snd_pitch = 1
-	snd2 = make_sine_wave(440, 1, 44100)
-	snd3 = make_sine_wave(700, 1, 22050)
-	wav = k2.load_audio_clip_from_bytes(#load("chord.wav"))
+	sine_clip_440 = make_sine_wave(440, 1, 44100)
+	sine_clip_700 = make_sine_wave(700, 1, 22050)
+	chord_clip = k2.load_audio_clip_from_bytes(#load("chord.wav"))
 
 	when HAS_MUSIC {
 		when ODIN_OS == .JS {
@@ -42,7 +42,7 @@ init :: proc() {
 		}
 		music_sound = k2.play_audio_stream(music, loop = true)
 	} else {
-		snd_sound = k2.play_audio_clip(snd, loop = true)
+		sine_sound = k2.play_audio_clip(sine_clip_200, loop = true)
 	}
 }
 
@@ -68,11 +68,11 @@ step :: proc() -> bool {
 	}
 
 	if k2.key_went_down(.Enter) {
-		k2.play_audio_clip(snd2)
+		k2.play_audio_clip(sine_clip_440)
 	}
 
 	if k2.key_went_down(.N3) {
-		k2.play_audio_clip(snd3)
+		k2.play_audio_clip(sine_clip_700)
 	}
 	
 	if k2.key_is_held(.Up) {
@@ -101,12 +101,12 @@ step :: proc() -> bool {
 
 
 	if k2.key_went_down(.Space) {
-		k2.play_audio_clip(wav)
+		k2.play_audio_clip(chord_clip)
 	}
 
 	if k2.key_went_down(.T)	{
-		k2.play_audio_clip(wav, pitch = 2, pan = -1)
-		k2.play_audio_clip(wav, pitch = 0.5, pan = 1)
+		k2.play_audio_clip(chord_clip, pitch = 2, pan = -1)
+		k2.play_audio_clip(chord_clip, pitch = 0.5, pan = 1)
 	}
 	
 	snd_pan = clamp(snd_pan, -1, 1)
@@ -134,9 +134,9 @@ step :: proc() -> bool {
 		k2.set_sound_pan(music_sound, snd_pan)
 		k2.set_sound_volume(music_sound, snd_volume)
 	} else {
-		k2.set_sound_volume(snd_sound, snd_volume)
-		k2.set_sound_pan(snd_sound, snd_pan)
-		k2.set_sound_pitch(snd_sound, snd_pitch)
+		k2.set_sound_volume(sine_sound, snd_volume)
+		k2.set_sound_pan(sine_sound, snd_pan)
+		k2.set_sound_pitch(sine_sound, snd_pitch)
 	}
 	
 	k2.clear(k2.WHITE)
@@ -173,10 +173,10 @@ step :: proc() -> bool {
 }
 
 shutdown :: proc() {
-	k2.destroy_audio_clip(snd)
-	k2.destroy_audio_clip(snd2)
-	k2.destroy_audio_clip(snd3)
-	k2.destroy_audio_clip(wav)
+	k2.destroy_audio_clip(sine_clip_200)
+	k2.destroy_audio_clip(sine_clip_440)
+	k2.destroy_audio_clip(sine_clip_700)
+	k2.destroy_audio_clip(chord_clip)
 
 	when HAS_MUSIC {
 		k2.destroy_audio_stream(music)

--- a/examples/audio/audio.odin
+++ b/examples/audio/audio.odin
@@ -117,7 +117,7 @@ step :: proc() -> bool {
 		k2.update_audio_stream(music)
 
 		// Home starts the music. End stops it, which also rewinds the stream. P pauses and
-		// resumes. R jumps back to the start of the stream without stopping anything.
+		// resumes, keeping the position.
 		if k2.key_went_down(.Home) {
 			music_sound = k2.play_audio_stream(
 				music,
@@ -134,10 +134,6 @@ step :: proc() -> bool {
 
 		if k2.key_went_down(.P) {
 			k2.set_sound_paused(music_sound, k2.sound_is_playing(music_sound))
-		}
-
-		if k2.key_went_down(.R) {
-			k2.reset_audio_stream(music)
 		}
 
 		k2.set_sound_pitch(music_sound, snd_pitch)
@@ -173,7 +169,7 @@ step :: proc() -> bool {
 	k2.draw_text("Press Enter to also play a 1 second 440 hz sine wave.", {20, 240}, 40, k2.BLACK)
 
 	when HAS_MUSIC {
-		k2.draw_text("Home plays the music, End stops it, P pauses, R rewinds.", {20, 280}, 40, k2.BLACK)
+		k2.draw_text("Home plays the music, End stops it, P pauses.", {20, 280}, 40, k2.BLACK)
 	}
 
 	k2.present()

--- a/examples/audio/audio.odin
+++ b/examples/audio/audio.odin
@@ -7,12 +7,11 @@ import "core:fmt"
 import "core:slice"
 
 pos: k2.Vec2
-snd: k2.Sound
-snd2: k2.Sound
-snd3: k2.Sound
+snd: k2.Audio_Clip
+snd_sound: k2.Sound
+snd2: k2.Audio_Clip
+snd3: k2.Audio_Clip
 wav: k2.Audio_Clip
-wav_1: k2.Sound
-wav_2: k2.Sound
 
 music: k2.Audio_Stream
 snd_volume: f32
@@ -31,8 +30,6 @@ init :: proc() {
 	snd2 = make_sine_wave(440, 1, 44100)
 	snd3 = make_sine_wave(700, 1, 22050)
 	wav = k2.load_audio_clip_from_bytes(#load("chord.wav"))
-	wav_1 = k2.create_sound_from_audio_buffer(wav)
-	wav_2 = k2.create_sound_from_audio_buffer(wav)
 
 	when HAS_MUSIC {
 		when ODIN_OS == .JS {
@@ -45,14 +42,13 @@ init :: proc() {
 		k2.set_audio_stream_loop(music, true)
 		k2.play_audio_stream(music)
 	} else {
-		k2.set_sound_loop(snd, true)
-		k2.play_sound(snd)
+		snd_sound = k2.play_audio_clip(snd, loop = true)
 	}
 }
 
 // Makes a sine wave of min_length rounded up to so that it ends at the end of a period. This makes
 // it possible to loop cleanly.
-make_sine_wave :: proc(freq: int, min_length: f32, sample_rate: int) -> k2.Sound {
+make_sine_wave :: proc(freq: int, min_length: f32, sample_rate: int) -> k2.Audio_Clip {
 	period_num_samples := f32(sample_rate) / f32(freq)
 	num_periods := math.ceil(f32(sample_rate) * min_length)
 	sine_data := make([]k2.Audio_Sample, int(num_periods), allocator = context.temp_allocator)
@@ -63,7 +59,7 @@ make_sine_wave :: proc(freq: int, min_length: f32, sample_rate: int) -> k2.Sound
 		samp = sf
 	}
 
-	return k2.load_sound_from_bytes_raw(slice.reinterpret([]u8, sine_data), .Float32, sample_rate, .Mono)
+	return k2.load_audio_clip_from_bytes_raw(slice.reinterpret([]u8, sine_data), .Float32, sample_rate, .Mono)
 }
 
 step :: proc() -> bool {
@@ -72,11 +68,11 @@ step :: proc() -> bool {
 	}
 
 	if k2.key_went_down(.Enter) {
-		k2.play_sound(snd2)
+		k2.play_audio_clip(snd2)
 	}
 
 	if k2.key_went_down(.N3) {
-		k2.play_sound(snd3)
+		k2.play_audio_clip(snd3)
 	}
 	
 	if k2.key_is_held(.Up) {
@@ -105,18 +101,12 @@ step :: proc() -> bool {
 
 
 	if k2.key_went_down(.Space) {
-		k2.set_sound_pitch(wav_1, 1)
-		k2.set_sound_pan(wav_1, 0)
-		k2.play_sound(wav_1)
+		k2.play_audio_clip(wav)
 	}
 
 	if k2.key_went_down(.T)	{
-		k2.set_sound_pitch(wav_1, 2)
-		k2.set_sound_pan(wav_1, -1)
-		k2.play_sound(wav_1)
-		k2.set_sound_pitch(wav_2, 0.5)
-		k2.set_sound_pan(wav_2, 1)
-		k2.play_sound(wav_2)
+		k2.play_audio_clip(wav, pitch = 2, pan = -1)
+		k2.play_audio_clip(wav, pitch = 0.5, pan = 1)
 	}
 	
 	snd_pan = clamp(snd_pan, -1, 1)
@@ -138,9 +128,9 @@ step :: proc() -> bool {
 		k2.set_audio_stream_pan(music, snd_pan)
 		k2.set_audio_stream_volume(music, snd_volume)
 	} else {
-		k2.set_sound_volume(snd, snd_volume)
-		k2.set_sound_pan(snd, snd_pan)
-		k2.set_sound_pitch(snd, snd_pitch)
+		k2.set_sound_volume(snd_sound, snd_volume)
+		k2.set_sound_pan(snd_sound, snd_pan)
+		k2.set_sound_pitch(snd_sound, snd_pitch)
 	}
 	
 	k2.clear(k2.WHITE)
@@ -172,11 +162,9 @@ step :: proc() -> bool {
 }
 
 shutdown :: proc() {
-	k2.destroy_sound(snd)
-	k2.destroy_sound(snd2)
-	k2.destroy_sound(snd3)
-	k2.destroy_sound(wav_1)
-	k2.destroy_sound(wav_2)
+	k2.destroy_audio_clip(snd)
+	k2.destroy_audio_clip(snd2)
+	k2.destroy_audio_clip(snd3)
 	k2.destroy_audio_clip(wav)
 
 	when HAS_MUSIC {

--- a/examples/audio/audio.odin
+++ b/examples/audio/audio.odin
@@ -14,6 +14,7 @@ snd3: k2.Audio_Clip
 wav: k2.Audio_Clip
 
 music: k2.Audio_Stream
+music_sound: k2.Sound
 snd_volume: f32
 snd_pan: f32
 snd_pitch: f32 = 1
@@ -39,8 +40,7 @@ init :: proc() {
 		} else {
 			music = k2.load_audio_stream_from_file(MUSIC_FILE)
 		}
-		k2.set_audio_stream_loop(music, true)
-		k2.play_audio_stream(music)
+		music_sound = k2.play_audio_stream(music, loop = true)
 	} else {
 		snd_sound = k2.play_audio_clip(snd, loop = true)
 	}
@@ -115,18 +115,24 @@ step :: proc() -> bool {
 	
 	when HAS_MUSIC {
 		k2.update_audio_stream(music)
-		
+
+		// Home resumes from wherever the stream cursor is. End pauses (stop_sound doesn't rewind
+		// the stream). R moves the cursor back to the start, without silencing anything.
 		if k2.key_went_down(.Home) {
-			k2.play_audio_stream(music)
+			music_sound = k2.play_audio_stream(music, volume = snd_volume, pan = snd_pan, pitch = snd_pitch, loop = true)
 		}
 
 		if k2.key_went_down(.End) {
-			k2.stop_audio_stream(music)
+			k2.stop_sound(music_sound)
 		}
 
-		k2.set_audio_stream_pitch(music, snd_pitch)
-		k2.set_audio_stream_pan(music, snd_pan)
-		k2.set_audio_stream_volume(music, snd_volume)
+		if k2.key_went_down(.R) {
+			k2.reset_audio_stream(music)
+		}
+
+		k2.set_sound_pitch(music_sound, snd_pitch)
+		k2.set_sound_pan(music_sound, snd_pan)
+		k2.set_sound_volume(music_sound, snd_volume)
 	} else {
 		k2.set_sound_volume(snd_sound, snd_volume)
 		k2.set_sound_pan(snd_sound, snd_pan)
@@ -155,6 +161,11 @@ step :: proc() -> bool {
 	)
 	k2.draw_text("Press Space to play a familiar sound.", {20, 200}, 40, k2.BLACK)
 	k2.draw_text("Press Enter to also play a 1 second 440 hz sine wave.", {20, 240}, 40, k2.BLACK)
+
+	when HAS_MUSIC {
+		k2.draw_text("Home resumes the music, End pauses it, R resets it to the start.", {20, 280}, 40, k2.BLACK)
+	}
+
 	k2.present()
 	free_all(context.temp_allocator)
 

--- a/examples/audio/audio.odin
+++ b/examples/audio/audio.odin
@@ -116,14 +116,24 @@ step :: proc() -> bool {
 	when HAS_MUSIC {
 		k2.update_audio_stream(music)
 
-		// Home resumes from wherever the stream cursor is. End pauses (stop_sound doesn't rewind
-		// the stream). R moves the cursor back to the start, without silencing anything.
+		// Home starts the music. End stops it, which also rewinds the stream. P pauses and
+		// resumes. R jumps back to the start of the stream without stopping anything.
 		if k2.key_went_down(.Home) {
-			music_sound = k2.play_audio_stream(music, volume = snd_volume, pan = snd_pan, pitch = snd_pitch, loop = true)
+			music_sound = k2.play_audio_stream(
+				music,
+				volume = snd_volume,
+				pan = snd_pan,
+				pitch = snd_pitch,
+				loop = true,
+			)
 		}
 
 		if k2.key_went_down(.End) {
 			k2.stop_sound(music_sound)
+		}
+
+		if k2.key_went_down(.P) {
+			k2.set_sound_paused(music_sound, k2.sound_is_playing(music_sound))
 		}
 
 		if k2.key_went_down(.R) {
@@ -163,7 +173,7 @@ step :: proc() -> bool {
 	k2.draw_text("Press Enter to also play a 1 second 440 hz sine wave.", {20, 240}, 40, k2.BLACK)
 
 	when HAS_MUSIC {
-		k2.draw_text("Home resumes the music, End pauses it, R resets it to the start.", {20, 280}, 40, k2.BLACK)
+		k2.draw_text("Home plays the music, End stops it, P pauses, R rewinds.", {20, 280}, 40, k2.BLACK)
 	}
 
 	k2.present()

--- a/examples/audio/audio.odin
+++ b/examples/audio/audio.odin
@@ -10,7 +10,7 @@ pos: k2.Vec2
 snd: k2.Sound
 snd2: k2.Sound
 snd3: k2.Sound
-wav: k2.Audio_Buffer
+wav: k2.Audio_Clip
 wav_1: k2.Sound
 wav_2: k2.Sound
 
@@ -30,7 +30,7 @@ init :: proc() {
 	snd_pitch = 1
 	snd2 = make_sine_wave(440, 1, 44100)
 	snd3 = make_sine_wave(700, 1, 22050)
-	wav = k2.load_audio_buffer_from_bytes(#load("chord.wav"))
+	wav = k2.load_audio_clip_from_bytes(#load("chord.wav"))
 	wav_1 = k2.create_sound_from_audio_buffer(wav)
 	wav_2 = k2.create_sound_from_audio_buffer(wav)
 
@@ -177,7 +177,7 @@ shutdown :: proc() {
 	k2.destroy_sound(snd3)
 	k2.destroy_sound(wav_1)
 	k2.destroy_sound(wav_2)
-	k2.destroy_audio_buffer(wav)
+	k2.destroy_audio_clip(wav)
 
 	when HAS_MUSIC {
 		k2.destroy_audio_stream(music)

--- a/examples/audio_bus/audio_bus.odin
+++ b/examples/audio_bus/audio_bus.odin
@@ -20,15 +20,15 @@ sfx_bus: k2.Audio_Bus
 sfx_bus_destroyed: bool
 
 // Played as one-shots on the sfx bus. Several of these can overlap.
-blip: k2.Audio_Buffer
+blip: k2.Audio_Clip
 
 // A drone on the sfx bus, so you can hear the bus volume and pan without pressing anything.
 drone: k2.Sound
-drone_buffer: k2.Audio_Buffer
+drone_buffer: k2.Audio_Clip
 
 // This one stays on the master bus. It is what the sfx bus volume does NOT affect.
 tone: k2.Sound
-tone_buffer: k2.Audio_Buffer
+tone_buffer: k2.Audio_Clip
 
 sfx_volume: f32 = 1
 sfx_pan: f32
@@ -83,7 +83,7 @@ init :: proc() {
 }
 
 // Makes a sine wave that is a whole number of periods long, so that it loops cleanly.
-make_sine_wave :: proc(freq: int, min_length: f32, sample_rate: int) -> k2.Audio_Buffer {
+make_sine_wave :: proc(freq: int, min_length: f32, sample_rate: int) -> k2.Audio_Clip {
 	period_num_samples := f32(sample_rate) / f32(freq)
 	num_periods := math.ceil(f32(sample_rate) * min_length)
 	sine_data := make([]k2.Audio_Sample, int(num_periods), allocator = context.temp_allocator)
@@ -94,7 +94,7 @@ make_sine_wave :: proc(freq: int, min_length: f32, sample_rate: int) -> k2.Audio
 	}
 
 	bytes := slice.reinterpret([]u8, sine_data)
-	return k2.load_audio_buffer_from_bytes_raw(bytes, .Float32, sample_rate, .Mono)
+	return k2.load_audio_clip_from_bytes_raw(bytes, .Float32, sample_rate, .Mono)
 }
 
 step :: proc() -> bool {
@@ -212,9 +212,9 @@ step :: proc() -> bool {
 shutdown :: proc() {
 	k2.destroy_sound(drone)
 	k2.destroy_sound(tone)
-	k2.destroy_audio_buffer(blip)
-	k2.destroy_audio_buffer(drone_buffer)
-	k2.destroy_audio_buffer(tone_buffer)
+	k2.destroy_audio_clip(blip)
+	k2.destroy_audio_clip(drone_buffer)
+	k2.destroy_audio_clip(tone_buffer)
 
 	if !sfx_bus_destroyed {
 		k2.destroy_audio_bus(sfx_bus)

--- a/examples/audio_bus/audio_bus.odin
+++ b/examples/audio_bus/audio_bus.odin
@@ -20,15 +20,13 @@ sfx_bus: k2.Audio_Bus
 sfx_bus_destroyed: bool
 
 // Played as one-shots on the sfx bus. Several of these can overlap.
-blip: k2.Audio_Clip
+blip_clip: k2.Audio_Clip
 
-// A drone on the sfx bus, so you can hear the bus volume and pan without pressing anything.
-drone: k2.Sound
-drone_buffer: k2.Audio_Clip
+// A looping drone on the sfx bus, so you can hear the bus volume and pan without pressing anything.
+drone_clip: k2.Audio_Clip
 
-// This one stays on the master bus. It is what the sfx bus volume does NOT affect.
-tone: k2.Sound
-tone_buffer: k2.Audio_Clip
+// A looping tone that stays on the master bus. It is what the sfx bus volume does NOT affect.
+tone_clip: k2.Audio_Clip
 
 sfx_volume: f32 = 1
 sfx_pan: f32
@@ -63,13 +61,15 @@ init :: proc() {
 
 	sfx_bus = k2.create_audio_bus()
 
-	blip = make_sine_wave(600, 0.12, 44100)
-	drone_buffer = make_sine_wave(80, 1, 44100)
-	tone_buffer = make_sine_wave(220, 1, 44100)
+	blip_clip = make_sine_wave(600, 0.12, 44100)
+	drone_clip = make_sine_wave(80, 1, 44100)
+	tone_clip = make_sine_wave(220, 1, 44100)
 
-	// The drone goes on the sfx bus. The tone is left alone, so it plays on the master bus.
-	drone = k2.play_audio_clip(drone_buffer, volume = 0.3, loop = true, bus = sfx_bus)
-	tone = k2.play_audio_clip(tone_buffer, volume = 0.15, loop = true)
+	// The drone goes on the sfx bus. The tone is left alone, so it plays on the master bus. We
+	// never stop them one by one, and destroying the clips in `shutdown` stops them, so the
+	// returned sound handles can be discarded.
+	k2.play_audio_clip(drone_clip, volume = 0.3, loop = true, bus = sfx_bus)
+	k2.play_audio_clip(tone_clip, volume = 0.15, loop = true)
 }
 
 // Makes a sine wave that is a whole number of periods long, so that it loops cleanly.
@@ -97,7 +97,7 @@ step :: proc() -> bool {
 	// Each press starts a separate playback, so pressing quickly overlaps them. The pitch is
 	// randomized to make that easier to hear.
 	if k2.key_went_down(.Space) {
-		k2.play_audio_clip(blip, pitch = rand.float32_range(0.8, 1.6), bus = sfx_bus)
+		k2.play_audio_clip(blip_clip, pitch = rand.float32_range(0.8, 1.6), bus = sfx_bus)
 	}
 
 	// BUS SETTINGS
@@ -200,9 +200,9 @@ step :: proc() -> bool {
 }
 
 shutdown :: proc() {
-	k2.destroy_audio_clip(blip)
-	k2.destroy_audio_clip(drone_buffer)
-	k2.destroy_audio_clip(tone_buffer)
+	k2.destroy_audio_clip(blip_clip)
+	k2.destroy_audio_clip(drone_clip)
+	k2.destroy_audio_clip(tone_clip)
 
 	if !sfx_bus_destroyed {
 		k2.destroy_audio_bus(sfx_bus)

--- a/examples/audio_bus/audio_bus.odin
+++ b/examples/audio_bus/audio_bus.odin
@@ -63,23 +63,13 @@ init :: proc() {
 
 	sfx_bus = k2.create_audio_bus()
 
-	// A sound doesn't own the audio buffer it was created from, so we hang on to the buffers and
-	// destroy them ourselves further down.
 	blip = make_sine_wave(600, 0.12, 44100)
 	drone_buffer = make_sine_wave(80, 1, 44100)
 	tone_buffer = make_sine_wave(220, 1, 44100)
-	drone = k2.create_sound_from_audio_buffer(drone_buffer)
-	tone = k2.create_sound_from_audio_buffer(tone_buffer)
 
 	// The drone goes on the sfx bus. The tone is left alone, so it plays on the master bus.
-	k2.set_sound_bus(drone, sfx_bus)
-	k2.set_sound_volume(drone, 0.3)
-	k2.set_sound_loop(drone, true)
-	k2.play_sound(drone)
-
-	k2.set_sound_volume(tone, 0.15)
-	k2.set_sound_loop(tone, true)
-	k2.play_sound(tone)
+	drone = k2.play_audio_clip(drone_buffer, volume = 0.3, loop = true, bus = sfx_bus)
+	tone = k2.play_audio_clip(tone_buffer, volume = 0.15, loop = true)
 }
 
 // Makes a sine wave that is a whole number of periods long, so that it loops cleanly.
@@ -107,7 +97,7 @@ step :: proc() -> bool {
 	// Each press starts a separate playback, so pressing quickly overlaps them. The pitch is
 	// randomized to make that easier to hear.
 	if k2.key_went_down(.Space) {
-		k2.play_audio_buffer(blip, pitch = rand.float32_range(0.8, 1.6), bus = sfx_bus)
+		k2.play_audio_clip(blip, pitch = rand.float32_range(0.8, 1.6), bus = sfx_bus)
 	}
 
 	// BUS SETTINGS
@@ -210,8 +200,6 @@ step :: proc() -> bool {
 }
 
 shutdown :: proc() {
-	k2.destroy_sound(drone)
-	k2.destroy_sound(tone)
 	k2.destroy_audio_clip(blip)
 	k2.destroy_audio_clip(drone_buffer)
 	k2.destroy_audio_clip(tone_buffer)

--- a/examples/positional_audio/positional_audio.odin
+++ b/examples/positional_audio/positional_audio.odin
@@ -44,50 +44,31 @@ init :: proc() {
 	player_pos = {200, 200}
 
 	spinning_audio_source = {
-		sound = k2.create_sound_from_audio_buffer(sine_wave),
+		sound = k2.play_audio_clip(sine_wave, loop = true),
 	}
-
-	k2.set_sound_loop(spinning_audio_source.sound, true)
-	k2.play_sound(spinning_audio_source.sound)
 
 	stationary_1 := Audio_Source {
-		sound = k2.create_sound_from_audio_buffer(sine_wave),
+		sound = k2.play_audio_clip(sine_wave, pitch = 0.5, loop = true),
 		pos = {50, 50},
 	}
-
-	k2.set_sound_loop(stationary_1.sound, true)
-	k2.play_sound(stationary_1.sound)
-	k2.set_sound_pitch(stationary_1.sound, 0.5)
 	append(&stationary_audio_sources, stationary_1)
 
 	stationary_2 := Audio_Source {
-		sound = k2.create_sound_from_audio_buffer(sine_wave),
+		sound = k2.play_audio_clip(sine_wave, pitch = 0.45, loop = true),
 		pos = {450, 50},
 	}
-
-	k2.set_sound_loop(stationary_2.sound, true)
-	k2.play_sound(stationary_2.sound)
-	k2.set_sound_pitch(stationary_2.sound, 0.45)
 	append(&stationary_audio_sources, stationary_2)
 
 	stationary_3 := Audio_Source {
-		sound = k2.create_sound_from_audio_buffer(sine_wave),
+		sound = k2.play_audio_clip(sine_wave, pitch = 0.55, loop = true),
 		pos = {450, 450},
 	}
-
-	k2.set_sound_loop(stationary_3.sound, true)
-	k2.play_sound(stationary_3.sound)
-	k2.set_sound_pitch(stationary_3.sound, 0.55)
 	append(&stationary_audio_sources, stationary_3)
 
 	stationary_4 := Audio_Source {
-		sound = k2.create_sound_from_audio_buffer(sine_wave),
+		sound = k2.play_audio_clip(sine_wave, pitch = 0.6, loop = true),
 		pos = {50, 450},
 	}
-	
-	k2.set_sound_loop(stationary_4.sound, true)
-	k2.play_sound(stationary_4.sound)
-	k2.set_sound_pitch(stationary_4.sound, 0.6)
 	append(&stationary_audio_sources, stationary_4)
 }
 
@@ -160,12 +141,6 @@ step :: proc() -> bool {
 }
 
 shutdown :: proc() {
-	k2.destroy_sound(spinning_audio_source.sound)
-
-	for s in stationary_audio_sources {
-		k2.destroy_sound(s.sound)
-	}
-
 	delete(stationary_audio_sources)
 	k2.destroy_audio_clip(sine_wave)
 	k2.shutdown()

--- a/examples/positional_audio/positional_audio.odin
+++ b/examples/positional_audio/positional_audio.odin
@@ -8,7 +8,7 @@ import "core:mem"
 import "core:fmt"
 
 player_pos: k2.Vec2
-sine_wave: k2.Audio_Buffer
+sine_wave: k2.Audio_Clip
 spinning_audio_source: Audio_Source
 stationary_audio_sources: [dynamic]Audio_Source
 
@@ -167,11 +167,11 @@ shutdown :: proc() {
 	}
 
 	delete(stationary_audio_sources)
-	k2.destroy_audio_buffer(sine_wave)
+	k2.destroy_audio_clip(sine_wave)
 	k2.shutdown()
 }
 
-make_sine_wave :: proc(freq: int, min_length: f32, sample_rate: int) -> k2.Audio_Buffer {
+make_sine_wave :: proc(freq: int, min_length: f32, sample_rate: int) -> k2.Audio_Clip {
 	period_num_samples := f32(sample_rate) / f32(freq)
 	num_periods := math.ceil(f32(sample_rate) * min_length)
 	sine_data := make([]k2.Audio_Sample, int(num_periods), allocator = context.temp_allocator)
@@ -182,7 +182,7 @@ make_sine_wave :: proc(freq: int, min_length: f32, sample_rate: int) -> k2.Audio
 		samp = sf
 	}
 
-	return k2.load_audio_buffer_from_bytes_raw(slice.reinterpret([]u8, sine_data), .Float32, sample_rate, .Mono)
+	return k2.load_audio_clip_from_bytes_raw(slice.reinterpret([]u8, sine_data), .Float32, sample_rate, .Mono)
 }
 
 // This is not run by the web version, but it makes this program also work on non-web!

--- a/examples/space_cat/space_cat.odin
+++ b/examples/space_cat/space_cat.odin
@@ -117,9 +117,9 @@ plasma_ball_textures: [3]k2.Texture
 
 // We play these audio buffers directly using `play_audio_buffer`. That's good for these kind of
 // "one-shot" sounds that just need some initial playback settings.
-ab_shoot: k2.Audio_Buffer
-ab_pickup: k2.Audio_Buffer
-ab_hit: k2.Audio_Buffer
+ab_shoot: k2.Audio_Clip
+ab_pickup: k2.Audio_Clip
+ab_hit: k2.Audio_Clip
 
 // For making a texture appear on the screen for a short period.
 flash_texture: k2.Texture
@@ -251,9 +251,9 @@ init :: proc() {
 
 	enemy_hidden_tex = k2.load_texture_from_bytes(#load("enemy_hidden.png"))
 
-	ab_shoot = k2.load_audio_buffer_from_bytes(#load("laser_shoot.wav"))
-	ab_hit = k2.load_audio_buffer_from_bytes(#load("hit_hurt.wav"))
-	ab_pickup = k2.load_audio_buffer_from_bytes(#load("power_up.wav"))
+	ab_shoot = k2.load_audio_clip_from_bytes(#load("laser_shoot.wav"))
+	ab_hit = k2.load_audio_clip_from_bytes(#load("hit_hurt.wav"))
+	ab_pickup = k2.load_audio_clip_from_bytes(#load("power_up.wav"))
 
 	space_tileset_version = file_version("space_tileset.png")
 
@@ -351,9 +351,9 @@ shutdown :: proc() {
 		k2.destroy_texture(t)	
 	}
 
-	k2.destroy_audio_buffer(ab_hit)
-	k2.destroy_audio_buffer(ab_pickup)
-	k2.destroy_audio_buffer(ab_shoot)
+	k2.destroy_audio_clip(ab_hit)
+	k2.destroy_audio_clip(ab_pickup)
+	k2.destroy_audio_clip(ab_shoot)
 	k2.destroy_texture(space_tileset)
 	k2.destroy_texture(player.tex_east_west)
 	k2.destroy_texture(player.tex_up)

--- a/examples/space_cat/space_cat.odin
+++ b/examples/space_cat/space_cat.odin
@@ -115,7 +115,7 @@ bg_object_textures: [6]k2.Texture
 fg_object_textures: [7]k2.Texture
 plasma_ball_textures: [3]k2.Texture
 
-// We play these audio buffers directly using `play_audio_buffer`. That's good for these kind of
+// We play these audio buffers directly using `play_audio_clip`. That's good for these kind of
 // "one-shot" sounds that just need some initial playback settings.
 ab_shoot: k2.Audio_Clip
 ab_pickup: k2.Audio_Clip
@@ -516,7 +516,7 @@ update :: proc() {
 		})
 
 		// The shoot sound has pitch randomization and spatial panning.
-		k2.play_audio_buffer(
+		k2.play_audio_clip(
 			ab_shoot,
 			volume = rand.float32_range(0.7, 0.9),
 			pan = math.remap_clamped(player.pos.x, 0, SCREEN_WIDTH, -0.5, 0.5),
@@ -591,7 +591,7 @@ update :: proc() {
 					flash_texture_timer = 0.2
 					flash_texture_pos = p.pos
 					pidx -= 1
-					k2.play_audio_buffer(ab_hit)
+					k2.play_audio_clip(ab_hit)
 				}
 			}
 
@@ -600,7 +600,7 @@ update :: proc() {
 				unordered_remove(&current_room.interactables, inter_idx)
 				inter_idx -= 1
 				has_key = true
-				k2.play_audio_buffer(ab_pickup)
+				k2.play_audio_clip(ab_pickup)
 			}
 
 		case .Wall:

--- a/examples/space_cat/space_cat.odin
+++ b/examples/space_cat/space_cat.odin
@@ -115,11 +115,11 @@ bg_object_textures: [6]k2.Texture
 fg_object_textures: [7]k2.Texture
 plasma_ball_textures: [3]k2.Texture
 
-// We play these audio buffers directly using `play_audio_clip`. That's good for these kind of
+// We play these audio clips directly using `play_audio_clip`. That's good for these kind of
 // "one-shot" sounds that just need some initial playback settings.
-ab_shoot: k2.Audio_Clip
-ab_pickup: k2.Audio_Clip
-ab_hit: k2.Audio_Clip
+clip_shoot: k2.Audio_Clip
+clip_pickup: k2.Audio_Clip
+clip_hit: k2.Audio_Clip
 
 // For making a texture appear on the screen for a short period.
 flash_texture: k2.Texture
@@ -251,9 +251,9 @@ init :: proc() {
 
 	enemy_hidden_tex = k2.load_texture_from_bytes(#load("enemy_hidden.png"))
 
-	ab_shoot = k2.load_audio_clip_from_bytes(#load("laser_shoot.wav"))
-	ab_hit = k2.load_audio_clip_from_bytes(#load("hit_hurt.wav"))
-	ab_pickup = k2.load_audio_clip_from_bytes(#load("power_up.wav"))
+	clip_shoot = k2.load_audio_clip_from_bytes(#load("laser_shoot.wav"))
+	clip_hit = k2.load_audio_clip_from_bytes(#load("hit_hurt.wav"))
+	clip_pickup = k2.load_audio_clip_from_bytes(#load("power_up.wav"))
 
 	space_tileset_version = file_version("space_tileset.png")
 
@@ -351,9 +351,9 @@ shutdown :: proc() {
 		k2.destroy_texture(t)	
 	}
 
-	k2.destroy_audio_clip(ab_hit)
-	k2.destroy_audio_clip(ab_pickup)
-	k2.destroy_audio_clip(ab_shoot)
+	k2.destroy_audio_clip(clip_hit)
+	k2.destroy_audio_clip(clip_pickup)
+	k2.destroy_audio_clip(clip_shoot)
 	k2.destroy_texture(space_tileset)
 	k2.destroy_texture(player.tex_east_west)
 	k2.destroy_texture(player.tex_up)
@@ -517,7 +517,7 @@ update :: proc() {
 
 		// The shoot sound has pitch randomization and spatial panning.
 		k2.play_audio_clip(
-			ab_shoot,
+			clip_shoot,
 			volume = rand.float32_range(0.7, 0.9),
 			pan = math.remap_clamped(player.pos.x, 0, SCREEN_WIDTH, -0.5, 0.5),
 			pitch = rand.float32_range(0.8, 1.2),
@@ -591,7 +591,7 @@ update :: proc() {
 					flash_texture_timer = 0.2
 					flash_texture_pos = p.pos
 					pidx -= 1
-					k2.play_audio_clip(ab_hit)
+					k2.play_audio_clip(clip_hit)
 				}
 			}
 
@@ -600,7 +600,7 @@ update :: proc() {
 				unordered_remove(&current_room.interactables, inter_idx)
 				inter_idx -= 1
 				has_key = true
-				k2.play_audio_clip(ab_pickup)
+				k2.play_audio_clip(clip_pickup)
 			}
 
 		case .Wall:

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -496,9 +496,9 @@ set_texture_filter_ex :: proc(
 //-------//
 
 // Play an audio clip with the supplied initial settings. The return value is a `Sound`, which means
-// something that is currently playing in the audio mixer. Ignore the return value for
-// fire-and-forget playback. You can use the returned `Sound` with `set_sound_volume`, `stop_sound`
-// etc in order to control the playback.
+// something that is currently playing in the audio mixer. You can use the returned `Sound` with
+// `set_sound_volume`, `stop_sound` etc in order to control the playback. Ignore the return value
+// if you just want to start the sound and never touch it again.
 //
 // Audio clips are loaded using `load_audio_clip_from_file`, `load_audio_clip_from_bytes` and
 // `load_audio_clip_from_bytes_raw`.
@@ -538,21 +538,22 @@ set_sound_volume :: proc(sound: Sound, volume: f32)
 // Set the pan of a sound. Range: -1 to 1, where -1 is full left, 0 is center and 1 is full right.
 set_sound_pan :: proc(sound: Sound, pan: f32)
 
-// Set the pitch of a sound. Range: 0.01 and up.
+// Set the pitch of a sound. Range: 0.01 and up, where 1 is the default. Pitch 2 makes the sound
+// play twice as fast, which also makes it sound higher pitched.
 set_sound_pitch :: proc(sound: Sound, pitch: f32)
 
 // Make a sound loop when it reaches the end.
 //
 // Technical note: This also works for sounds started using `play_audio_stream`, but then it
-// reaches into the streaming decoder and tells that one to loop. A stream-fed `Sound` plays a
-// short buffer that the decoder keeps filling, so that sound always loops.
+// reaches into the streaming decoder and tells that one to loop. A `Sound` started from a stream
+// plays a short buffer that the decoder keeps filling, so that sound always loops.
 set_sound_loop :: proc(sound: Sound, loop: bool)
 
 // Route a sound into an audio bus. Pass `AUDIO_BUS_MASTER` for the master bus.
 set_sound_bus :: proc(sound: Sound, bus: Audio_Bus)
 
-// How many sounds currently play this clip. Useful for limiting how many copies of an effect pile
-// up.
+// How many sounds currently play this clip. Useful for limiting how many overlapping sounds you
+// start from the same clip.
 get_num_sounds_playing_clip :: proc(clip: Audio_Clip) -> int
 
 // Load a WAV file from disk. Returns an `Audio_Clip` which can be played using `play_audio_clip`.
@@ -610,7 +611,7 @@ load_audio_stream_from_file :: proc(filename: string) -> Audio_Stream
 // `.wasm` file.
 //
 // Another use case is if you're making a desktop game and you want to embed all the assets in the
-// executable (so the game is a single file). In that case you'd could also use `#load` to fetch the
+// executable (so the game is a single file). In that case you could also use `#load` to fetch the
 // file and then send it into this procedure.
 //
 // Note that this procedure wants the encoded file, for example an ogg file just like it was on
@@ -631,8 +632,10 @@ destroy_audio_stream :: proc(stream: Audio_Stream)
 update_audio_stream :: proc(stream: Audio_Stream)
 
 // Start playing an audio stream. Returns a `Sound`, which you can control using
-// `set_sound_volume`, `stop_sound` etc. Starts from wherever the decode cursor currently is and
-// never rewinds. A stream feeds at most one sound: playing again replaces the previous one.
+// `set_sound_volume`, `stop_sound` etc. The playback continues from wherever the stream last was:
+// It starts over from the beginning only if the stream was just loaded, was stopped using
+// `stop_sound` or has finished playing. A stream can only play one sound at a time: Playing again
+// replaces the previous one.
 //
 // Don't forget to call `update_audio_stream` every frame in order to stream in new data.
 play_audio_stream :: proc(
@@ -664,9 +667,10 @@ set_audio_bus_volume :: proc(bus: Audio_Bus, volume: f32)
 // Set the pan of an audio bus. Range: -1 to 1, where -1 is full left, 0 is center and 1 is full
 // right.
 //
-// This is a balance control: It turns the opposite side down. That's different from the pan of a
-// sound, which uses a constant-power curve to place a source in the stereo field. A bus is already
-// a finished stereo mix, and a bus at pan 0 has to leave it exactly as it is.
+// This is a balance control: It turns the opposite side down. The pan of a sound works
+// differently: It moves the sound between the left and right speakers while keeping the overall
+// loudness the same. A bus is already a finished stereo mix, and a bus at pan 0 has to leave it
+// exactly as it is.
 set_audio_bus_pan :: proc(bus: Audio_Bus, pan: f32)
 
 // Set an effect to run on everything that is mixed into the bus. This is how you apply your own
@@ -1379,12 +1383,17 @@ AUDIO_MIX_CHUNK_SIZE :: 1400
 // sample in an array of samples will be interpreted as left and right respectively.
 Audio_Sample :: f32
 
-// One playing instance in the mixer. Spawned by `play_audio_clip` or `play_audio_stream`.
-// Auto-destroys when it finishes playing. Operations on a finished sound are silent no-ops.
+// Represents something that is currently playing in the audio mixer. Created using
+// `play_audio_clip` and `play_audio_stream`. A sound is automatically destroyed when it finishes
+// playing. It is safe to keep using the handle after that: The procedures that take a `Sound` will
+// then just do nothing.
 Sound :: distinct Handle
 
 SOUND_NONE :: Sound {}
 
+// Plays an ogg file by decoding it a little bit at a time, instead of loading all of the audio
+// data up front like an `Audio_Clip` does. Good for music, which would otherwise use a lot of
+// memory. Start it using `play_audio_stream`.
 Audio_Stream :: distinct Handle
 
 AUDIO_STREAM_NONE :: Audio_Stream {}
@@ -1412,9 +1421,8 @@ Audio_Stream_Data :: struct {
 	sound: Sound,
 	clip: Audio_Clip,
 
-	// Where in the audio clip referred to by `buffer_handle` that we have most recently written
-	// samples. Together with the `offset` of the Sound_Object, this forms a circular
-	// buffer.
+	// Where in the audio clip referred to by `clip` that we have most recently written samples.
+	// Together with the `offset` of the Sound_Object, this forms a circular buffer.
 	buffer_write_pos: int,
 
 	// Different from `loop` in `Sound_Object`. This says if the whole stream should loop
@@ -1444,6 +1452,8 @@ Raw_Audio_Format :: enum {
 	Float64,
 }
 
+// A piece of audio that has been completely loaded into memory. Play it using `play_audio_clip`.
+// Several sounds can play the same clip at the same time.
 Audio_Clip :: distinct Handle
 
 AUDIO_CLIP_NONE :: Audio_Clip{}
@@ -1470,8 +1480,8 @@ Sound_Settings :: struct {
 	pitch: f32,
 }
 
-// A sound instance is what `Sound` handles are mapped to. It is a voice currently playing in the
-// mixer, holding the clip (or stream) it plays and the settings it plays with.
+// What `Sound` handles are mapped to: something that is currently playing in the mixer. It holds
+// the clip it plays and the settings it plays with.
 Sound_Object :: struct {
 	handle: Sound,
 	clip: Audio_Clip,
@@ -1494,7 +1504,7 @@ Sound_Object :: struct {
 	// The bus this is mixed into. The zero value is the master bus.
 	bus: Audio_Bus,
 
-	// Set when a stream feeds this sound. Zero for sounds played from a clip. Used by
+	// Set when this sound plays an audio stream. Zero for sounds played from a clip. Used by
 	// `set_sound_loop` to redirect to the stream's own loop flag.
 	stream: Audio_Stream,
 }

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -543,10 +543,9 @@ set_sound_pitch :: proc(sound: Sound, pitch: f32)
 
 // Make a sound loop when it reaches the end.
 //
-// Technical note: This works for sounds started using `play_audio_stream`. But it actually reaches
-// into the streaming decoder and tells that one to loop. The `Sound` that is used by the audio
-// stream is just a short buffer that is filled by the decoding stream, so that one always loops
-// when playing from a stream.
+// Technical note: This also works for sounds started using `play_audio_stream`, but then it
+// reaches into the streaming decoder and tells that one to loop. A stream-fed `Sound` plays a
+// short buffer that the decoder keeps filling, so that sound always loops.
 set_sound_loop :: proc(sound: Sound, loop: bool)
 
 // Route a sound into an audio bus. Pass `AUDIO_BUS_MASTER` for the master bus.

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -549,7 +549,7 @@ load_audio_clip_from_file :: proc(filename: string) -> Audio_Clip
 // data does not include the header, then please use `load_audio_clip_from_bytes_raw`.
 load_audio_clip_from_bytes :: proc(bytes: []u8) -> Audio_Clip
 
-// Load an audio buffer from some raw audio data. You need to specify the data, format and sample
+// Load an audio clip from some raw audio data. You need to specify the data, format and sample
 // rate of the sound yourself. This assumes that there is no header in the data. If your data has a
 // header (you read the data from a file on disk), then please use `load_audio_clip_from_bytes`
 // instead.
@@ -1487,7 +1487,7 @@ Sound_Object :: struct {
 Audio_Bus :: distinct Handle
 
 // All other buses are mixed into the master bus, as well as sounds that play directly on the master
-// bus. This is the default bus of all sounds, audio streams and playing audio buffers.
+// bus. This is the default bus of all sounds.
 //
 // You can use this with `set_audio_bus_volume`, `set_audio_bus_pan` and `set_audio_bus_effect`.
 // That's how you set the master volume of your game.

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -495,144 +495,74 @@ set_texture_filter_ex :: proc(
 // AUDIO //
 //-------//
 
-// Play a sound previous created using `load_sound_from_xxx` or `create_sound_from_audio_buffer`.
-// The sound will be mixed when `update_audio_mixer` runs, which happens as part of `update`.
-play_sound :: proc(sound: Sound)
-
-// Play an audio buffer, using the playback settings you pass in. The playback does not loop. Good
-// for playing one-off sound effects such as footsteps. You can play the same Audio_Buffer multiple
-// times simultaneously, without one stopping the another.
-//
-// The difference between using this and a `Sound` is that the `Sound` remembers its playback
-// settings, can be stopped and looped.
+// Play an audio clip. Always starts a new sound, never restarts. Discard the returned handle for
+// fire-and-forget playback. Parameters are the starting settings.
 //
 // Pass `bus` to play the sound on an audio bus. It plays on the master bus by default.
-play_audio_buffer :: proc(
-	ab: Audio_Buffer,
+play_audio_clip :: proc(
+	clip: Audio_Clip,
 	volume: f32 = 1,
 	pan: f32 = 0,
 	pitch: f32 = 1,
+	loop := false,
 	bus: Audio_Bus = AUDIO_BUS_MASTER,
-)
+) -> Sound
 
-// Stop a sound. Rewinds it to the start.
+// Stops and destroys the sound. For a stream-fed sound this is a pause: the stream cursor stays
+// put.
 stop_sound :: proc(sound: Sound)
 
 // Returns true if the sound is currently playing.
 sound_is_playing :: proc(sound: Sound) -> bool
 
-// Set the volume of a sound. Range: 0 to 1, where 0 is silence and 1 is the original volume of the
-// sound. The volume change will only affect this instance of the sound. Use `create_sound_instance`
-// to create more instances without duplicating data.
+// Set the volume of a sound. Range: 0 to 1.
 set_sound_volume :: proc(sound: Sound, volume: f32)
 
 // Set the pan of a sound. Range: -1 to 1, where -1 is full left, 0 is center and 1 is full right.
-// The pan change will only affect this instance of the sound. Use `create_sound_instance` to create
-// more instances without duplicating data.
 set_sound_pan :: proc(sound: Sound, pan: f32)
 
-// Set the pitch of a sound. Range: 0.01 to infinity, where 0.01 is the lowest pitch and higher
-// values increase the pitch. The pitch change will only affect this instance of the sound. Use
-// `create_sound_instance` to create more instances without duplicating data.
+// Set the pitch of a sound. Range: 0.01 and up.
 set_sound_pitch :: proc(sound: Sound, pitch: f32)
 
-// Makes a sound loop when it reaches the end. You can set this before playing but also while
-// playing the sound.
+// Loops the sound. For a stream-fed sound this sets the stream's loop instead.
 set_sound_loop :: proc(sound: Sound, loop: bool)
 
-// Route a sound into an audio bus. The sound is then mixed into that bus instead of straight into
-// the master bus. You can set the volume and pan of the whole bus, making it possible to control
-// whole categories of sounds.
-//
-// Pass `AUDIO_BUS_MASTER` to route the sound to the master bus.
+// Route a sound into an audio bus. Pass `AUDIO_BUS_MASTER` for the master bus.
 set_sound_bus :: proc(sound: Sound, bus: Audio_Bus)
 
-// Load a WAV file from disk. Returns a `Sound` which can be used with `play_sound`. If you need to
-// play a sound multiple times simultaneously, then use `load_audio_buffer_from_file` followed by
-// one or more calls to `create_sound_from_audio_buffer`.
-//
-// Sounds created using this procedure owns their internal audio buffer: Calling `destroy_sound`
-// will also destroy the audio buffer. 
+// How many sounds currently play this clip. Useful for limiting how many copies of an effect pile
+// up.
+get_num_sounds_playing_clip :: proc(clip: Audio_Clip) -> int
+
+// Load a WAV file from disk. Returns an `Audio_Clip`.
 //
 // Supports mono and stereo WAV files with 8, 16, 24 or 32 bit integer samples, or 32 or 64 bit
 // float samples.
-load_sound_from_file :: proc(filename: string) -> Sound
-
-// Load a sound some pre-loaded memory (for example using `#load("sound.wav")`). Returns a `Sound`
-// which can be used with `play_sound`. If you need to play a sound multiple times simultaneously,
-// then use `load_audio_buffer_from_bytes` followed by one or more calls to
-// `create_sound_from_audio_buffer`.
-//
-// Sounds created using this procedure owns their internal audio buffer: Calling `destroy_sound`
-// will also destroy the audio buffer.
-//
-// Supports mono and stereo WAV data with 8, 16, 24 or 32 bit integer samples, or 32 or 64 bit
-// float samples. Note that the data should be the entire WAV file, including the header. If your
-// data does not include the header, then please use `load_audio_buffer_from_bytes_raw` combined
-// with `create_sound_from_audio_buffer`.
-load_sound_from_bytes :: proc(bytes: []byte) -> Sound
-
-// Load a sound from some raw audio data. You need to specify the data, format and sample rate of
-// the audio data yourself. This assumes that there is no header in the data. If your data has a
-// header (you read the data from a file on disk), then please use `load_sound_from_bytes` instead.
-//
-// The returned Sound owns its internal Audio_Buffer: Calling `destroy_sound` with it will destroy
-// the audio buffer.
-load_sound_from_bytes_raw :: proc(
-	bytes: []u8,
-	format: Raw_Sound_Format,
-	sample_rate: int,
-	channels: Audio_Channels,
-) -> Sound
-
-// Load a WAV file from disk. Returns an `Audio_Buffer` which can be used with
-// `create_sound_from_audio_buffer` in order to play the audio buffer multiple times simultaneously.
-//
-// Supports mono and stereo WAV files with 8, 16, 24 or 32 bit integer samples, or 32 or 64 bit
-// float samples.
-load_audio_buffer_from_file :: proc(filename: string) -> Audio_Buffer
+load_audio_clip_from_file :: proc(filename: string) -> Audio_Clip
 
 // Load a WAV file from some pre-loaded memory (can be loaded using `#load("sound.wav")`). Returns
-// an `Audio_Buffer` which can be used with `create_sound_from_audio_buffer` in order to play the
-// audio buffer multiple times simultaneously.
+// an `Audio_Clip` which can be played, including multiple times simultaneously, using
+// `play_audio_clip`.
 //
 // Supports mono and stereo WAV data with 8, 16, 24 or 32 bit integer samples, or 32 or 64 bit
 // float samples. Note that the data should be the entire WAV file, including the header. If your
-// data does not include the header, then please use `load_audio_buffer_from_bytes_raw`.
-load_audio_buffer_from_bytes :: proc(bytes: []u8) -> Audio_Buffer
+// data does not include the header, then please use `load_audio_clip_from_bytes_raw`.
+load_audio_clip_from_bytes :: proc(bytes: []u8) -> Audio_Clip
 
 // Load an audio buffer from some raw audio data. You need to specify the data, format and sample
 // rate of the sound yourself. This assumes that there is no header in the data. If your data has a
-// header (you read the data from a file on disk), then please use `load_audio_buffer_from_bytes`
+// header (you read the data from a file on disk), then please use `load_audio_clip_from_bytes`
 // instead.
-load_audio_buffer_from_bytes_raw :: proc(
+load_audio_clip_from_bytes_raw :: proc(
 	bytes: []u8,
-	format: Raw_Sound_Format,
+	format: Raw_Audio_Format,
 	sample_rate: int,
 	channels: Audio_Channels,
-) -> Audio_Buffer
+) -> Audio_Clip
 
-// Creates a sound that can be used to play the contents of an `Audio_Buffer`. This can be used to
-// load an audio buffer once and have multiple sounds playing the contents of it, simultaneously.
-// This makes all those sounds share the same audio data.
-//
-// Sounds created using this procedure do not own the buffer. This means that calling
-// `destroy_sound` on the Sound will only remove the Sound from Karl2D's internal state, but it
-// won't destroy the Audio_Buffer. Such auto-destroying of the `Audio_Buffer` only happen with
-// sounds created using `load_sound_from_file` and `load_sound_from_bytes`.
-create_sound_from_audio_buffer :: proc(buffer: Audio_Buffer) -> Sound
-
-// Destroy a sound, removing it from Karl2D's internal list of sounds.
-//
-// If the sound was created using `create_sound_from_audio_buffer`, then this procedure will not
-// destroy the audio buffer. If the sound was created using `load_sound_from_file` or
-// `load_sound_from_bytes`, then this procedure WILL destroy the audio buffer.
-destroy_sound :: proc(sound: Sound)
-
-// Destroy an audio buffer previously loaded using `load_audio_buffer_from_xxx`. Before destroying
-// this audio buffer, make sure it is not in use by any playing sounds. Destroy the sounds that
-// reference it using `destroy_sound` first.
-destroy_audio_buffer :: proc(audio_buffer: Audio_Buffer)
+// Destroy an audio clip previously loaded using `load_audio_clip_from_xxx`. Also stops sounds
+// playing this clip.
+destroy_audio_clip :: proc(clip: Audio_Clip)
 
 // Load an audio stream from a file on disk. This is often used for playing music. An audio stream
 // only loads a small part of the file at a time. As the file is played, new parts are streamed into
@@ -664,9 +594,9 @@ load_audio_stream_from_file :: proc(filename: string) -> Audio_Stream
 // file and then send it into this procedure.
 //
 // Note that this procedure wants the encoded file, for example an ogg file just like it was on
-// disk. For normal sounds there is a `load_sound_from_bytes_raw` procedure where you just send in
-// the samples. There is no such procedure for audio streams since the whole idea is to stream an
-// encoded file into memory without having to decode the whole thing first.  
+// disk. For normal sounds there is a `load_audio_clip_from_bytes_raw` procedure where you just send
+// in the samples. There is no such procedure for audio streams since the whole idea is to stream an
+// encoded file into memory without having to decode the whole thing first.
 load_audio_stream_from_bytes :: proc(bytes: []u8) -> Audio_Stream
 
 // Destroy an audio stream previously loaded using `load_audio_stream_from_file` or
@@ -680,59 +610,27 @@ destroy_audio_stream :: proc(stream: Audio_Stream)
 // for the streaming to actually happen. 
 update_audio_stream :: proc(stream: Audio_Stream)
 
-// Start playing an audio stream. Don't forget to call `update_audio_stream` every frame in order to
-// stream in new data.
+// Returns a `Sound`, controllable like any other. Starts from wherever the decode cursor
+// currently is and never rewinds. A stream feeds at most one sound: playing again replaces the
+// previous one.
 //
-// Running this this while the stream is already playing will restart it from the beginning. Use
-// `pause_audio_stream` if you just want to pause it.
-play_audio_stream :: proc(stream: Audio_Stream)
+// Don't forget to call `update_audio_stream` every frame in order to stream in new data.
+play_audio_stream :: proc(
+	stream: Audio_Stream,
+	volume: f32 = 1,
+	pan: f32 = 0,
+	pitch: f32 = 1,
+	loop := false,
+	bus: Audio_Bus = AUDIO_BUS_MASTER,
+) -> Sound
 
-// Pause an audio stream. Run `play_audio_stream` to unpause it.
-pause_audio_stream :: proc(stream: Audio_Stream)
-
-// Stop an audio stream. If `play_audio_stream` is called again, the stream will start over from the
-// beginning.
-stop_audio_stream :: proc(stream: Audio_Stream)
-
-// Returns true if the audio stream is currently playing. Note that a looping audio stream will
-// always return true.
-is_audio_stream_playing :: proc(stream: Audio_Stream) -> bool
-
-// Set the volume of the audio stream. Range: 0 to 1.
-//
-// You can use this both with a playing and non-playing stream. If its already playing, then this
-// will affect the playing stream.
-set_audio_stream_volume :: proc(stream: Audio_Stream, volume: f32)
-
-// Set the pan (balance between left and right) of the audio stream. Range: -1 to 1, where -1 is
-// full left, 0 is center and 1 is full right.
-//
-// You can use this both with a playing and non-playing stream. If its already playing, then this
-// will affect the playing stream.
-set_audio_stream_pan :: proc(stream: Audio_Stream, pan: f32)
-
-// Set the pitch of the audio stream. Range: 0.01 to infinity. A higher value will make the audio
-// play faster.
-//
-// You can use this both with a playing and non-playing stream. If its already playing, then this
-// will affect the playing stream.
-set_audio_stream_pitch :: proc(stream: Audio_Stream, pitch: f32)
-
-// Set the audio stream to loop when it reaches the end of the stream. You can set this before
-// playing the stream. You can also modify the loop state of an already playing stream.
-set_audio_stream_loop :: proc(stream: Audio_Stream, loop: bool)
-
-// Route an audio stream into an audio bus. The stream is then mixed into that bus instead of
-// straight into the master bus. Handy for putting your music on its own bus, so the player can
-// turn the music down without turning the sound effects down.
-//
-// You can use this both with a playing and non-playing stream. If it's already playing, then this
-// will affect the playing stream. Pass `AUDIO_BUS_MASTER` to put it back on the master bus.
-set_audio_stream_bus :: proc(stream: Audio_Stream, bus: Audio_Bus)
+// Moves the decode cursor to the start. Does not silence anything: combine with `stop_sound` to
+// fully stop. If the stream is playing, the music jumps back to the top and keeps playing.
+reset_audio_stream :: proc(stream: Audio_Stream)
 
 // Create an audio bus: A group of sounds that are mixed together before they reach the master bus.
-// Route sounds into it using `set_sound_bus`, `set_audio_stream_bus`, or the `bus` parameter of
-// `play_audio_buffer`.
+// Route sounds into it using `set_sound_bus`, or the `bus` parameter of `play_audio_clip` or
+// `play_audio_stream`.
 //
 // A new bus has volume 1, pan 0 and no effect. That makes it a passthrough: Playing a sound on a
 // fresh bus sounds exactly like playing it on the master bus, until you change something.
@@ -1465,46 +1363,11 @@ AUDIO_MIX_CHUNK_SIZE :: 1400
 // sample in an array of samples will be interpreted as left and right respectively.
 Audio_Sample :: f32
 
-// Represents a sound you can play using the `play_sound` procedure. Loaded using
-// `load_sound_from_file` or `load_sound_from_bytes`. Create instances of an already loaded sound
-// using `create_sound_instance`.
+// One playing instance in the mixer. Spawned by `play_audio_clip` or `play_audio_stream`.
+// Auto-destroys when it finishes playing. Operations on a finished sound are silent no-ops.
 Sound :: distinct Handle
 
 SOUND_NONE :: Sound {}
-
-// A sound instance is what `Sound` handles are mapped to. They contain a handle to a an audio
-// buffer, and the settings for use when playing that buffer. The audio buffer may be shared between
-// multiple sound instances, which allows you to play the same sound multiple times at the same time
-// without having to clone the data.
-Sound_Object :: struct {
-	handle: Sound,
-
-	// The audio buffer may be used by multiple sound instances. This is the key idea of sound
-	// instances: That you can use `create_sound_instance` to make it possible to play a sound
-	// multiple times at the same time, without having to clone the data.
-	audio_buffer: Audio_Buffer,
-
-	// If true, then the audio buffer will be destroyed when this sound is destroyed. This is true
-	// when the sound was loaded using the `load_sound_xxx` procedures. It's false when the sound
-	// is created from `create_sound_from_audio_buffer`.
-	owns_audio_buffer: bool,
-
-	// If this sound is currently playing, then this identifies the state of the playing sound. It
-	// is PLAYING_AUDIO_BUFFER_NONE (zero) when it is not playing.
-	playing_buffer_handle: Playing_Audio_Buffer_Handle,
-
-	// This exists both here and in the `Playing_Audio_Buffer`. That way we can store settings
-	// even when the sound isn't playing. Set using `set_sound_volume/pan/pitch`.
-	playback_settings: Audio_Buffer_Playback_Settings,
-
-	// If true, then the playing sound will be set up as "looping" when `play_sound` is called. Set
-	// using `set_sound_loop`.
-	loop: bool,
-
-	// The bus the sound is mixed into when it plays. The zero value is the master bus. Set using
-	// `set_sound_bus`.
-	bus: Audio_Bus,
-}
 
 Audio_Stream :: distinct Handle
 
@@ -1530,22 +1393,16 @@ Audio_Stream_Data :: struct {
 	
 	vorbis: ^stbv.vorbis,
 	vorbis_buffer: stbv.vorbis_alloc,
-	playing_buffer_handle: Playing_Audio_Buffer_Handle,
-	buffer: Audio_Buffer,
-	
-	// Where in the audio buffer referred to by `buffer_handle` that we have most recently written
-	// samples. Together with the `offset` of the Playing_Audio_Buffer, this forms a circular
+	sound: Sound,
+	clip: Audio_Clip,
+
+	// Where in the audio clip referred to by `buffer_handle` that we have most recently written
+	// samples. Together with the `offset` of the Sound_Object, this forms a circular
 	// buffer.
 	buffer_write_pos: int,
 
-	playback_settings: Audio_Buffer_Playback_Settings,
-
-	// The bus the stream is mixed into when it plays. The zero value is the master bus. Set using
-	// `set_audio_stream_bus`.
-	bus: Audio_Bus,
-
-	// Different from `loop` in `Playing_Audio_Buffer`. This says if the whole stream should loop
-	// when it reaches end-of-file. The `loop` in `Playing_Audio_Buffer` just says to loop the
+	// Different from `loop` in `Sound_Object`. This says if the whole stream should loop
+	// when it reaches end-of-file. The `loop` in `Sound_Object` just says to loop the
 	// buffer itself. That's something you always want for a stream: We are continously writing
 	// data from a file into a small buffer that is a few seconds long.
 	loop: bool,
@@ -1561,8 +1418,8 @@ Audio_Stream_Data :: struct {
 	bytes: []u8,
 }
 
-// The format used to describe that data passed to `load_sound_from_bytes_raw`.
-Raw_Sound_Format :: enum {
+// The format used to describe that data passed to `load_audio_clip_from_bytes_raw`.
+Raw_Audio_Format :: enum {
 	Integer8, // unsigned, like in 8 bit WAV files. The other integer formats are signed.
 	Integer16,
 	Integer24, // three bytes per sample, little endian
@@ -1571,14 +1428,14 @@ Raw_Sound_Format :: enum {
 	Float64,
 }
 
-Audio_Buffer :: distinct Handle
+Audio_Clip :: distinct Handle
 
-AUDIO_BUFFER_NONE :: Audio_Buffer{}
+AUDIO_CLIP_NONE :: Audio_Clip{}
 
-Audio_Buffer_Object :: struct {
-	handle: Audio_Buffer,
+Audio_Clip_Object :: struct {
+	handle: Audio_Clip,
 
-	// All the samples of the audio buffer. In the case of stereo, the left and right samples are
+	// All the samples of the audio clip. In the case of stereo, the left and right samples are
 	// interleaved.
 	samples: []Audio_Sample,
 
@@ -1591,27 +1448,19 @@ Audio_Buffer_Object :: struct {
 	channels: Audio_Channels,
 }
 
-Audio_Buffer_Playback_Settings :: struct {
+Sound_Settings :: struct {
 	volume: f32,
 	pan: f32,
 	pitch: f32,
 }
 
-DEFAULT_AUDIO_BUFFER_PLAYBACK_SETTINGS :: Audio_Buffer_Playback_Settings {
-	volume = 1,
-	pan = 0,
-	pitch = 1,
-}
-
-PLAYING_AUDIO_BUFFER_NONE :: Playing_Audio_Buffer_Handle {}
-
-Playing_Audio_Buffer_Handle :: distinct Handle
-
-Playing_Audio_Buffer :: struct {
-	handle: Playing_Audio_Buffer_Handle,
-	audio_buffer: Audio_Buffer,
-	target_settings: Audio_Buffer_Playback_Settings,
-	current_settings: Audio_Buffer_Playback_Settings,
+// A sound instance is what `Sound` handles are mapped to. It is a voice currently playing in the
+// mixer, holding the clip (or stream) it plays and the settings it plays with.
+Sound_Object :: struct {
+	handle: Sound,
+	clip: Audio_Clip,
+	target_settings: Sound_Settings,
+	current_settings: Sound_Settings,
 
 	// How many samples have played?
 	offset: int,
@@ -1625,12 +1474,16 @@ Playing_Audio_Buffer :: struct {
 
 	// The bus this is mixed into. The zero value is the master bus.
 	bus: Audio_Bus,
+
+	// Set when a stream feeds this sound. Zero for sounds played from a clip. Used by
+	// `set_sound_loop` to redirect to the stream's own loop flag.
+	stream: Audio_Stream,
 }
 
 // A bus is a group of sounds that are mixed together before they reach the master bus. You can set
 // the volume and the pan of the whole group, and you can run an effect on it. Create one using
-// `create_audio_bus` and route sounds into it using `set_sound_bus`, `set_audio_stream_bus` or the
-// `bus` parameter of `play_audio_buffer`.
+// `create_audio_bus` and route sounds into it using `set_sound_bus`, or the `bus` parameter of
+// `play_audio_clip` or `play_audio_stream`.
 Audio_Bus :: distinct Handle
 
 // All other buses are mixed into the master bus, as well as sounds that play directly on the master
@@ -1659,7 +1512,7 @@ Audio_Bus_Settings :: struct {
 Audio_Bus_Object :: struct {
 	handle: Audio_Bus,
 
-	// Same idea as in `Playing_Audio_Buffer`: The current settings move towards the target
+	// Same idea as in `Sound_Object`: The current settings move towards the target
 	// settings a bit at a time, so that changing the volume of a bus doesn't click.
 	target_settings: Audio_Bus_Settings,
 	current_settings: Audio_Bus_Settings,
@@ -1773,10 +1626,8 @@ State :: struct {
 	audio_backend: Audio_Backend_Interface,
 	audio_backend_state: rawptr,
 
-	audio_buffers: hm.Dynamic_Handle_Map(Audio_Buffer_Object, Audio_Buffer),
+	audio_clips: hm.Dynamic_Handle_Map(Audio_Clip_Object, Audio_Clip),
 	sounds: hm.Dynamic_Handle_Map(Sound_Object, Sound),
-
-	playing_audio_buffers: hm.Dynamic_Handle_Map(Playing_Audio_Buffer, Playing_Audio_Buffer_Handle),
 
 	audio_streams: hm.Dynamic_Handle_Map(Audio_Stream_Data, Audio_Stream),
 

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -632,10 +632,6 @@ play_audio_stream :: proc(
 	bus: Audio_Bus = AUDIO_BUS_MASTER,
 ) -> Sound
 
-// Moves the decode cursor to the start. Does not silence anything: combine with `stop_sound` to
-// fully stop. If the stream is playing, the music jumps back to the top and keeps playing.
-reset_audio_stream :: proc(stream: Audio_Stream)
-
 // Create an audio bus: A group of sounds that are mixed together before they reach the master bus.
 // Route sounds into it using `set_sound_bus`, or the `bus` parameter of `play_audio_clip` or
 // `play_audio_stream`.

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -495,10 +495,18 @@ set_texture_filter_ex :: proc(
 // AUDIO //
 //-------//
 
-// Play an audio clip. Always starts a new sound, never restarts. Discard the returned handle for
-// fire-and-forget playback. Parameters are the starting settings.
+// Play an audio clip with the supplied initial settings. The return value is a `Sound`, which means
+// something that is currently playing in the audio mixer. Ignore the return value for
+// fire-and-forget playback. You can use the returned `Sound` with `set_sound_volume`, `stop_sound`
+// etc in order to control the playback.
+//
+// Audio clips are loaded using `load_audio_clip_from_file`, `load_audio_clip_from_bytes` and
+// `load_audio_clip_from_bytes_raw`.
 //
 // Pass `bus` to play the sound on an audio bus. It plays on the master bus by default.
+//
+// Warning: If you pass `loop = true` and don't save the return value anywhere, then you've started
+// a sound you cannot stop.
 play_audio_clip :: proc(
 	clip: Audio_Clip,
 	volume: f32 = 1,
@@ -508,8 +516,9 @@ play_audio_clip :: proc(
 	bus: Audio_Bus = AUDIO_BUS_MASTER,
 ) -> Sound
 
-// Stops and destroys the sound. For a stream-fed sound this also rewinds the stream to the start.
-// Use `set_sound_paused` to pause without destroying.
+// Stops the sound, which destroys its playback state in the mixer. For a `Sound` started using
+// `play_audio_stream`, this also rewinds the stream to the start. Use `set_sound_paused` to pause
+// the Sound instead, which won't lose the current playback position and settings.
 stop_sound :: proc(sound: Sound)
 
 // Pause or unpause a sound. A paused sound keeps its position and stays valid until it is unpaused
@@ -532,7 +541,12 @@ set_sound_pan :: proc(sound: Sound, pan: f32)
 // Set the pitch of a sound. Range: 0.01 and up.
 set_sound_pitch :: proc(sound: Sound, pitch: f32)
 
-// Loops the sound. For a stream-fed sound this sets the stream's loop instead.
+// Make a sound loop when it reaches the end.
+//
+// Technical note: This works for sounds started using `play_audio_stream`. But it actually reaches
+// into the streaming decoder and tells that one to loop. The `Sound` that is used by the audio
+// stream is just a short buffer that is filled by the decoding stream, so that one always loops
+// when playing from a stream.
 set_sound_loop :: proc(sound: Sound, loop: bool)
 
 // Route a sound into an audio bus. Pass `AUDIO_BUS_MASTER` for the master bus.
@@ -542,15 +556,14 @@ set_sound_bus :: proc(sound: Sound, bus: Audio_Bus)
 // up.
 get_num_sounds_playing_clip :: proc(clip: Audio_Clip) -> int
 
-// Load a WAV file from disk. Returns an `Audio_Clip`.
+// Load a WAV file from disk. Returns an `Audio_Clip` which can be played using `play_audio_clip`.
 //
 // Supports mono and stereo WAV files with 8, 16, 24 or 32 bit integer samples, or 32 or 64 bit
 // float samples.
 load_audio_clip_from_file :: proc(filename: string) -> Audio_Clip
 
 // Load a WAV file from some pre-loaded memory (can be loaded using `#load("sound.wav")`). Returns
-// an `Audio_Clip` which can be played, including multiple times simultaneously, using
-// `play_audio_clip`.
+// an `Audio_Clip` which can be played using `play_audio_clip`.
 //
 // Supports mono and stereo WAV data with 8, 16, 24 or 32 bit integer samples, or 32 or 64 bit
 // float samples. Note that the data should be the entire WAV file, including the header. If your
@@ -559,8 +572,8 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> Audio_Clip
 
 // Load an audio clip from some raw audio data. You need to specify the data, format and sample
 // rate of the sound yourself. This assumes that there is no header in the data. If your data has a
-// header (you read the data from a file on disk), then please use `load_audio_clip_from_bytes`
-// instead.
+// header (for example, you read a whole WAV file from disk), then please use
+// `load_audio_clip_from_bytes` instead.
 load_audio_clip_from_bytes_raw :: proc(
 	bytes: []u8,
 	format: Raw_Audio_Format,
@@ -574,7 +587,7 @@ destroy_audio_clip :: proc(clip: Audio_Clip)
 
 // Load an audio stream from a file on disk. This is often used for playing music. An audio stream
 // only loads a small part of the file at a time. As the file is played, new parts are streamed into
-// memory.
+// memory. Start playing the stream using `play_audio_stream`.
 //
 // Supported file formats: ogg
 //
@@ -618,9 +631,9 @@ destroy_audio_stream :: proc(stream: Audio_Stream)
 // for the streaming to actually happen. 
 update_audio_stream :: proc(stream: Audio_Stream)
 
-// Returns a `Sound`, controllable like any other. Starts from wherever the decode cursor
-// currently is and never rewinds. A stream feeds at most one sound: playing again replaces the
-// previous one.
+// Start playing an audio stream. Returns a `Sound`, which you can control using
+// `set_sound_volume`, `stop_sound` etc. Starts from wherever the decode cursor currently is and
+// never rewinds. A stream feeds at most one sound: playing again replaces the previous one.
 //
 // Don't forget to call `update_audio_stream` every frame in order to stream in new data.
 play_audio_stream :: proc(

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -508,12 +508,20 @@ play_audio_clip :: proc(
 	bus: Audio_Bus = AUDIO_BUS_MASTER,
 ) -> Sound
 
-// Stops and destroys the sound. For a stream-fed sound this is a pause: the stream cursor stays
-// put.
+// Stops and destroys the sound. For a stream-fed sound this also rewinds the stream to the start.
+// Use `set_sound_paused` to pause without destroying.
 stop_sound :: proc(sound: Sound)
 
-// Returns true if the sound is currently playing.
+// Pause or unpause a sound. A paused sound keeps its position and stays valid until it is unpaused
+// or stopped.
+set_sound_paused :: proc(sound: Sound, paused: bool)
+
+// Returns true if the sound exists and is not paused.
 sound_is_playing :: proc(sound: Sound) -> bool
+
+// Returns true if the sound still exists. Both playing and paused sounds are valid. A finished or
+// stopped sound is not.
+sound_is_valid :: proc(sound: Sound) -> bool
 
 // Set the volume of a sound. Range: 0 to 1.
 set_sound_volume :: proc(sound: Sound, volume: f32)
@@ -1471,6 +1479,9 @@ Sound_Object :: struct {
 	offset_fraction: f32,
 
 	loop: bool,
+
+	// Set using `set_sound_paused`. The mixer skips paused sounds.
+	paused: bool,
 
 	// The bus this is mixed into. The zero value is the master bus.
 	bus: Audio_Bus,

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1927,10 +1927,9 @@ set_sound_pitch :: proc(sound: Sound, pitch: f32) {
 
 // Make a sound loop when it reaches the end.
 //
-// Technical note: This works for sounds started using `play_audio_stream`. But it actually reaches
-// into the streaming decoder and tells that one to loop. The `Sound` that is used by the audio
-// stream is just a short buffer that is filled by the decoding stream, so that one always loops
-// when playing from a stream.
+// Technical note: This also works for sounds started using `play_audio_stream`, but then it
+// reaches into the streaming decoder and tells that one to loop. A stream-fed `Sound` plays a
+// short buffer that the decoder keeps filling, so that sound always loops.
 set_sound_loop :: proc(sound: Sound, loop: bool) {
 	sound_object := hm.get(&s.sounds, sound)
 

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1945,7 +1945,7 @@ load_audio_clip_from_file :: proc(filename: string) -> Audio_Clip {
 	data, data_ok := read_entire_file(filename, frame_allocator)
 
 	if !data_ok {
-		log.errorf("Failed to load audio buffer from file '%v'", filename)
+		log.errorf("Failed to load audio clip from file '%v'", filename)
 		return AUDIO_CLIP_NONE
 	}
 
@@ -2133,7 +2133,7 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> Audio_Clip {
 	return load_audio_clip_from_bytes_raw(samples, format, sample_rate, channels)
 }
 
-// Load an audio buffer from some raw audio data. You need to specify the data, format and sample
+// Load an audio clip from some raw audio data. You need to specify the data, format and sample
 // rate of the sound yourself. This assumes that there is no header in the data. If your data has a
 // header (you read the data from a file on disk), then please use `load_audio_clip_from_bytes`
 // instead.
@@ -2203,7 +2203,7 @@ load_audio_clip_from_bytes_raw :: proc(
 	audio_clip, audio_clip_add_error := hm.add(&s.audio_clips, audio_clip_object)
 
 	if audio_clip_add_error != nil {
-		log.errorf("Failed to load sound. Error: %v", audio_clip_add_error)
+		log.errorf("Failed to load audio clip. Error: %v", audio_clip_add_error)
 		return AUDIO_CLIP_NONE
 	}
 
@@ -2216,7 +2216,7 @@ destroy_audio_clip :: proc(clip: Audio_Clip)  {
 	audio_clip_object := hm.get(&s.audio_clips, clip)
 
 	if audio_clip_object == nil {
-		log.debug("Tried to destroy non-existing audio buffer")
+		log.debug("Tried to destroy non-existing audio clip")
 		return
 	}
 
@@ -2536,7 +2536,7 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 
 	if ab == nil {
 		hm.remove(&s.sounds, sd.sound)
-		log.error("Trying to update audio stream with destroyed buffer")
+		log.error("Trying to update audio stream with destroyed clip")
 		return
 	}
 
@@ -2652,7 +2652,7 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 					continue
 				} else {
 					// TODO: Stopping here is bad as the samples haven't been mixed in yet. Remove the
-					// stream but push the final samples into the audio buffer and destroy that one
+					// stream but push the final samples into the clip and destroy that one
 					// when it finishes playing (in the mixer).
 					hm.remove(&s.sounds, sd.sound)
 					reset_audio_stream(stream)
@@ -2739,7 +2739,7 @@ play_audio_stream :: proc(
 	sd.sound, add_err = hm.add(&s.sounds, sound_object)
 
 	if add_err != nil {
-		log.errorf("Failed playing the audio stream because the audio buffer could not be set up for playing. Error: %v", add_err)
+		log.errorf("Failed playing audio stream. Error: %v", add_err)
 		return SOUND_NONE
 	}
 
@@ -4989,7 +4989,7 @@ Sound_Object :: struct {
 Audio_Bus :: distinct Handle
 
 // All other buses are mixed into the master bus, as well as sounds that play directly on the master
-// bus. This is the default bus of all sounds, audio streams and playing audio buffers.
+// bus. This is the default bus of all sounds.
 //
 // You can use this with `set_audio_bus_volume`, `set_audio_bus_pan` and `set_audio_bus_effect`.
 // That's how you set the master volume of your game.

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -173,7 +173,7 @@ init :: proc(
 		log.assertf(audio_alloc_error == nil, "Failed allocating memory for audio backend: %v", audio_alloc_error)
 		ab.init(s.audio_backend_state, s.allocator)
 		hm.dynamic_init(&s.playing_audio_buffers, s.allocator)
-		hm.dynamic_init(&s.audio_buffers, s.allocator)
+		hm.dynamic_init(&s.audio_clips, s.allocator)
 		hm.dynamic_init(&s.sounds, s.allocator)
 		hm.dynamic_init(&s.audio_streams, s.allocator)
 		hm.dynamic_init(&s.audio_buses, s.allocator)
@@ -238,7 +238,7 @@ shutdown :: proc() {
 		ab.shutdown()
 		hm.dynamic_destroy(&s.playing_audio_buffers)
 		hm.dynamic_destroy(&s.sounds)
-		hm.dynamic_destroy(&s.audio_buffers)
+		hm.dynamic_destroy(&s.audio_clips)
 		hm.dynamic_destroy(&s.audio_buses)
 		free(s.audio_backend_state, s.allocator)
 	}
@@ -1811,7 +1811,7 @@ play_sound :: proc(sound: Sound) {
 	}
 
 	playing_audio_buffer := Playing_Audio_Buffer {
-		audio_buffer = sound_object.audio_buffer,
+		clip = sound_object.clip,
 		target_settings = sound_object.playback_settings,
 		current_settings = sound_object.playback_settings,
 		loop = sound_object.loop,
@@ -1827,7 +1827,7 @@ play_sound :: proc(sound: Sound) {
 }
 
 // Play an audio buffer, using the playback settings you pass in. The playback does not loop. Good
-// for playing one-off sound effects such as footsteps. You can play the same Audio_Buffer multiple
+// for playing one-off sound effects such as footsteps. You can play the same Audio_Clip multiple
 // times simultaneously, without one stopping the another.
 //
 // The difference between using this and a `Sound` is that the `Sound` remembers its playback
@@ -1835,15 +1835,15 @@ play_sound :: proc(sound: Sound) {
 //
 // Pass `bus` to play the sound on an audio bus. It plays on the master bus by default.
 play_audio_buffer :: proc(
-	ab: Audio_Buffer,
+	ab: Audio_Clip,
 	volume: f32 = 1,
 	pan: f32 = 0,
 	pitch: f32 = 1,
 	bus: Audio_Bus = AUDIO_BUS_MASTER,
 ) {
-	audio_buffer_object := hm.get(&s.audio_buffers, ab)
+	audio_clip_object := hm.get(&s.audio_clips, ab)
 
-	if audio_buffer_object == nil {
+	if audio_clip_object == nil {
 		log.error("Cannot play audio buffer, audio buffer does not exist.")
 		return
 	}
@@ -1860,7 +1860,7 @@ play_audio_buffer :: proc(
 	}
 
 	playing_audio_buffer := Playing_Audio_Buffer {
-		audio_buffer = ab,
+		clip = ab,
 		target_settings = playback_settings,
 		current_settings = playback_settings,
 		bus = bus,
@@ -2004,7 +2004,7 @@ set_sound_bus :: proc(sound: Sound, bus: Audio_Bus) {
 }
 
 // Load a WAV file from disk. Returns a `Sound` which can be used with `play_sound`. If you need to
-// play a sound multiple times simultaneously, then use `load_audio_buffer_from_file` followed by
+// play a sound multiple times simultaneously, then use `load_audio_clip_from_file` followed by
 // one or more calls to `create_sound_from_audio_buffer`.
 //
 // Sounds created using this procedure owns their internal audio buffer: Calling `destroy_sound`
@@ -2025,7 +2025,7 @@ load_sound_from_file :: proc(filename: string) -> Sound {
 
 // Load a sound some pre-loaded memory (for example using `#load("sound.wav")`). Returns a `Sound`
 // which can be used with `play_sound`. If you need to play a sound multiple times simultaneously,
-// then use `load_audio_buffer_from_bytes` followed by one or more calls to
+// then use `load_audio_clip_from_bytes` followed by one or more calls to
 // `create_sound_from_audio_buffer`.
 //
 // Sounds created using this procedure owns their internal audio buffer: Calling `destroy_sound`
@@ -2033,18 +2033,18 @@ load_sound_from_file :: proc(filename: string) -> Sound {
 //
 // Supports mono and stereo WAV data with 8, 16, 24 or 32 bit integer samples, or 32 or 64 bit
 // float samples. Note that the data should be the entire WAV file, including the header. If your
-// data does not include the header, then please use `load_audio_buffer_from_bytes_raw` combined
+// data does not include the header, then please use `load_audio_clip_from_bytes_raw` combined
 // with `create_sound_from_audio_buffer`.
 load_sound_from_bytes :: proc(bytes: []byte) -> Sound {
-	audio_buffer := load_audio_buffer_from_bytes(bytes)
+	audio_clip := load_audio_clip_from_bytes(bytes)
 
-	if audio_buffer == AUDIO_BUFFER_NONE {
+	if audio_clip == AUDIO_CLIP_NONE {
 		return SOUND_NONE
 	}
 
 	sound_object := Sound_Object {
 		playback_settings = DEFAULT_AUDIO_BUFFER_PLAYBACK_SETTINGS,
-		audio_buffer = audio_buffer,
+		clip = audio_clip,
 		owns_audio_buffer = true,
 	}
 
@@ -2062,23 +2062,23 @@ load_sound_from_bytes :: proc(bytes: []byte) -> Sound {
 // the audio data yourself. This assumes that there is no header in the data. If your data has a
 // header (you read the data from a file on disk), then please use `load_sound_from_bytes` instead.
 //
-// The returned Sound owns its internal Audio_Buffer: Calling `destroy_sound` with it will destroy
+// The returned Sound owns its internal Audio_Clip: Calling `destroy_sound` with it will destroy
 // the audio buffer.
 load_sound_from_bytes_raw :: proc(
 	bytes: []u8,
-	format: Raw_Sound_Format,
+	format: Raw_Audio_Format,
 	sample_rate: int,
 	channels: Audio_Channels,
 ) -> Sound {
-	audio_buffer := load_audio_buffer_from_bytes_raw(bytes, format, sample_rate, channels)
+	audio_clip := load_audio_clip_from_bytes_raw(bytes, format, sample_rate, channels)
 
-	if audio_buffer == AUDIO_BUFFER_NONE {
+	if audio_clip == AUDIO_CLIP_NONE {
 		return SOUND_NONE
 	}
 
 	sound_object := Sound_Object {
 		playback_settings = DEFAULT_AUDIO_BUFFER_PLAYBACK_SETTINGS,
-		audio_buffer = audio_buffer,
+		clip = audio_clip,
 		owns_audio_buffer = true,
 	}
 
@@ -2092,39 +2092,39 @@ load_sound_from_bytes_raw :: proc(
 	return sound
 }
 
-// Load a WAV file from disk. Returns an `Audio_Buffer` which can be used with
+// Load a WAV file from disk. Returns an `Audio_Clip` which can be used with
 // `create_sound_from_audio_buffer` in order to play the audio buffer multiple times simultaneously.
 //
 // Supports mono and stereo WAV files with 8, 16, 24 or 32 bit integer samples, or 32 or 64 bit
 // float samples.
-load_audio_buffer_from_file :: proc(filename: string) -> Audio_Buffer {
+load_audio_clip_from_file :: proc(filename: string) -> Audio_Clip {
 	data, data_ok := read_entire_file(filename, frame_allocator)
 
 	if !data_ok {
 		log.errorf("Failed to load audio buffer from file '%v'", filename)
-		return AUDIO_BUFFER_NONE
+		return AUDIO_CLIP_NONE
 	}
 
-	return load_audio_buffer_from_bytes(data)
+	return load_audio_clip_from_bytes(data)
 }
 
 // Load a WAV file from some pre-loaded memory (can be loaded using `#load("sound.wav")`). Returns
-// an `Audio_Buffer` which can be used with `create_sound_from_audio_buffer` in order to play the
+// an `Audio_Clip` which can be used with `create_sound_from_audio_buffer` in order to play the
 // audio buffer multiple times simultaneously.
 //
 // Supports mono and stereo WAV data with 8, 16, 24 or 32 bit integer samples, or 32 or 64 bit
 // float samples. Note that the data should be the entire WAV file, including the header. If your
-// data does not include the header, then please use `load_audio_buffer_from_bytes_raw`.
-load_audio_buffer_from_bytes :: proc(bytes: []u8) -> Audio_Buffer {
+// data does not include the header, then please use `load_audio_clip_from_bytes_raw`.
+load_audio_clip_from_bytes :: proc(bytes: []u8) -> Audio_Clip {
 	// A WAV file is a RIFF file: A 12 byte header followed by any number of chunks.
 	if len(bytes) < 12 {
 		log.error("Invalid wav file: Too small to contain a RIFF header")
-		return AUDIO_BUFFER_NONE
+		return AUDIO_CLIP_NONE
 	}
 
 	if string(bytes[:4]) != "RIFF" {
 		log.error("Invalid wav file: No RIFF identifier")
-		return AUDIO_BUFFER_NONE
+		return AUDIO_CLIP_NONE
 	}
 
 	// This size can only fail to read if there are less than four bytes left, which the check above
@@ -2133,7 +2133,7 @@ load_audio_buffer_from_bytes :: proc(bytes: []u8) -> Audio_Buffer {
 
 	if string(bytes[8:12]) != "WAVE" {
 		log.error("Invalid wav file: Not WAVE format")
-		return AUDIO_BUFFER_NONE
+		return AUDIO_CLIP_NONE
 	}
 
 	// `riff_size` counts everything after itself. Some programs write a size that doesn't match the
@@ -2149,7 +2149,7 @@ load_audio_buffer_from_bytes :: proc(bytes: []u8) -> Audio_Buffer {
 	sample_rate: int
 	samples: []u8
 	channels: Audio_Channels
-	format: Raw_Sound_Format
+	format: Raw_Audio_Format
 	has_fmt: bool
 	has_data: bool
 
@@ -2185,7 +2185,7 @@ load_audio_buffer_from_bytes :: proc(bytes: []u8) -> Audio_Buffer {
 			//	bits_per_sample: u16
 			if len(content) < 16 {
 				log.errorf("Invalid wav fmt chunk: Size is %v, expected at least 16", len(content))
-				return AUDIO_BUFFER_NONE
+				return AUDIO_CLIP_NONE
 			}
 
 			audio_format, _ := endian.get_u16(content[0:2], .Little)
@@ -2202,7 +2202,7 @@ load_audio_buffer_from_bytes :: proc(bytes: []u8) -> Audio_Buffer {
 				if len(content) < 26 {
 					log.errorf("Invalid wav fmt chunk: Size is %v, too small for an extensible " +
 						"sub format", len(content))
-					return AUDIO_BUFFER_NONE
+					return AUDIO_CLIP_NONE
 				}
 
 				audio_format, _ = endian.get_u16(content[24:26], .Little)
@@ -2210,7 +2210,7 @@ load_audio_buffer_from_bytes :: proc(bytes: []u8) -> Audio_Buffer {
 
 			if fmt_sample_rate == 0 {
 				log.error("Invalid wav fmt chunk: Sample rate is zero")
-				return AUDIO_BUFFER_NONE
+				return AUDIO_CLIP_NONE
 			}
 
 			switch num_channels {
@@ -2220,7 +2220,7 @@ load_audio_buffer_from_bytes :: proc(bytes: []u8) -> Audio_Buffer {
 				channels = .Stereo
 			case:
 				log.errorf("Unsupported number of channels in wav fmt chunk: %v", num_channels)
-				return AUDIO_BUFFER_NONE
+				return AUDIO_CLIP_NONE
 			}
 
 			switch audio_format {
@@ -2236,7 +2236,7 @@ load_audio_buffer_from_bytes :: proc(bytes: []u8) -> Audio_Buffer {
 					format = .Integer32
 				case:
 					log.errorf("Unsupported bits per sample in wav fmt chunk: %v", bits_per_sample)
-					return AUDIO_BUFFER_NONE
+					return AUDIO_CLIP_NONE
 				}
 
 			case WAV_FORMAT_FLOAT:
@@ -2250,12 +2250,12 @@ load_audio_buffer_from_bytes :: proc(bytes: []u8) -> Audio_Buffer {
 						"Unsupported bits per sample in float wav fmt chunk: %v",
 						bits_per_sample,
 					)
-					return AUDIO_BUFFER_NONE
+					return AUDIO_CLIP_NONE
 				}
 
 			case:
 				log.errorf("Unsupported format in wav fmt chunk: %v", audio_format)
-				return AUDIO_BUFFER_NONE
+				return AUDIO_CLIP_NONE
 			}
 
 			sample_rate = int(fmt_sample_rate)
@@ -2278,27 +2278,27 @@ load_audio_buffer_from_bytes :: proc(bytes: []u8) -> Audio_Buffer {
 
 	if !has_fmt {
 		log.error("Invalid wav file: No fmt chunk")
-		return AUDIO_BUFFER_NONE
+		return AUDIO_CLIP_NONE
 	}
 
 	if !has_data {
 		log.error("Invalid wav file: No data chunk")
-		return AUDIO_BUFFER_NONE
+		return AUDIO_CLIP_NONE
 	}
 
-	return load_audio_buffer_from_bytes_raw(samples, format, sample_rate, channels)
+	return load_audio_clip_from_bytes_raw(samples, format, sample_rate, channels)
 }
 
 // Load an audio buffer from some raw audio data. You need to specify the data, format and sample
 // rate of the sound yourself. This assumes that there is no header in the data. If your data has a
-// header (you read the data from a file on disk), then please use `load_audio_buffer_from_bytes`
+// header (you read the data from a file on disk), then please use `load_audio_clip_from_bytes`
 // instead.
-load_audio_buffer_from_bytes_raw :: proc(
+load_audio_clip_from_bytes_raw :: proc(
 	bytes: []u8,
-	format: Raw_Sound_Format,
+	format: Raw_Audio_Format,
 	sample_rate: int,
 	channels: Audio_Channels,
-) -> Audio_Buffer {
+) -> Audio_Clip {
 	samples: []Audio_Sample
 
 	switch format{
@@ -2350,41 +2350,41 @@ load_audio_buffer_from_bytes_raw :: proc(
 		}
 	}
 
-	buffer_object := Audio_Buffer_Object {
+	audio_clip_object := Audio_Clip_Object {
 		sample_rate = sample_rate,
 		samples = samples,
 		channels = channels,
 	}
 
-	buffer, buffer_add_error := hm.add(&s.audio_buffers, buffer_object)
+	audio_clip, audio_clip_add_error := hm.add(&s.audio_clips, audio_clip_object)
 
-	if buffer_add_error != nil {
-		log.errorf("Failed to load sound. Error: %v", buffer_add_error)
-		return AUDIO_BUFFER_NONE
+	if audio_clip_add_error != nil {
+		log.errorf("Failed to load sound. Error: %v", audio_clip_add_error)
+		return AUDIO_CLIP_NONE
 	}
 
-	return buffer
+	return audio_clip
 }
 
-// Creates a sound that can be used to play the contents of an `Audio_Buffer`. This can be used to
+// Creates a sound that can be used to play the contents of an `Audio_Clip`. This can be used to
 // load an audio buffer once and have multiple sounds playing the contents of it, simultaneously.
 // This makes all those sounds share the same audio data.
 //
 // Sounds created using this procedure do not own the buffer. This means that calling
 // `destroy_sound` on the Sound will only remove the Sound from Karl2D's internal state, but it
-// won't destroy the Audio_Buffer. Such auto-destroying of the `Audio_Buffer` only happen with
+// won't destroy the Audio_Clip. Such auto-destroying of the `Audio_Clip` only happen with
 // sounds created using `load_sound_from_file` and `load_sound_from_bytes`.
-create_sound_from_audio_buffer :: proc(buffer: Audio_Buffer) -> Sound {
-	buffer_object := hm.get(&s.audio_buffers, buffer)
+create_sound_from_audio_buffer :: proc(buffer: Audio_Clip) -> Sound {
+	audio_clip_object := hm.get(&s.audio_clips, buffer)
 
-	if buffer_object == nil {
+	if audio_clip_object == nil {
 		log.error("Trying to create sound from invalid audio buffer")
 		return SOUND_NONE
 	}
 
 	sound_object := Sound_Object {
 		playback_settings = DEFAULT_AUDIO_BUFFER_PLAYBACK_SETTINGS,
-		audio_buffer = buffer,
+		clip = buffer,
 		owns_audio_buffer = false,
 	}
 
@@ -2416,25 +2416,25 @@ destroy_sound :: proc(sound: Sound) {
 	}
 	
 	if sound_object.owns_audio_buffer {
-		destroy_audio_buffer(sound_object.audio_buffer)
+		destroy_audio_clip(sound_object.clip)
 	}
 
 	hm.remove(&s.sounds, sound)
 }
 
-// Destroy an audio buffer previously loaded using `load_audio_buffer_from_xxx`. Before destroying
+// Destroy an audio buffer previously loaded using `load_audio_clip_from_xxx`. Before destroying
 // this audio buffer, make sure it is not in use by any playing sounds. Destroy the sounds that
 // reference it using `destroy_sound` first.
-destroy_audio_buffer :: proc(audio_buffer: Audio_Buffer)  {
-	audio_buffer_object := hm.get(&s.audio_buffers, audio_buffer)
+destroy_audio_clip :: proc(clip: Audio_Clip)  {
+	audio_clip_object := hm.get(&s.audio_clips, clip)
 
-	if audio_buffer_object == nil {
+	if audio_clip_object == nil {
 		log.debug("Tried to destroy non-existing audio buffer")
 		return
 	}
 
-	delete(audio_buffer_object.samples, s.allocator)
-	hm.remove(&s.audio_buffers, audio_buffer)
+	delete(audio_clip_object.samples, s.allocator)
+	hm.remove(&s.audio_clips, clip)
 }
 
 // Load an audio stream from a file on disk. This is often used for playing music. An audio stream
@@ -2548,22 +2548,22 @@ load_audio_stream_from_file :: proc(filename: string) -> Audio_Stream {
 		return AUDIO_STREAM_NONE
 	}
 
-	buffer := Audio_Buffer_Object {
+	audio_clip := Audio_Clip_Object {
 		sample_rate = int(info.sample_rate),
 		samples = make([]Audio_Sample, AUDIO_STREAM_BUFFER_SIZE, s.allocator),
 		channels = channels,
 	}
 
-	buffer_handle, buffer_handle_add_err := hm.add(&s.audio_buffers, buffer)
+	audio_clip_handle, audio_clip_handle_add_err := hm.add(&s.audio_clips, audio_clip)
 
-	if buffer_handle_add_err != nil {
-		log.errorf("Failed to load audio stream. Error: %v", buffer_handle_add_err)
+	if audio_clip_handle_add_err != nil {
+		log.errorf("Failed to load audio stream. Error: %v", audio_clip_handle_add_err)
 		
 		if close_err := file_close(f); close_err != nil {
 			log.errorf("Failed closing file. Error: %v", close_err)
 		}
 
-		delete(buffer.samples, s.allocator)
+		delete(audio_clip.samples, s.allocator)
 		free(vorbis_buffer.alloc_buffer, s.allocator)
 		return AUDIO_STREAM_NONE
 	}
@@ -2573,7 +2573,7 @@ load_audio_stream_from_file :: proc(filename: string) -> Audio_Stream {
 		file = f,
 		vorbis = vorbis_res,
 		vorbis_buffer = vorbis_buffer,
-		buffer = buffer_handle,
+		clip = audio_clip_handle,
 		playback_settings = {
 			pan = 0,
 			volume = 1,
@@ -2588,8 +2588,8 @@ load_audio_stream_from_file :: proc(filename: string) -> Audio_Stream {
 		log.errorf("Failed to create audio stream from file. Error: %v", stream_add_err)
 		file_close(asd.file)
 		delete(asd.file_read_buf)
-		delete(buffer.samples, s.allocator)
-		hm.remove(&s.audio_buffers, buffer_handle)
+		delete(audio_clip.samples, s.allocator)
+		hm.remove(&s.audio_clips, audio_clip_handle)
 		free(vorbis_buffer.alloc_buffer, s.allocator)
 		return AUDIO_STREAM_NONE
 	}
@@ -2656,17 +2656,17 @@ load_audio_stream_from_bytes :: proc(bytes: []u8) -> Audio_Stream {
 		return AUDIO_STREAM_NONE
 	}
 
-	buffer := Audio_Buffer_Object {
+	audio_clip := Audio_Clip_Object {
 		sample_rate = int(info.sample_rate),
 		samples = make([]Audio_Sample, AUDIO_STREAM_BUFFER_SIZE, s.allocator),
 		channels = channels,
 	}
 
-	buffer_handle, buffer_handle_add_err := hm.add(&s.audio_buffers, buffer)
+	audio_clip_handle, audio_clip_handle_add_err := hm.add(&s.audio_clips, audio_clip)
 
-	if buffer_handle_add_err != nil {
-		log.errorf("Failed to load audio stream. Error: %v", buffer_handle_add_err)
-		delete(buffer.samples, s.allocator)
+	if audio_clip_handle_add_err != nil {
+		log.errorf("Failed to load audio stream. Error: %v", audio_clip_handle_add_err)
+		delete(audio_clip.samples, s.allocator)
 		free(vorbis_buffer.alloc_buffer, s.allocator)
 		return AUDIO_STREAM_NONE
 	}
@@ -2675,7 +2675,7 @@ load_audio_stream_from_bytes :: proc(bytes: []u8) -> Audio_Stream {
 		mode = .From_Bytes,
 		bytes = bytes,
 		vorbis = vorbis_res,
-		buffer = buffer_handle,
+		clip = audio_clip_handle,
 		vorbis_buffer = vorbis_buffer,
 		playback_settings = {
 			pan = 0,
@@ -2688,8 +2688,8 @@ load_audio_stream_from_bytes :: proc(bytes: []u8) -> Audio_Stream {
 
 	if stream_add_err != nil {
 		log.errorf("Failed to create audio stream from bytes. Error: %v", stream_add_err)
-		delete(buffer.samples, s.allocator)
-		hm.remove(&s.audio_buffers, buffer_handle)
+		delete(audio_clip.samples, s.allocator)
+		hm.remove(&s.audio_clips, audio_clip_handle)
 		free(vorbis_buffer.alloc_buffer, s.allocator)
 		return AUDIO_STREAM_NONE
 	}
@@ -2714,9 +2714,9 @@ destroy_audio_stream :: proc(stream: Audio_Stream) {
 		hm.remove(&s.playing_audio_buffers, sd.playing_buffer_handle)
 	}
 
-	if ab := hm.get(&s.audio_buffers, sd.buffer); ab != nil {
+	if ab := hm.get(&s.audio_clips, sd.clip); ab != nil {
 		delete(ab.samples, s.allocator)
-		hm.remove(&s.audio_buffers, sd.buffer)
+		hm.remove(&s.audio_clips, sd.clip)
 	}
 
 	switch sd.mode {
@@ -2749,7 +2749,7 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 		return
 	}
 
-	ab := hm.get(&s.audio_buffers, pab.audio_buffer)
+	ab := hm.get(&s.audio_clips, pab.clip)
 
 	if ab == nil {
 		hm.remove(&s.playing_audio_buffers, sd.playing_buffer_handle)
@@ -2757,7 +2757,7 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 		return
 	}
 
-	audio_stream_remaining :: proc(as: ^Audio_Stream_Data, pab: ^Playing_Audio_Buffer, ab: ^Audio_Buffer_Object) -> int {
+	audio_stream_remaining :: proc(as: ^Audio_Stream_Data, pab: ^Playing_Audio_Buffer, ab: ^Audio_Clip_Object) -> int {
 		remaining := as.buffer_write_pos - pab.offset 
 
 		if remaining < 0 {
@@ -2917,7 +2917,7 @@ play_audio_stream :: proc(stream: Audio_Stream) {
 	}
 
 	playing_audio_buffer := Playing_Audio_Buffer {
-		audio_buffer = sd.buffer,
+		clip = sd.clip,
 		target_settings = sd.playback_settings,
 		current_settings = sd.playback_settings,
 		bus = sd.bus,
@@ -3400,7 +3400,7 @@ update_audio_mixer :: proc() {
 	}
 
 	for ps_iter := hm.dynamic_iterator_make(&s.playing_audio_buffers); ps, ps_handle in hm.dynamic_iterate(&ps_iter) {
-		data := hm.get(&s.audio_buffers, ps.audio_buffer)
+		data := hm.get(&s.audio_clips, ps.clip)
 
 		if data == nil {
 			log.error("Trying to play sound with destroyed data")
@@ -5205,17 +5205,17 @@ Sound :: distinct Handle
 
 SOUND_NONE :: Sound {}
 
-// A sound instance is what `Sound` handles are mapped to. They contain a handle to a an audio
-// buffer, and the settings for use when playing that buffer. The audio buffer may be shared between
+// A sound instance is what `Sound` handles are mapped to. They contain a handle to an audio
+// clip, and the settings for use when playing that clip. The audio clip may be shared between
 // multiple sound instances, which allows you to play the same sound multiple times at the same time
 // without having to clone the data.
 Sound_Object :: struct {
 	handle: Sound,
 
-	// The audio buffer may be used by multiple sound instances. This is the key idea of sound
+	// The audio clip may be used by multiple sound instances. This is the key idea of sound
 	// instances: That you can use `create_sound_instance` to make it possible to play a sound
 	// multiple times at the same time, without having to clone the data.
-	audio_buffer: Audio_Buffer,
+	clip: Audio_Clip,
 
 	// If true, then the audio buffer will be destroyed when this sound is destroyed. This is true
 	// when the sound was loaded using the `load_sound_xxx` procedures. It's false when the sound
@@ -5264,9 +5264,9 @@ Audio_Stream_Data :: struct {
 	vorbis: ^stbv.vorbis,
 	vorbis_buffer: stbv.vorbis_alloc,
 	playing_buffer_handle: Playing_Audio_Buffer_Handle,
-	buffer: Audio_Buffer,
-	
-	// Where in the audio buffer referred to by `buffer_handle` that we have most recently written
+	clip: Audio_Clip,
+
+	// Where in the audio clip referred to by `buffer_handle` that we have most recently written
 	// samples. Together with the `offset` of the Playing_Audio_Buffer, this forms a circular
 	// buffer.
 	buffer_write_pos: int,
@@ -5295,7 +5295,7 @@ Audio_Stream_Data :: struct {
 }
 
 // The format used to describe that data passed to `load_sound_from_bytes_raw`.
-Raw_Sound_Format :: enum {
+Raw_Audio_Format :: enum {
 	Integer8, // unsigned, like in 8 bit WAV files. The other integer formats are signed.
 	Integer16,
 	Integer24, // three bytes per sample, little endian
@@ -5304,14 +5304,14 @@ Raw_Sound_Format :: enum {
 	Float64,
 }
 
-Audio_Buffer :: distinct Handle
+Audio_Clip :: distinct Handle
 
-AUDIO_BUFFER_NONE :: Audio_Buffer{}
+AUDIO_CLIP_NONE :: Audio_Clip{}
 
-Audio_Buffer_Object :: struct {
-	handle: Audio_Buffer,
+Audio_Clip_Object :: struct {
+	handle: Audio_Clip,
 
-	// All the samples of the audio buffer. In the case of stereo, the left and right samples are
+	// All the samples of the audio clip. In the case of stereo, the left and right samples are
 	// interleaved.
 	samples: []Audio_Sample,
 
@@ -5342,7 +5342,7 @@ Playing_Audio_Buffer_Handle :: distinct Handle
 
 Playing_Audio_Buffer :: struct {
 	handle: Playing_Audio_Buffer_Handle,
-	audio_buffer: Audio_Buffer,
+	clip: Audio_Clip,
 	target_settings: Audio_Buffer_Playback_Settings,
 	current_settings: Audio_Buffer_Playback_Settings,
 
@@ -5506,7 +5506,7 @@ State :: struct {
 	audio_backend: Audio_Backend_Interface,
 	audio_backend_state: rawptr,
 
-	audio_buffers: hm.Dynamic_Handle_Map(Audio_Buffer_Object, Audio_Buffer),
+	audio_clips: hm.Dynamic_Handle_Map(Audio_Clip_Object, Audio_Clip),
 	sounds: hm.Dynamic_Handle_Map(Sound_Object, Sound),
 
 	playing_audio_buffers: hm.Dynamic_Handle_Map(Playing_Audio_Buffer, Playing_Audio_Buffer_Handle),

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1855,7 +1855,7 @@ stop_sound :: proc(sound: Sound) {
 	hm.remove(&s.sounds, sound)
 
 	if stream != AUDIO_STREAM_NONE {
-		reset_audio_stream(stream)
+		_reset_audio_stream(stream)
 	}
 }
 
@@ -2613,7 +2613,7 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 							if seek_err != nil {
 								log.errorf("Failed seeking in audio stream file. Stopping it. Error: %v", seek_err)
 								hm.remove(&s.sounds, sd.sound)
-								reset_audio_stream(stream)
+								_reset_audio_stream(stream)
 								break
 							}
 
@@ -2621,7 +2621,7 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 							continue
 						} else {
 							hm.remove(&s.sounds, sd.sound)
-							reset_audio_stream(stream)
+							_reset_audio_stream(stream)
 							break
 						}
 					} else {
@@ -2685,7 +2685,7 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 					// stream but push the final samples into the clip and destroy that one
 					// when it finishes playing (in the mixer).
 					hm.remove(&s.sounds, sd.sound)
-					reset_audio_stream(stream)
+					_reset_audio_stream(stream)
 					break
 				}
 			}
@@ -2777,41 +2777,6 @@ play_audio_stream :: proc(
 	}
 
 	return sd.sound
-}
-
-// Moves the decode cursor to the start. Does not silence anything: combine with `stop_sound` to
-// fully stop. If the stream is playing, the music jumps back to the top and keeps playing.
-reset_audio_stream :: proc(stream: Audio_Stream) {
-	sd := hm.get(&s.audio_streams, stream)
-
-	if sd == nil {
-		log.error("Cannot reset audio stream, stream does not exist.")
-		return
-	}
-
-	sd.buffer_write_pos = 0
-
-	switch sd.mode {
-	case .From_File:
-		file_seek(sd.file, 0, .Start)
-		runtime.clear(&sd.file_read_buf)
-		sd.file_read_buf_offset = 0
-		stbv.flush_pushdata(sd.vorbis)
-
-	case .From_Bytes:
-		stbv.seek_start(sd.vorbis)
-	}
-
-	// Zero the staging buffer so a replay doesn't briefly play stale samples before
-	// `update_audio_stream` refills it.
-	if ab := hm.get(&s.audio_clips, sd.clip); ab != nil {
-		slice.zero(ab.samples)
-	}
-
-	if snd := hm.get(&s.sounds, sd.sound); snd != nil {
-		snd.offset = 0
-		snd.offset_fraction = 0
-	}
 }
 
 // Create an audio bus: A group of sounds that are mixed together before they reach the master bus.
@@ -5498,6 +5463,42 @@ count_text_lines :: proc "contextless" (text: string) -> int {
 
 assert_initialized :: proc(loc := #caller_location) {
 	assert(s != nil, "Call k2.init before using this Karl2D procedure", loc)
+}
+
+// Moves the decode cursor of a stream back to the start. Run when a stream-fed sound is stopped
+// and when a non-looping stream reaches the end of the file, so that playing it again starts from
+// the beginning.
+_reset_audio_stream :: proc(stream: Audio_Stream) {
+	sd := hm.get(&s.audio_streams, stream)
+
+	if sd == nil {
+		log.error("Cannot reset audio stream, stream does not exist.")
+		return
+	}
+
+	sd.buffer_write_pos = 0
+
+	switch sd.mode {
+	case .From_File:
+		file_seek(sd.file, 0, .Start)
+		runtime.clear(&sd.file_read_buf)
+		sd.file_read_buf_offset = 0
+		stbv.flush_pushdata(sd.vorbis)
+
+	case .From_Bytes:
+		stbv.seek_start(sd.vorbis)
+	}
+
+	// Zero the staging buffer so a replay doesn't briefly play stale samples before
+	// `update_audio_stream` refills it.
+	if ab := hm.get(&s.audio_clips, sd.clip); ab != nil {
+		slice.zero(ab.samples)
+	}
+
+	if snd := hm.get(&s.sounds, sd.sound); snd != nil {
+		snd.offset = 0
+		snd.offset_fraction = 0
+	}
 }
 
 // Run by the drawing procedures before they add any vertices. Draws the batch if `vertices_needed`

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1795,9 +1795,9 @@ set_texture_filter_ex :: proc(
 //-------//
 
 // Play an audio clip with the supplied initial settings. The return value is a `Sound`, which means
-// something that is currently playing in the audio mixer. Ignore the return value for
-// fire-and-forget playback. You can use the returned `Sound` with `set_sound_volume`, `stop_sound`
-// etc in order to control the playback.
+// something that is currently playing in the audio mixer. You can use the returned `Sound` with
+// `set_sound_volume`, `stop_sound` etc in order to control the playback. Ignore the return value
+// if you just want to start the sound and never touch it again.
 //
 // Audio clips are loaded using `load_audio_clip_from_file`, `load_audio_clip_from_bytes` and
 // `load_audio_clip_from_bytes_raw`.
@@ -1914,7 +1914,8 @@ set_sound_pan :: proc(sound: Sound, pan: f32) {
 	sound_object.target_settings.pan = clamp(pan, -1, 1)
 }
 
-// Set the pitch of a sound. Range: 0.01 and up.
+// Set the pitch of a sound. Range: 0.01 and up, where 1 is the default. Pitch 2 makes the sound
+// play twice as fast, which also makes it sound higher pitched.
 set_sound_pitch :: proc(sound: Sound, pitch: f32) {
 	sound_object := hm.get(&s.sounds, sound)
 
@@ -1928,8 +1929,8 @@ set_sound_pitch :: proc(sound: Sound, pitch: f32) {
 // Make a sound loop when it reaches the end.
 //
 // Technical note: This also works for sounds started using `play_audio_stream`, but then it
-// reaches into the streaming decoder and tells that one to loop. A stream-fed `Sound` plays a
-// short buffer that the decoder keeps filling, so that sound always loops.
+// reaches into the streaming decoder and tells that one to loop. A `Sound` started from a stream
+// plays a short buffer that the decoder keeps filling, so that sound always loops.
 set_sound_loop :: proc(sound: Sound, loop: bool) {
 	sound_object := hm.get(&s.sounds, sound)
 
@@ -1966,8 +1967,8 @@ set_sound_bus :: proc(sound: Sound, bus: Audio_Bus) {
 	sound_object.bus = bus
 }
 
-// How many sounds currently play this clip. Useful for limiting how many copies of an effect pile
-// up.
+// How many sounds currently play this clip. Useful for limiting how many overlapping sounds you
+// start from the same clip.
 get_num_sounds_playing_clip :: proc(clip: Audio_Clip) -> int {
 	count: int
 
@@ -2443,7 +2444,7 @@ load_audio_stream_from_file :: proc(filename: string) -> Audio_Stream {
 // `.wasm` file.
 //
 // Another use case is if you're making a desktop game and you want to embed all the assets in the
-// executable (so the game is a single file). In that case you'd could also use `#load` to fetch the
+// executable (so the game is a single file). In that case you could also use `#load` to fetch the
 // file and then send it into this procedure.
 //
 // Note that this procedure wants the encoded file, for example an ogg file just like it was on
@@ -2728,8 +2729,10 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 }
 
 // Start playing an audio stream. Returns a `Sound`, which you can control using
-// `set_sound_volume`, `stop_sound` etc. Starts from wherever the decode cursor currently is and
-// never rewinds. A stream feeds at most one sound: playing again replaces the previous one.
+// `set_sound_volume`, `stop_sound` etc. The playback continues from wherever the stream last was:
+// It starts over from the beginning only if the stream was just loaded, was stopped using
+// `stop_sound` or has finished playing. A stream can only play one sound at a time: Playing again
+// replaces the previous one.
 //
 // Don't forget to call `update_audio_stream` every frame in order to stream in new data.
 play_audio_stream :: proc(
@@ -2858,9 +2861,10 @@ set_audio_bus_volume :: proc(bus: Audio_Bus, volume: f32) {
 // Set the pan of an audio bus. Range: -1 to 1, where -1 is full left, 0 is center and 1 is full
 // right.
 //
-// This is a balance control: It turns the opposite side down. That's different from the pan of a
-// sound, which uses a constant-power curve to place a source in the stereo field. A bus is already
-// a finished stereo mix, and a bus at pan 0 has to leave it exactly as it is.
+// This is a balance control: It turns the opposite side down. The pan of a sound works
+// differently: It moves the sound between the left and right speakers while keeping the overall
+// loudness the same. A bus is already a finished stereo mix, and a bus at pan 0 has to leave it
+// exactly as it is.
 set_audio_bus_pan :: proc(bus: Audio_Bus, pan: f32) {
 	bus_object := bus == AUDIO_BUS_MASTER ? &s.master_bus : hm.get(&s.audio_buses, bus)
 
@@ -4880,12 +4884,17 @@ AUDIO_MIX_CHUNK_SIZE :: 1400
 // sample in an array of samples will be interpreted as left and right respectively.
 Audio_Sample :: f32
 
-// One playing instance in the mixer. Spawned by `play_audio_clip` or `play_audio_stream`.
-// Auto-destroys when it finishes playing. Operations on a finished sound are silent no-ops.
+// Represents something that is currently playing in the audio mixer. Created using
+// `play_audio_clip` and `play_audio_stream`. A sound is automatically destroyed when it finishes
+// playing. It is safe to keep using the handle after that: The procedures that take a `Sound` will
+// then just do nothing.
 Sound :: distinct Handle
 
 SOUND_NONE :: Sound {}
 
+// Plays an ogg file by decoding it a little bit at a time, instead of loading all of the audio
+// data up front like an `Audio_Clip` does. Good for music, which would otherwise use a lot of
+// memory. Start it using `play_audio_stream`.
 Audio_Stream :: distinct Handle
 
 AUDIO_STREAM_NONE :: Audio_Stream {}
@@ -4913,9 +4922,8 @@ Audio_Stream_Data :: struct {
 	sound: Sound,
 	clip: Audio_Clip,
 
-	// Where in the audio clip referred to by `buffer_handle` that we have most recently written
-	// samples. Together with the `offset` of the Sound_Object, this forms a circular
-	// buffer.
+	// Where in the audio clip referred to by `clip` that we have most recently written samples.
+	// Together with the `offset` of the Sound_Object, this forms a circular buffer.
 	buffer_write_pos: int,
 
 	// Different from `loop` in `Sound_Object`. This says if the whole stream should loop
@@ -4945,6 +4953,8 @@ Raw_Audio_Format :: enum {
 	Float64,
 }
 
+// A piece of audio that has been completely loaded into memory. Play it using `play_audio_clip`.
+// Several sounds can play the same clip at the same time.
 Audio_Clip :: distinct Handle
 
 AUDIO_CLIP_NONE :: Audio_Clip{}
@@ -4971,8 +4981,8 @@ Sound_Settings :: struct {
 	pitch: f32,
 }
 
-// A sound instance is what `Sound` handles are mapped to. It is a voice currently playing in the
-// mixer, holding the clip (or stream) it plays and the settings it plays with.
+// What `Sound` handles are mapped to: something that is currently playing in the mixer. It holds
+// the clip it plays and the settings it plays with.
 Sound_Object :: struct {
 	handle: Sound,
 	clip: Audio_Clip,
@@ -4995,7 +5005,7 @@ Sound_Object :: struct {
 	// The bus this is mixed into. The zero value is the master bus.
 	bus: Audio_Bus,
 
-	// Set when a stream feeds this sound. Zero for sounds played from a clip. Used by
+	// Set when this sound plays an audio stream. Zero for sounds played from a clip. Used by
 	// `set_sound_loop` to redirect to the stream's own loop flag.
 	stream: Audio_Stream,
 }

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -2367,11 +2367,6 @@ load_audio_stream_from_file :: proc(filename: string) -> Audio_Stream {
 		vorbis = vorbis_res,
 		vorbis_buffer = vorbis_buffer,
 		clip = audio_clip_handle,
-		playback_settings = {
-			pan = 0,
-			volume = 1,
-			pitch = 1,
-		},
 		file_read_buf = make([dynamic]u8, s.allocator),
 	}
 
@@ -2470,11 +2465,6 @@ load_audio_stream_from_bytes :: proc(bytes: []u8) -> Audio_Stream {
 		vorbis = vorbis_res,
 		clip = audio_clip_handle,
 		vorbis_buffer = vorbis_buffer,
-		playback_settings = {
-			pan = 0,
-			volume = 1,
-			pitch = 1,
-		},
 	}
 
 	stream, stream_add_err := hm.add(&s.audio_streams, asd)
@@ -2503,8 +2493,8 @@ destroy_audio_stream :: proc(stream: Audio_Stream) {
 		return
 	}
 
-	if playing := hm.get(&s.sounds, sd.playing_buffer_handle); playing != nil {
-		hm.remove(&s.sounds, sd.playing_buffer_handle)
+	if playing := hm.get(&s.sounds, sd.sound); playing != nil {
+		hm.remove(&s.sounds, sd.sound)
 	}
 
 	if ab := hm.get(&s.audio_clips, sd.clip); ab != nil {
@@ -2534,7 +2524,7 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 		return
 	}
 
-	pab := hm.get(&s.sounds, sd.playing_buffer_handle)
+	pab := hm.get(&s.sounds, sd.sound)
 
 	if pab == nil {
 		// Don't log an error here: Not playing the stream is a valid state. It just doesn't need
@@ -2545,7 +2535,7 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 	ab := hm.get(&s.audio_clips, pab.clip)
 
 	if ab == nil {
-		hm.remove(&s.sounds, sd.playing_buffer_handle)
+		hm.remove(&s.sounds, sd.sound)
 		log.error("Trying to update audio stream with destroyed buffer")
 		return
 	}
@@ -2592,18 +2582,20 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 
 							if seek_err != nil {
 								log.errorf("Failed seeking in audio stream file. Stopping it. Error: %v", seek_err)
-								stop_audio_stream(stream)
+								hm.remove(&s.sounds, sd.sound)
+								reset_audio_stream(stream)
 								break
 							}
 
 							stbv.flush_pushdata(sd.vorbis)
 							continue
 						} else {
-							stop_audio_stream(stream)
+							hm.remove(&s.sounds, sd.sound)
+							reset_audio_stream(stream)
 							break
 						}
 					} else {
-						hm.remove(&s.sounds, sd.playing_buffer_handle)
+						hm.remove(&s.sounds, sd.sound)
 						log.errorf("Failed reading from audio stream file. Error: %v", read_err)
 						break
 					}
@@ -2628,13 +2620,13 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 						sd.buffer_write_pos = (sd.buffer_write_pos + 2) % len(ab.samples)
 					}
 				} else {
-					hm.remove(&s.sounds, sd.playing_buffer_handle)
+					hm.remove(&s.sounds, sd.sound)
 					log.error("Invalid num channels")
 					break
 				}
 				sd.file_read_buf_offset += int(bytes_used)
 			} else {
-				hm.remove(&s.sounds, sd.playing_buffer_handle)
+				hm.remove(&s.sounds, sd.sound)
 				log.error("Invalid vorbis")
 				break
 			}
@@ -2662,7 +2654,8 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 					// TODO: Stopping here is bad as the samples haven't been mixed in yet. Remove the
 					// stream but push the final samples into the audio buffer and destroy that one
 					// when it finishes playing (in the mixer).
-					stop_audio_stream(stream)
+					hm.remove(&s.sounds, sd.sound)
+					reset_audio_stream(stream)
 					break
 				}
 			}
@@ -2684,7 +2677,7 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 					sd.buffer_write_pos = (sd.buffer_write_pos + 2) % len(ab.samples)
 				}
 			} else {
-				hm.remove(&s.sounds, sd.playing_buffer_handle)
+				hm.remove(&s.sounds, sd.sound)
 				log.error("Invalid num channels")
 				break
 			}
@@ -2692,28 +2685,49 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 	}
 }
 
-// Start playing an audio stream. Don't forget to call `update_audio_stream` every frame in order to
-// stream in new data.
+// Returns a `Sound`, controllable like any other. Starts from wherever the decode cursor
+// currently is and never rewinds. A stream feeds at most one sound: playing again replaces the
+// previous one.
 //
-// Running this this while the stream is already playing will restart it from the beginning. Use
-// `pause_audio_stream` if you just want to pause it.
-play_audio_stream :: proc(stream: Audio_Stream) {
+// Don't forget to call `update_audio_stream` every frame in order to stream in new data.
+play_audio_stream :: proc(
+	stream: Audio_Stream,
+	volume: f32 = 1,
+	pan: f32 = 0,
+	pitch: f32 = 1,
+	loop := false,
+	bus: Audio_Bus = AUDIO_BUS_MASTER,
+) -> Sound {
 	sd := hm.get(&s.audio_streams, stream)
 
 	if sd == nil {
 		log.error("Cannot play audio stream, stream does not exist.")
-		return
+		return SOUND_NONE
 	}
 
-	if existing := hm.get(&s.sounds, sd.playing_buffer_handle); existing != nil {
-		stop_audio_stream(stream)
+	if bus != AUDIO_BUS_MASTER && hm.get(&s.audio_buses, bus) == nil {
+		log.error("Cannot play audio stream, audio bus does not exist.")
+		return SOUND_NONE
 	}
 
-	playing_audio_buffer := Sound_Object {
+	if existing := hm.get(&s.sounds, sd.sound); existing != nil {
+		hm.remove(&s.sounds, sd.sound)
+	}
+
+	sd.loop = loop
+
+	playback_settings := Sound_Settings {
+		volume = clamp(volume, 0, 1),
+		pan = clamp(pan, -1, 1),
+		pitch = max(pitch, 0.01),
+	}
+
+	sound_object := Sound_Object {
 		clip = sd.clip,
-		target_settings = sd.playback_settings,
-		current_settings = sd.playback_settings,
-		bus = sd.bus,
+		target_settings = playback_settings,
+		current_settings = playback_settings,
+		bus = bus,
+		stream = stream,
 
 		// This means that we are looping the buffer itself. We will use this buffer as a circular
 		// buffer, filling it with samples as we stream in more. Thus it needs to be looped to not
@@ -2722,44 +2736,26 @@ play_audio_stream :: proc(stream: Audio_Stream) {
 	}
 
 	add_err: runtime.Allocator_Error
-	sd.playing_buffer_handle, add_err = hm.add(&s.sounds, playing_audio_buffer)
+	sd.sound, add_err = hm.add(&s.sounds, sound_object)
 
 	if add_err != nil {
 		log.errorf("Failed playing the audio stream because the audio buffer could not be set up for playing. Error: %v", add_err)
+		return SOUND_NONE
 	}
+
+	return sd.sound
 }
 
-// Pause an audio stream. Run `play_audio_stream` to unpause it.
-pause_audio_stream :: proc(stream: Audio_Stream) {
+// Moves the decode cursor to the start. Does not silence anything: combine with `stop_sound` to
+// fully stop. If the stream is playing, the music jumps back to the top and keeps playing.
+reset_audio_stream :: proc(stream: Audio_Stream) {
 	sd := hm.get(&s.audio_streams, stream)
 
 	if sd == nil {
-		log.error("Cannot pause audio stream, stream does not exist.")
+		log.error("Cannot reset audio stream, stream does not exist.")
 		return
 	}
 
-	if existing := hm.get(&s.sounds, sd.playing_buffer_handle); existing != nil {
-		hm.remove(&s.sounds, sd.playing_buffer_handle)
-	}
-
-	sd.playing_buffer_handle = SOUND_NONE
-}
-
-// Stop an audio stream. If `play_audio_stream` is called again, the stream will start over from the
-// beginning.
-stop_audio_stream :: proc(stream: Audio_Stream) {
-	sd := hm.get(&s.audio_streams, stream)
-
-	if sd == nil {
-		log.error("Cannot stop audio stream, stream does not exist.")
-		return
-	}
-
-	if existing := hm.get(&s.sounds, sd.playing_buffer_handle); existing != nil {
-		hm.remove(&s.sounds, sd.playing_buffer_handle)
-	}
-
-	sd.playing_buffer_handle = SOUND_NONE
 	sd.buffer_write_pos = 0
 
 	switch sd.mode {
@@ -2772,132 +2768,22 @@ stop_audio_stream :: proc(stream: Audio_Stream) {
 	case .From_Bytes:
 		stbv.seek_start(sd.vorbis)
 	}
-}
 
-// Returns true if the audio stream is currently playing. Note that a looping audio stream will
-// always return true.
-is_audio_stream_playing :: proc(stream: Audio_Stream) -> bool {
-	sd := hm.get(&s.audio_streams, stream)
-
-	if sd == nil {
-		return false
+	// Zero the staging buffer so a replay doesn't briefly play stale samples before
+	// `update_audio_stream` refills it.
+	if ab := hm.get(&s.audio_clips, sd.clip); ab != nil {
+		slice.zero(ab.samples)
 	}
 
-	return hm.is_valid(&s.sounds, sd.playing_buffer_handle)
-}
-
-// Set the volume of the audio stream. Range: 0 to 1.
-//
-// You can use this both with a playing and non-playing stream. If its already playing, then this
-// will affect the playing stream.
-set_audio_stream_volume :: proc(stream: Audio_Stream, volume: f32) {
-	sd := hm.get(&s.audio_streams, stream)
-	
-	if sd == nil {
-		log.error("Cannot set audio stream volume, stream does not exist.")
-		return
+	if snd := hm.get(&s.sounds, sd.sound); snd != nil {
+		snd.offset = 0
+		snd.offset_fraction = 0
 	}
-
-	clamped_volume := clamp(volume, 0, 1)
-
-	if playing := hm.get(&s.sounds, sd.playing_buffer_handle); playing != nil {
-		playing.target_settings.volume = clamped_volume
-	}
-	
-	sd.playback_settings.volume = clamped_volume
-}
-
-// Set the pan (balance between left and right) of the audio stream. Range: -1 to 1, where -1 is
-// full left, 0 is center and 1 is full right.
-//
-// You can use this both with a playing and non-playing stream. If its already playing, then this
-// will affect the playing stream.
-set_audio_stream_pan :: proc(stream: Audio_Stream, pan: f32) {
-	sd := hm.get(&s.audio_streams, stream)
-	
-	if sd == nil {
-		log.error("Cannot set audio stream pan, stream does not exist.")
-		return
-	}
-
-	clamped_pan := clamp(pan, -1, 1)
-
-	if playing := hm.get(&s.sounds, sd.playing_buffer_handle); playing != nil {
-		playing.target_settings.pan = clamped_pan
-	}
-
-	sd.playback_settings.pan = clamped_pan
-}
-
-// Set the pitch of the audio stream. Range: 0.01 to infinity. A higher value will make the audio
-// play faster.
-//
-// You can use this both with a playing and non-playing stream. If its already playing, then this
-// will affect the playing stream.
-set_audio_stream_pitch :: proc(stream: Audio_Stream, pitch: f32) {
-	sd := hm.get(&s.audio_streams, stream)
-	
-	if sd == nil {
-		log.error("Cannot set audio stream pitch, stream does not exist.")
-		return
-	}
-
-	capped_pitch := max(pitch, 0.01)
-
-	if playing := hm.get(&s.sounds, sd.playing_buffer_handle); playing != nil {
-		playing.target_settings.pitch = capped_pitch
-	}
-	
-	sd.playback_settings.pitch = capped_pitch
-}
-
-// Set the audio stream to loop when it reaches the end of the stream. You can set this before
-// playing the stream. You can also modify the loop state of an already playing stream.
-set_audio_stream_loop :: proc(stream: Audio_Stream, loop: bool) {
-	sd := hm.get(&s.audio_streams, stream)
-	
-	if sd == nil {
-		log.errorf("Cannot set audio stream loop = %v, stream does not exist.", loop)
-		return
-	}
-
-	// Note a difference from `set_sound_loop`: We don't set the looping state of the playing audio
-	// buffer. That one should always loop for an audio stream. The stream is continuously writing
-	// data into a small looping buffer. We just set the stream itself to not loop, so it will stop
-	// feeding in data when it reaches the end.
-	
-	sd.loop = loop
-}
-
-// Route an audio stream into an audio bus. The stream is then mixed into that bus instead of
-// straight into the master bus. Handy for putting your music on its own bus, so the player can
-// turn the music down without turning the sound effects down.
-//
-// You can use this both with a playing and non-playing stream. If it's already playing, then this
-// will affect the playing stream. Pass `AUDIO_BUS_MASTER` to put it back on the master bus.
-set_audio_stream_bus :: proc(stream: Audio_Stream, bus: Audio_Bus) {
-	sd := hm.get(&s.audio_streams, stream)
-
-	if sd == nil {
-		log.error("Cannot set audio stream bus, stream does not exist.")
-		return
-	}
-
-	if bus != AUDIO_BUS_MASTER && hm.get(&s.audio_buses, bus) == nil {
-		log.error("Cannot set audio stream bus, audio bus does not exist.")
-		return
-	}
-
-	if playing := hm.get(&s.sounds, sd.playing_buffer_handle); playing != nil {
-		playing.bus = bus
-	}
-
-	sd.bus = bus
 }
 
 // Create an audio bus: A group of sounds that are mixed together before they reach the master bus.
-// Route sounds into it using `set_sound_bus`, `set_audio_stream_bus`, or the `bus` parameter of
-// `play_audio_clip`.
+// Route sounds into it using `set_sound_bus`, or the `bus` parameter of `play_audio_clip` or
+// `play_audio_stream`.
 //
 // A new bus has volume 1, pan 0 and no effect. That makes it a passthrough: Playing a sound on a
 // fresh bus sounds exactly like playing it on the master bus, until you change something.
@@ -2939,12 +2825,6 @@ destroy_audio_bus :: proc(bus: Audio_Bus) {
 	for it := hm.dynamic_iterator_make(&s.sounds); sound_object, _ in hm.dynamic_iterate(&it) {
 		if sound_object.bus == bus {
 			sound_object.bus = AUDIO_BUS_MASTER
-		}
-	}
-
-	for it := hm.dynamic_iterator_make(&s.audio_streams); sd, _ in hm.dynamic_iterate(&it) {
-		if sd.bus == bus {
-			sd.bus = AUDIO_BUS_MASTER
 		}
 	}
 
@@ -5015,19 +4895,13 @@ Audio_Stream_Data :: struct {
 	
 	vorbis: ^stbv.vorbis,
 	vorbis_buffer: stbv.vorbis_alloc,
-	playing_buffer_handle: Sound,
+	sound: Sound,
 	clip: Audio_Clip,
 
 	// Where in the audio clip referred to by `buffer_handle` that we have most recently written
 	// samples. Together with the `offset` of the Sound_Object, this forms a circular
 	// buffer.
 	buffer_write_pos: int,
-
-	playback_settings: Sound_Settings,
-
-	// The bus the stream is mixed into when it plays. The zero value is the master bus. Set using
-	// `set_audio_stream_bus`.
-	bus: Audio_Bus,
 
 	// Different from `loop` in `Sound_Object`. This says if the whole stream should loop
 	// when it reaches end-of-file. The `loop` in `Sound_Object` just says to loop the
@@ -5110,8 +4984,8 @@ Sound_Object :: struct {
 
 // A bus is a group of sounds that are mixed together before they reach the master bus. You can set
 // the volume and the pan of the whole group, and you can run an effect on it. Create one using
-// `create_audio_bus` and route sounds into it using `set_sound_bus`, `set_audio_stream_bus` or the
-// `bus` parameter of `play_audio_clip`.
+// `create_audio_bus` and route sounds into it using `set_sound_bus`, or the `bus` parameter of
+// `play_audio_clip` or `play_audio_stream`.
 Audio_Bus :: distinct Handle
 
 // All other buses are mixed into the master bus, as well as sounds that play directly on the master

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -172,9 +172,8 @@ init :: proc(
 		s.audio_backend_state, audio_alloc_error = mem.alloc(ab.state_size(), allocator = s.allocator)
 		log.assertf(audio_alloc_error == nil, "Failed allocating memory for audio backend: %v", audio_alloc_error)
 		ab.init(s.audio_backend_state, s.allocator)
-		hm.dynamic_init(&s.playing_audio_buffers, s.allocator)
-		hm.dynamic_init(&s.audio_clips, s.allocator)
 		hm.dynamic_init(&s.sounds, s.allocator)
+		hm.dynamic_init(&s.audio_clips, s.allocator)
 		hm.dynamic_init(&s.audio_streams, s.allocator)
 		hm.dynamic_init(&s.audio_buses, s.allocator)
 		s.master_bus.target_settings = DEFAULT_AUDIO_BUS_SETTINGS
@@ -236,7 +235,6 @@ shutdown :: proc() {
 	{
 		hm.dynamic_destroy(&s.audio_streams)
 		ab.shutdown()
-		hm.dynamic_destroy(&s.playing_audio_buffers)
 		hm.dynamic_destroy(&s.sounds)
 		hm.dynamic_destroy(&s.audio_clips)
 		hm.dynamic_destroy(&s.audio_buses)
@@ -1796,198 +1794,124 @@ set_texture_filter_ex :: proc(
 // AUDIO //
 //-------//
 
-// Play a sound previous created using `load_sound_from_xxx` or `create_sound_from_audio_buffer`.
-// The sound will be mixed when `update_audio_mixer` runs, which happens as part of `update`.
-play_sound :: proc(sound: Sound) {
-	sound_object := hm.get(&s.sounds, sound)
-
-	if sound_object == nil {
-		log.error("Cannot play sound, sound does not exist.")
-		return
-	}
-
-	if existing := hm.get(&s.playing_audio_buffers, sound_object.playing_buffer_handle); existing != nil {
-		hm.remove(&s.playing_audio_buffers, sound_object.playing_buffer_handle)
-	}
-
-	playing_audio_buffer := Playing_Audio_Buffer {
-		clip = sound_object.clip,
-		target_settings = sound_object.playback_settings,
-		current_settings = sound_object.playback_settings,
-		loop = sound_object.loop,
-		bus = sound_object.bus,
-	}
-
-	add_err: runtime.Allocator_Error
-	sound_object.playing_buffer_handle, add_err = hm.add(&s.playing_audio_buffers, playing_audio_buffer)
-
-	if add_err != nil {
-		log.errorf("Failed to play sound. Error: %v", add_err)
-	}
-}
-
-// Play an audio buffer, using the playback settings you pass in. The playback does not loop. Good
-// for playing one-off sound effects such as footsteps. You can play the same Audio_Clip multiple
-// times simultaneously, without one stopping the another.
-//
-// The difference between using this and a `Sound` is that the `Sound` remembers its playback
-// settings, can be stopped and looped.
+// Play an audio clip. Always starts a new sound, never restarts. Discard the returned handle for
+// fire-and-forget playback. Parameters are the starting settings.
 //
 // Pass `bus` to play the sound on an audio bus. It plays on the master bus by default.
-play_audio_buffer :: proc(
-	ab: Audio_Clip,
+play_audio_clip :: proc(
+	clip: Audio_Clip,
 	volume: f32 = 1,
 	pan: f32 = 0,
 	pitch: f32 = 1,
+	loop := false,
 	bus: Audio_Bus = AUDIO_BUS_MASTER,
-) {
-	audio_clip_object := hm.get(&s.audio_clips, ab)
+) -> Sound {
+	audio_clip_object := hm.get(&s.audio_clips, clip)
 
 	if audio_clip_object == nil {
-		log.error("Cannot play audio buffer, audio buffer does not exist.")
-		return
+		log.error("Cannot play audio clip, audio clip does not exist.")
+		return SOUND_NONE
 	}
 
 	if bus != AUDIO_BUS_MASTER && hm.get(&s.audio_buses, bus) == nil {
-		log.error("Cannot play audio buffer, audio bus does not exist.")
-		return
+		log.error("Cannot play audio clip, audio bus does not exist.")
+		return SOUND_NONE
 	}
 
-	playback_settings := Audio_Buffer_Playback_Settings {
+	playback_settings := Sound_Settings {
 		volume = clamp(volume, 0, 1),
 		pan = clamp(pan, -1, 1),
 		pitch = max(pitch, 0.01),
 	}
 
-	playing_audio_buffer := Playing_Audio_Buffer {
-		clip = ab,
+	sound_object := Sound_Object {
+		clip = clip,
 		target_settings = playback_settings,
 		current_settings = playback_settings,
+		loop = loop,
 		bus = bus,
 	}
 
-	// The playing audio buffer will be removed when mixer is finished playing it.
-	_, add_err := hm.add(&s.playing_audio_buffers, playing_audio_buffer)
+	sound, add_err := hm.add(&s.sounds, sound_object)
 
 	if add_err != nil {
-		log.errorf("Failed playing audio buffer. Error: %v", add_err)
+		log.errorf("Failed playing audio clip. Error: %v", add_err)
+		return SOUND_NONE
 	}
+
+	return sound
 }
 
-// Stop a sound. Rewinds it to the start.
+// Stops and destroys the sound. For a stream-fed sound this is a pause: the stream cursor stays
+// put.
 stop_sound :: proc(sound: Sound) {
-	sound_object := hm.get(&s.sounds, sound)
-
-	if sound_object == nil {
-		log.error("Cannot stop sound, sound does not exist.")
-		return
-	}
-
-	if existing := hm.get(&s.playing_audio_buffers, sound_object.playing_buffer_handle); existing != nil {
-		hm.remove(&s.playing_audio_buffers, sound_object.playing_buffer_handle)
-	}
-
-	sound_object.playing_buffer_handle = PLAYING_AUDIO_BUFFER_NONE
+	hm.remove(&s.sounds, sound)
 }
 
 // Returns true if the sound is currently playing.
 sound_is_playing :: proc(sound: Sound) -> bool {
-	sound_object := hm.get(&s.sounds, sound)
-
-	if sound_object == nil {
-		return false
-	}
-
-	return hm.is_valid(&s.playing_audio_buffers, sound_object.playing_buffer_handle)
+	return hm.is_valid(&s.sounds, sound)
 }
 
-// Set the volume of a sound. Range: 0 to 1, where 0 is silence and 1 is the original volume of the
-// sound. The volume change will only affect this instance of the sound. Use `create_sound_instance`
-// to create more instances without duplicating data.
+// Set the volume of a sound. Range: 0 to 1.
 set_sound_volume :: proc(sound: Sound, volume: f32) {
 	sound_object := hm.get(&s.sounds, sound)
-	
+
 	if sound_object == nil {
-		log.error("Cannot set volume, sound does not exist.")
 		return
 	}
 
-	clamped_volume := clamp(volume, 0, 1)
-
-	if playing := hm.get(&s.playing_audio_buffers, sound_object.playing_buffer_handle); playing != nil {
-		playing.target_settings.volume = clamped_volume
-	}
-	
-	sound_object.playback_settings.volume = clamped_volume
+	sound_object.target_settings.volume = clamp(volume, 0, 1)
 }
 
 // Set the pan of a sound. Range: -1 to 1, where -1 is full left, 0 is center and 1 is full right.
-// The pan change will only affect this instance of the sound. Use `create_sound_instance` to create
-// more instances without duplicating data.
 set_sound_pan :: proc(sound: Sound, pan: f32) {
 	sound_object := hm.get(&s.sounds, sound)
-	
+
 	if sound_object == nil {
-		log.error("Cannot set pan, sound does not exist.")
 		return
 	}
 
-	clamped_pan := clamp(pan, -1, 1)
-
-	if playing := hm.get(&s.playing_audio_buffers, sound_object.playing_buffer_handle); playing != nil {
-		playing.target_settings.pan = clamped_pan
-	}
-
-	sound_object.playback_settings.pan = clamped_pan
+	sound_object.target_settings.pan = clamp(pan, -1, 1)
 }
 
-// Set the pitch of a sound. Range: 0.01 to infinity, where 0.01 is the lowest pitch and higher
-// values increase the pitch. The pitch change will only affect this instance of the sound. Use
-// `create_sound_instance` to create more instances without duplicating data.
+// Set the pitch of a sound. Range: 0.01 and up.
 set_sound_pitch :: proc(sound: Sound, pitch: f32) {
 	sound_object := hm.get(&s.sounds, sound)
-	
+
 	if sound_object == nil {
-		log.error("Cannot set pitch, sound does not exist.")
 		return
 	}
 
-	capped_pitch := max(pitch, 0.01)
-
-	if playing := hm.get(&s.playing_audio_buffers, sound_object.playing_buffer_handle); playing != nil {
-		playing.target_settings.pitch = capped_pitch
-	}
-	
-	sound_object.playback_settings.pitch = capped_pitch
+	sound_object.target_settings.pitch = max(pitch, 0.01)
 }
 
-// Makes a sound loop when it reaches the end. You can set this before playing but also while
-// playing the sound.
+// Loops the sound. For a stream-fed sound this sets the stream's loop instead.
 set_sound_loop :: proc(sound: Sound, loop: bool) {
 	sound_object := hm.get(&s.sounds, sound)
-	
+
 	if sound_object == nil {
-		log.errorf("Cannot set loop = %v, sound does not exist.", loop)
 		return
 	}
 
-	if playing := hm.get(&s.playing_audio_buffers, sound_object.playing_buffer_handle); playing != nil {
-		playing.loop = loop
+	// A stream loops by seeking its decoder back to the start. The voice of a stream always loops:
+	// that is what makes its buffer circular, so it must not be touched here.
+	if sound_object.stream != AUDIO_STREAM_NONE {
+		if sd := hm.get(&s.audio_streams, sound_object.stream); sd != nil {
+			sd.loop = loop
+		}
+
+		return
 	}
-	
+
 	sound_object.loop = loop
 }
 
-// Route a sound into an audio bus. The sound is then mixed into that bus instead of straight into
-// the master bus. You can set the volume and pan of the whole bus, making it possible to control
-// whole categories of sounds.
-//
-// Pass `AUDIO_BUS_MASTER` to route the sound to the master bus.
+// Route a sound into an audio bus. Pass `AUDIO_BUS_MASTER` for the master bus.
 set_sound_bus :: proc(sound: Sound, bus: Audio_Bus) {
 	sound_object := hm.get(&s.sounds, sound)
 
 	if sound_object == nil {
-		log.error("Cannot set bus, sound does not exist.")
 		return
 	}
 
@@ -1996,104 +1920,24 @@ set_sound_bus :: proc(sound: Sound, bus: Audio_Bus) {
 		return
 	}
 
-	if playing := hm.get(&s.playing_audio_buffers, sound_object.playing_buffer_handle); playing != nil {
-		playing.bus = bus
-	}
-
 	sound_object.bus = bus
 }
 
-// Load a WAV file from disk. Returns a `Sound` which can be used with `play_sound`. If you need to
-// play a sound multiple times simultaneously, then use `load_audio_clip_from_file` followed by
-// one or more calls to `create_sound_from_audio_buffer`.
-//
-// Sounds created using this procedure owns their internal audio buffer: Calling `destroy_sound`
-// will also destroy the audio buffer. 
-//
-// Supports mono and stereo WAV files with 8, 16, 24 or 32 bit integer samples, or 32 or 64 bit
-// float samples.
-load_sound_from_file :: proc(filename: string) -> Sound {
-	data, data_ok := read_entire_file(filename, frame_allocator)
+// How many sounds currently play this clip. Useful for limiting how many copies of an effect pile
+// up.
+get_num_sounds_playing_clip :: proc(clip: Audio_Clip) -> int {
+	count: int
 
-	if !data_ok {
-		log.errorf("Failed to load sound from file '%v'", filename)
-		return SOUND_NONE
+	for it := hm.dynamic_iterator_make(&s.sounds); sound_object, _ in hm.dynamic_iterate(&it) {
+		if sound_object.clip == clip {
+			count += 1
+		}
 	}
 
-	return load_sound_from_bytes(data)
+	return count
 }
 
-// Load a sound some pre-loaded memory (for example using `#load("sound.wav")`). Returns a `Sound`
-// which can be used with `play_sound`. If you need to play a sound multiple times simultaneously,
-// then use `load_audio_clip_from_bytes` followed by one or more calls to
-// `create_sound_from_audio_buffer`.
-//
-// Sounds created using this procedure owns their internal audio buffer: Calling `destroy_sound`
-// will also destroy the audio buffer.
-//
-// Supports mono and stereo WAV data with 8, 16, 24 or 32 bit integer samples, or 32 or 64 bit
-// float samples. Note that the data should be the entire WAV file, including the header. If your
-// data does not include the header, then please use `load_audio_clip_from_bytes_raw` combined
-// with `create_sound_from_audio_buffer`.
-load_sound_from_bytes :: proc(bytes: []byte) -> Sound {
-	audio_clip := load_audio_clip_from_bytes(bytes)
-
-	if audio_clip == AUDIO_CLIP_NONE {
-		return SOUND_NONE
-	}
-
-	sound_object := Sound_Object {
-		playback_settings = DEFAULT_AUDIO_BUFFER_PLAYBACK_SETTINGS,
-		clip = audio_clip,
-		owns_audio_buffer = true,
-	}
-
-	sound, sound_add_error := hm.add(&s.sounds, sound_object)
-
-	if sound_add_error != nil {
-		log.errorf("Failed adding sound. Error: %v", sound_add_error)
-		return SOUND_NONE
-	}
-
-	return sound
-}
-
-// Load a sound from some raw audio data. You need to specify the data, format and sample rate of
-// the audio data yourself. This assumes that there is no header in the data. If your data has a
-// header (you read the data from a file on disk), then please use `load_sound_from_bytes` instead.
-//
-// The returned Sound owns its internal Audio_Clip: Calling `destroy_sound` with it will destroy
-// the audio buffer.
-load_sound_from_bytes_raw :: proc(
-	bytes: []u8,
-	format: Raw_Audio_Format,
-	sample_rate: int,
-	channels: Audio_Channels,
-) -> Sound {
-	audio_clip := load_audio_clip_from_bytes_raw(bytes, format, sample_rate, channels)
-
-	if audio_clip == AUDIO_CLIP_NONE {
-		return SOUND_NONE
-	}
-
-	sound_object := Sound_Object {
-		playback_settings = DEFAULT_AUDIO_BUFFER_PLAYBACK_SETTINGS,
-		clip = audio_clip,
-		owns_audio_buffer = true,
-	}
-
-	sound, sound_add_error := hm.add(&s.sounds, sound_object)
-
-	if sound_add_error != nil {
-		log.errorf("Failed adding sound. Error: %v", sound_add_error)
-		return SOUND_NONE
-	}
-
-	return sound
-}
-
-// Load a WAV file from disk. Returns an `Audio_Clip` which can be used with
-// `create_sound_from_audio_buffer` in order to play the audio buffer multiple times simultaneously.
+// Load a WAV file from disk. Returns an `Audio_Clip`.
 //
 // Supports mono and stereo WAV files with 8, 16, 24 or 32 bit integer samples, or 32 or 64 bit
 // float samples.
@@ -2109,8 +1953,8 @@ load_audio_clip_from_file :: proc(filename: string) -> Audio_Clip {
 }
 
 // Load a WAV file from some pre-loaded memory (can be loaded using `#load("sound.wav")`). Returns
-// an `Audio_Clip` which can be used with `create_sound_from_audio_buffer` in order to play the
-// audio buffer multiple times simultaneously.
+// an `Audio_Clip` which can be played, including multiple times simultaneously, using
+// `play_audio_clip`.
 //
 // Supports mono and stereo WAV data with 8, 16, 24 or 32 bit integer samples, or 32 or 64 bit
 // float samples. Note that the data should be the entire WAV file, including the header. If your
@@ -2366,71 +2210,20 @@ load_audio_clip_from_bytes_raw :: proc(
 	return audio_clip
 }
 
-// Creates a sound that can be used to play the contents of an `Audio_Clip`. This can be used to
-// load an audio buffer once and have multiple sounds playing the contents of it, simultaneously.
-// This makes all those sounds share the same audio data.
-//
-// Sounds created using this procedure do not own the buffer. This means that calling
-// `destroy_sound` on the Sound will only remove the Sound from Karl2D's internal state, but it
-// won't destroy the Audio_Clip. Such auto-destroying of the `Audio_Clip` only happen with
-// sounds created using `load_sound_from_file` and `load_sound_from_bytes`.
-create_sound_from_audio_buffer :: proc(buffer: Audio_Clip) -> Sound {
-	audio_clip_object := hm.get(&s.audio_clips, buffer)
-
-	if audio_clip_object == nil {
-		log.error("Trying to create sound from invalid audio buffer")
-		return SOUND_NONE
-	}
-
-	sound_object := Sound_Object {
-		playback_settings = DEFAULT_AUDIO_BUFFER_PLAYBACK_SETTINGS,
-		clip = buffer,
-		owns_audio_buffer = false,
-	}
-
-	sound, sound_add_error := hm.add(&s.sounds, sound_object)
-
-	if sound_add_error != nil {
-		log.errorf("Failed to create sound from audio buffer. Error: %v", sound_add_error)
-		return SOUND_NONE
-	}
-
-	return sound
-}
-
-// Destroy a sound, removing it from Karl2D's internal list of sounds.
-//
-// If the sound was created using `create_sound_from_audio_buffer`, then this procedure will not
-// destroy the audio buffer. If the sound was created using `load_sound_from_file` or
-// `load_sound_from_bytes`, then this procedure WILL destroy the audio buffer.
-destroy_sound :: proc(sound: Sound) {
-	sound_object := hm.get(&s.sounds, sound)
-
-	if sound_object == nil {
-		log.error("Trying to destroy invalid sound. It may already be destroyed, or the handle may be invalid.")
-		return
-	}
-
-	if playing := hm.get(&s.playing_audio_buffers, sound_object.playing_buffer_handle); playing != nil {
-		hm.remove(&s.playing_audio_buffers, sound_object.playing_buffer_handle)
-	}
-	
-	if sound_object.owns_audio_buffer {
-		destroy_audio_clip(sound_object.clip)
-	}
-
-	hm.remove(&s.sounds, sound)
-}
-
-// Destroy an audio buffer previously loaded using `load_audio_clip_from_xxx`. Before destroying
-// this audio buffer, make sure it is not in use by any playing sounds. Destroy the sounds that
-// reference it using `destroy_sound` first.
+// Destroy an audio clip previously loaded using `load_audio_clip_from_xxx`. Also stops sounds
+// playing this clip.
 destroy_audio_clip :: proc(clip: Audio_Clip)  {
 	audio_clip_object := hm.get(&s.audio_clips, clip)
 
 	if audio_clip_object == nil {
 		log.debug("Tried to destroy non-existing audio buffer")
 		return
+	}
+
+	for it := hm.dynamic_iterator_make(&s.sounds); snd, snd_handle in hm.dynamic_iterate(&it) {
+		if snd.clip == clip {
+			hm.remove(&s.sounds, snd_handle)
+		}
 	}
 
 	delete(audio_clip_object.samples, s.allocator)
@@ -2617,9 +2410,9 @@ load_audio_stream_from_file :: proc(filename: string) -> Audio_Stream {
 // file and then send it into this procedure.
 //
 // Note that this procedure wants the encoded file, for example an ogg file just like it was on
-// disk. For normal sounds there is a `load_sound_from_bytes_raw` procedure where you just send in
-// the samples. There is no such procedure for audio streams since the whole idea is to stream an
-// encoded file into memory without having to decode the whole thing first.  
+// disk. For normal sounds there is a `load_audio_clip_from_bytes_raw` procedure where you just send
+// in the samples. There is no such procedure for audio streams since the whole idea is to stream an
+// encoded file into memory without having to decode the whole thing first.
 load_audio_stream_from_bytes :: proc(bytes: []u8) -> Audio_Stream {
 	vorbis_err: stbv.Error
 
@@ -2710,8 +2503,8 @@ destroy_audio_stream :: proc(stream: Audio_Stream) {
 		return
 	}
 
-	if playing := hm.get(&s.playing_audio_buffers, sd.playing_buffer_handle); playing != nil {
-		hm.remove(&s.playing_audio_buffers, sd.playing_buffer_handle)
+	if playing := hm.get(&s.sounds, sd.playing_buffer_handle); playing != nil {
+		hm.remove(&s.sounds, sd.playing_buffer_handle)
 	}
 
 	if ab := hm.get(&s.audio_clips, sd.clip); ab != nil {
@@ -2741,7 +2534,7 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 		return
 	}
 
-	pab := hm.get(&s.playing_audio_buffers, sd.playing_buffer_handle)
+	pab := hm.get(&s.sounds, sd.playing_buffer_handle)
 
 	if pab == nil {
 		// Don't log an error here: Not playing the stream is a valid state. It just doesn't need
@@ -2752,12 +2545,12 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 	ab := hm.get(&s.audio_clips, pab.clip)
 
 	if ab == nil {
-		hm.remove(&s.playing_audio_buffers, sd.playing_buffer_handle)
+		hm.remove(&s.sounds, sd.playing_buffer_handle)
 		log.error("Trying to update audio stream with destroyed buffer")
 		return
 	}
 
-	audio_stream_remaining :: proc(as: ^Audio_Stream_Data, pab: ^Playing_Audio_Buffer, ab: ^Audio_Clip_Object) -> int {
+	audio_stream_remaining :: proc(as: ^Audio_Stream_Data, pab: ^Sound_Object, ab: ^Audio_Clip_Object) -> int {
 		remaining := as.buffer_write_pos - pab.offset 
 
 		if remaining < 0 {
@@ -2810,7 +2603,7 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 							break
 						}
 					} else {
-						hm.remove(&s.playing_audio_buffers, sd.playing_buffer_handle)
+						hm.remove(&s.sounds, sd.playing_buffer_handle)
 						log.errorf("Failed reading from audio stream file. Error: %v", read_err)
 						break
 					}
@@ -2835,13 +2628,13 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 						sd.buffer_write_pos = (sd.buffer_write_pos + 2) % len(ab.samples)
 					}
 				} else {
-					hm.remove(&s.playing_audio_buffers, sd.playing_buffer_handle)
+					hm.remove(&s.sounds, sd.playing_buffer_handle)
 					log.error("Invalid num channels")
 					break
 				}
 				sd.file_read_buf_offset += int(bytes_used)
 			} else {
-				hm.remove(&s.playing_audio_buffers, sd.playing_buffer_handle)
+				hm.remove(&s.sounds, sd.playing_buffer_handle)
 				log.error("Invalid vorbis")
 				break
 			}
@@ -2891,7 +2684,7 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 					sd.buffer_write_pos = (sd.buffer_write_pos + 2) % len(ab.samples)
 				}
 			} else {
-				hm.remove(&s.playing_audio_buffers, sd.playing_buffer_handle)
+				hm.remove(&s.sounds, sd.playing_buffer_handle)
 				log.error("Invalid num channels")
 				break
 			}
@@ -2912,11 +2705,11 @@ play_audio_stream :: proc(stream: Audio_Stream) {
 		return
 	}
 
-	if existing := hm.get(&s.playing_audio_buffers, sd.playing_buffer_handle); existing != nil {
+	if existing := hm.get(&s.sounds, sd.playing_buffer_handle); existing != nil {
 		stop_audio_stream(stream)
 	}
 
-	playing_audio_buffer := Playing_Audio_Buffer {
+	playing_audio_buffer := Sound_Object {
 		clip = sd.clip,
 		target_settings = sd.playback_settings,
 		current_settings = sd.playback_settings,
@@ -2929,7 +2722,7 @@ play_audio_stream :: proc(stream: Audio_Stream) {
 	}
 
 	add_err: runtime.Allocator_Error
-	sd.playing_buffer_handle, add_err = hm.add(&s.playing_audio_buffers, playing_audio_buffer)
+	sd.playing_buffer_handle, add_err = hm.add(&s.sounds, playing_audio_buffer)
 
 	if add_err != nil {
 		log.errorf("Failed playing the audio stream because the audio buffer could not be set up for playing. Error: %v", add_err)
@@ -2945,11 +2738,11 @@ pause_audio_stream :: proc(stream: Audio_Stream) {
 		return
 	}
 
-	if existing := hm.get(&s.playing_audio_buffers, sd.playing_buffer_handle); existing != nil {
-		hm.remove(&s.playing_audio_buffers, sd.playing_buffer_handle)
+	if existing := hm.get(&s.sounds, sd.playing_buffer_handle); existing != nil {
+		hm.remove(&s.sounds, sd.playing_buffer_handle)
 	}
 
-	sd.playing_buffer_handle = PLAYING_AUDIO_BUFFER_NONE
+	sd.playing_buffer_handle = SOUND_NONE
 }
 
 // Stop an audio stream. If `play_audio_stream` is called again, the stream will start over from the
@@ -2962,11 +2755,11 @@ stop_audio_stream :: proc(stream: Audio_Stream) {
 		return
 	}
 
-	if existing := hm.get(&s.playing_audio_buffers, sd.playing_buffer_handle); existing != nil {
-		hm.remove(&s.playing_audio_buffers, sd.playing_buffer_handle)
+	if existing := hm.get(&s.sounds, sd.playing_buffer_handle); existing != nil {
+		hm.remove(&s.sounds, sd.playing_buffer_handle)
 	}
 
-	sd.playing_buffer_handle = PLAYING_AUDIO_BUFFER_NONE
+	sd.playing_buffer_handle = SOUND_NONE
 	sd.buffer_write_pos = 0
 
 	switch sd.mode {
@@ -2990,7 +2783,7 @@ is_audio_stream_playing :: proc(stream: Audio_Stream) -> bool {
 		return false
 	}
 
-	return hm.is_valid(&s.playing_audio_buffers, sd.playing_buffer_handle)
+	return hm.is_valid(&s.sounds, sd.playing_buffer_handle)
 }
 
 // Set the volume of the audio stream. Range: 0 to 1.
@@ -3007,7 +2800,7 @@ set_audio_stream_volume :: proc(stream: Audio_Stream, volume: f32) {
 
 	clamped_volume := clamp(volume, 0, 1)
 
-	if playing := hm.get(&s.playing_audio_buffers, sd.playing_buffer_handle); playing != nil {
+	if playing := hm.get(&s.sounds, sd.playing_buffer_handle); playing != nil {
 		playing.target_settings.volume = clamped_volume
 	}
 	
@@ -3029,7 +2822,7 @@ set_audio_stream_pan :: proc(stream: Audio_Stream, pan: f32) {
 
 	clamped_pan := clamp(pan, -1, 1)
 
-	if playing := hm.get(&s.playing_audio_buffers, sd.playing_buffer_handle); playing != nil {
+	if playing := hm.get(&s.sounds, sd.playing_buffer_handle); playing != nil {
 		playing.target_settings.pan = clamped_pan
 	}
 
@@ -3051,7 +2844,7 @@ set_audio_stream_pitch :: proc(stream: Audio_Stream, pitch: f32) {
 
 	capped_pitch := max(pitch, 0.01)
 
-	if playing := hm.get(&s.playing_audio_buffers, sd.playing_buffer_handle); playing != nil {
+	if playing := hm.get(&s.sounds, sd.playing_buffer_handle); playing != nil {
 		playing.target_settings.pitch = capped_pitch
 	}
 	
@@ -3095,7 +2888,7 @@ set_audio_stream_bus :: proc(stream: Audio_Stream, bus: Audio_Bus) {
 		return
 	}
 
-	if playing := hm.get(&s.playing_audio_buffers, sd.playing_buffer_handle); playing != nil {
+	if playing := hm.get(&s.sounds, sd.playing_buffer_handle); playing != nil {
 		playing.bus = bus
 	}
 
@@ -3104,7 +2897,7 @@ set_audio_stream_bus :: proc(stream: Audio_Stream, bus: Audio_Bus) {
 
 // Create an audio bus: A group of sounds that are mixed together before they reach the master bus.
 // Route sounds into it using `set_sound_bus`, `set_audio_stream_bus`, or the `bus` parameter of
-// `play_audio_buffer`.
+// `play_audio_clip`.
 //
 // A new bus has volume 1, pan 0 and no effect. That makes it a passthrough: Playing a sound on a
 // fresh bus sounds exactly like playing it on the master bus, until you change something.
@@ -3152,12 +2945,6 @@ destroy_audio_bus :: proc(bus: Audio_Bus) {
 	for it := hm.dynamic_iterator_make(&s.audio_streams); sd, _ in hm.dynamic_iterate(&it) {
 		if sd.bus == bus {
 			sd.bus = AUDIO_BUS_MASTER
-		}
-	}
-
-	for it := hm.dynamic_iterator_make(&s.playing_audio_buffers); ps, _ in hm.dynamic_iterate(&it) {
-		if ps.bus == bus {
-			ps.bus = AUDIO_BUS_MASTER
 		}
 	}
 
@@ -3399,12 +3186,12 @@ update_audio_mixer :: proc() {
 		return current + dir * delta
 	}
 
-	for ps_iter := hm.dynamic_iterator_make(&s.playing_audio_buffers); ps, ps_handle in hm.dynamic_iterate(&ps_iter) {
+	for ps_iter := hm.dynamic_iterator_make(&s.sounds); ps, ps_handle in hm.dynamic_iterate(&ps_iter) {
 		data := hm.get(&s.audio_clips, ps.clip)
 
 		if data == nil {
 			log.error("Trying to play sound with destroyed data")
-			hm.remove(&s.playing_audio_buffers, ps_handle)
+			hm.remove(&s.sounds, ps_handle)
 			continue
 		}
 
@@ -3543,7 +3330,7 @@ update_audio_mixer :: proc() {
 					ps.offset_fraction = 0
 				}
 			} else {
-				hm.remove(&s.playing_audio_buffers, ps_handle)
+				hm.remove(&s.sounds, ps_handle)
 				continue
 			}
 		}
@@ -5198,46 +4985,11 @@ AUDIO_MIX_CHUNK_SIZE :: 1400
 // sample in an array of samples will be interpreted as left and right respectively.
 Audio_Sample :: f32
 
-// Represents a sound you can play using the `play_sound` procedure. Loaded using
-// `load_sound_from_file` or `load_sound_from_bytes`. Create instances of an already loaded sound
-// using `create_sound_instance`.
+// One playing instance in the mixer. Spawned by `play_audio_clip` or `play_audio_stream`.
+// Auto-destroys when it finishes playing. Operations on a finished sound are silent no-ops.
 Sound :: distinct Handle
 
 SOUND_NONE :: Sound {}
-
-// A sound instance is what `Sound` handles are mapped to. They contain a handle to an audio
-// clip, and the settings for use when playing that clip. The audio clip may be shared between
-// multiple sound instances, which allows you to play the same sound multiple times at the same time
-// without having to clone the data.
-Sound_Object :: struct {
-	handle: Sound,
-
-	// The audio clip may be used by multiple sound instances. This is the key idea of sound
-	// instances: That you can use `create_sound_instance` to make it possible to play a sound
-	// multiple times at the same time, without having to clone the data.
-	clip: Audio_Clip,
-
-	// If true, then the audio buffer will be destroyed when this sound is destroyed. This is true
-	// when the sound was loaded using the `load_sound_xxx` procedures. It's false when the sound
-	// is created from `create_sound_from_audio_buffer`.
-	owns_audio_buffer: bool,
-
-	// If this sound is currently playing, then this identifies the state of the playing sound. It
-	// is PLAYING_AUDIO_BUFFER_NONE (zero) when it is not playing.
-	playing_buffer_handle: Playing_Audio_Buffer_Handle,
-
-	// This exists both here and in the `Playing_Audio_Buffer`. That way we can store settings
-	// even when the sound isn't playing. Set using `set_sound_volume/pan/pitch`.
-	playback_settings: Audio_Buffer_Playback_Settings,
-
-	// If true, then the playing sound will be set up as "looping" when `play_sound` is called. Set
-	// using `set_sound_loop`.
-	loop: bool,
-
-	// The bus the sound is mixed into when it plays. The zero value is the master bus. Set using
-	// `set_sound_bus`.
-	bus: Audio_Bus,
-}
 
 Audio_Stream :: distinct Handle
 
@@ -5263,22 +5015,22 @@ Audio_Stream_Data :: struct {
 	
 	vorbis: ^stbv.vorbis,
 	vorbis_buffer: stbv.vorbis_alloc,
-	playing_buffer_handle: Playing_Audio_Buffer_Handle,
+	playing_buffer_handle: Sound,
 	clip: Audio_Clip,
 
 	// Where in the audio clip referred to by `buffer_handle` that we have most recently written
-	// samples. Together with the `offset` of the Playing_Audio_Buffer, this forms a circular
+	// samples. Together with the `offset` of the Sound_Object, this forms a circular
 	// buffer.
 	buffer_write_pos: int,
 
-	playback_settings: Audio_Buffer_Playback_Settings,
+	playback_settings: Sound_Settings,
 
 	// The bus the stream is mixed into when it plays. The zero value is the master bus. Set using
 	// `set_audio_stream_bus`.
 	bus: Audio_Bus,
 
-	// Different from `loop` in `Playing_Audio_Buffer`. This says if the whole stream should loop
-	// when it reaches end-of-file. The `loop` in `Playing_Audio_Buffer` just says to loop the
+	// Different from `loop` in `Sound_Object`. This says if the whole stream should loop
+	// when it reaches end-of-file. The `loop` in `Sound_Object` just says to loop the
 	// buffer itself. That's something you always want for a stream: We are continously writing
 	// data from a file into a small buffer that is a few seconds long.
 	loop: bool,
@@ -5294,7 +5046,7 @@ Audio_Stream_Data :: struct {
 	bytes: []u8,
 }
 
-// The format used to describe that data passed to `load_sound_from_bytes_raw`.
+// The format used to describe that data passed to `load_audio_clip_from_bytes_raw`.
 Raw_Audio_Format :: enum {
 	Integer8, // unsigned, like in 8 bit WAV files. The other integer formats are signed.
 	Integer16,
@@ -5324,27 +5076,19 @@ Audio_Clip_Object :: struct {
 	channels: Audio_Channels,
 }
 
-Audio_Buffer_Playback_Settings :: struct {
+Sound_Settings :: struct {
 	volume: f32,
 	pan: f32,
 	pitch: f32,
 }
 
-DEFAULT_AUDIO_BUFFER_PLAYBACK_SETTINGS :: Audio_Buffer_Playback_Settings {
-	volume = 1,
-	pan = 0,
-	pitch = 1,
-}
-
-PLAYING_AUDIO_BUFFER_NONE :: Playing_Audio_Buffer_Handle {}
-
-Playing_Audio_Buffer_Handle :: distinct Handle
-
-Playing_Audio_Buffer :: struct {
-	handle: Playing_Audio_Buffer_Handle,
+// A sound instance is what `Sound` handles are mapped to. It is a voice currently playing in the
+// mixer, holding the clip (or stream) it plays and the settings it plays with.
+Sound_Object :: struct {
+	handle: Sound,
 	clip: Audio_Clip,
-	target_settings: Audio_Buffer_Playback_Settings,
-	current_settings: Audio_Buffer_Playback_Settings,
+	target_settings: Sound_Settings,
+	current_settings: Sound_Settings,
 
 	// How many samples have played?
 	offset: int,
@@ -5358,12 +5102,16 @@ Playing_Audio_Buffer :: struct {
 
 	// The bus this is mixed into. The zero value is the master bus.
 	bus: Audio_Bus,
+
+	// Set when a stream feeds this sound. Zero for sounds played from a clip. Used by
+	// `set_sound_loop` to redirect to the stream's own loop flag.
+	stream: Audio_Stream,
 }
 
 // A bus is a group of sounds that are mixed together before they reach the master bus. You can set
 // the volume and the pan of the whole group, and you can run an effect on it. Create one using
 // `create_audio_bus` and route sounds into it using `set_sound_bus`, `set_audio_stream_bus` or the
-// `bus` parameter of `play_audio_buffer`.
+// `bus` parameter of `play_audio_clip`.
 Audio_Bus :: distinct Handle
 
 // All other buses are mixed into the master bus, as well as sounds that play directly on the master
@@ -5392,7 +5140,7 @@ Audio_Bus_Settings :: struct {
 Audio_Bus_Object :: struct {
 	handle: Audio_Bus,
 
-	// Same idea as in `Playing_Audio_Buffer`: The current settings move towards the target
+	// Same idea as in `Sound_Object`: The current settings move towards the target
 	// settings a bit at a time, so that changing the volume of a bus doesn't click.
 	target_settings: Audio_Bus_Settings,
 	current_settings: Audio_Bus_Settings,
@@ -5508,8 +5256,6 @@ State :: struct {
 
 	audio_clips: hm.Dynamic_Handle_Map(Audio_Clip_Object, Audio_Clip),
 	sounds: hm.Dynamic_Handle_Map(Sound_Object, Sound),
-
-	playing_audio_buffers: hm.Dynamic_Handle_Map(Playing_Audio_Buffer, Playing_Audio_Buffer_Handle),
 
 	audio_streams: hm.Dynamic_Handle_Map(Audio_Stream_Data, Audio_Stream),
 

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1794,10 +1794,18 @@ set_texture_filter_ex :: proc(
 // AUDIO //
 //-------//
 
-// Play an audio clip. Always starts a new sound, never restarts. Discard the returned handle for
-// fire-and-forget playback. Parameters are the starting settings.
+// Play an audio clip with the supplied initial settings. The return value is a `Sound`, which means
+// something that is currently playing in the audio mixer. Ignore the return value for
+// fire-and-forget playback. You can use the returned `Sound` with `set_sound_volume`, `stop_sound`
+// etc in order to control the playback.
+//
+// Audio clips are loaded using `load_audio_clip_from_file`, `load_audio_clip_from_bytes` and
+// `load_audio_clip_from_bytes_raw`.
 //
 // Pass `bus` to play the sound on an audio bus. It plays on the master bus by default.
+//
+// Warning: If you pass `loop = true` and don't save the return value anywhere, then you've started
+// a sound you cannot stop.
 play_audio_clip :: proc(
 	clip: Audio_Clip,
 	volume: f32 = 1,
@@ -1842,8 +1850,9 @@ play_audio_clip :: proc(
 	return sound
 }
 
-// Stops and destroys the sound. For a stream-fed sound this also rewinds the stream to the start.
-// Use `set_sound_paused` to pause without destroying.
+// Stops the sound, which destroys its playback state in the mixer. For a `Sound` started using
+// `play_audio_stream`, this also rewinds the stream to the start. Use `set_sound_paused` to pause
+// the Sound instead, which won't lose the current playback position and settings.
 stop_sound :: proc(sound: Sound) {
 	sound_object := hm.get(&s.sounds, sound)
 
@@ -1916,7 +1925,12 @@ set_sound_pitch :: proc(sound: Sound, pitch: f32) {
 	sound_object.target_settings.pitch = max(pitch, 0.01)
 }
 
-// Loops the sound. For a stream-fed sound this sets the stream's loop instead.
+// Make a sound loop when it reaches the end.
+//
+// Technical note: This works for sounds started using `play_audio_stream`. But it actually reaches
+// into the streaming decoder and tells that one to loop. The `Sound` that is used by the audio
+// stream is just a short buffer that is filled by the decoding stream, so that one always loops
+// when playing from a stream.
 set_sound_loop :: proc(sound: Sound, loop: bool) {
 	sound_object := hm.get(&s.sounds, sound)
 
@@ -1967,7 +1981,7 @@ get_num_sounds_playing_clip :: proc(clip: Audio_Clip) -> int {
 	return count
 }
 
-// Load a WAV file from disk. Returns an `Audio_Clip`.
+// Load a WAV file from disk. Returns an `Audio_Clip` which can be played using `play_audio_clip`.
 //
 // Supports mono and stereo WAV files with 8, 16, 24 or 32 bit integer samples, or 32 or 64 bit
 // float samples.
@@ -1983,8 +1997,7 @@ load_audio_clip_from_file :: proc(filename: string) -> Audio_Clip {
 }
 
 // Load a WAV file from some pre-loaded memory (can be loaded using `#load("sound.wav")`). Returns
-// an `Audio_Clip` which can be played, including multiple times simultaneously, using
-// `play_audio_clip`.
+// an `Audio_Clip` which can be played using `play_audio_clip`.
 //
 // Supports mono and stereo WAV data with 8, 16, 24 or 32 bit integer samples, or 32 or 64 bit
 // float samples. Note that the data should be the entire WAV file, including the header. If your
@@ -2165,8 +2178,8 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> Audio_Clip {
 
 // Load an audio clip from some raw audio data. You need to specify the data, format and sample
 // rate of the sound yourself. This assumes that there is no header in the data. If your data has a
-// header (you read the data from a file on disk), then please use `load_audio_clip_from_bytes`
-// instead.
+// header (for example, you read a whole WAV file from disk), then please use
+// `load_audio_clip_from_bytes` instead.
 load_audio_clip_from_bytes_raw :: proc(
 	bytes: []u8,
 	format: Raw_Audio_Format,
@@ -2262,7 +2275,7 @@ destroy_audio_clip :: proc(clip: Audio_Clip)  {
 
 // Load an audio stream from a file on disk. This is often used for playing music. An audio stream
 // only loads a small part of the file at a time. As the file is played, new parts are streamed into
-// memory.
+// memory. Start playing the stream using `play_audio_stream`.
 //
 // Supported file formats: ogg
 //
@@ -2715,9 +2728,9 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 	}
 }
 
-// Returns a `Sound`, controllable like any other. Starts from wherever the decode cursor
-// currently is and never rewinds. A stream feeds at most one sound: playing again replaces the
-// previous one.
+// Start playing an audio stream. Returns a `Sound`, which you can control using
+// `set_sound_volume`, `stop_sound` etc. Starts from wherever the decode cursor currently is and
+// never rewinds. A stream feeds at most one sound: playing again replaces the previous one.
 //
 // Don't forget to call `update_audio_stream` every frame in order to stream in new data.
 play_audio_stream :: proc(

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1842,14 +1842,44 @@ play_audio_clip :: proc(
 	return sound
 }
 
-// Stops and destroys the sound. For a stream-fed sound this is a pause: the stream cursor stays
-// put.
+// Stops and destroys the sound. For a stream-fed sound this also rewinds the stream to the start.
+// Use `set_sound_paused` to pause without destroying.
 stop_sound :: proc(sound: Sound) {
+	sound_object := hm.get(&s.sounds, sound)
+
+	if sound_object == nil {
+		return
+	}
+
+	stream := sound_object.stream
 	hm.remove(&s.sounds, sound)
+
+	if stream != AUDIO_STREAM_NONE {
+		reset_audio_stream(stream)
+	}
 }
 
-// Returns true if the sound is currently playing.
+// Pause or unpause a sound. A paused sound keeps its position and stays valid until it is unpaused
+// or stopped.
+set_sound_paused :: proc(sound: Sound, paused: bool) {
+	sound_object := hm.get(&s.sounds, sound)
+
+	if sound_object == nil {
+		return
+	}
+
+	sound_object.paused = paused
+}
+
+// Returns true if the sound exists and is not paused.
 sound_is_playing :: proc(sound: Sound) -> bool {
+	sound_object := hm.get(&s.sounds, sound)
+	return sound_object != nil && !sound_object.paused
+}
+
+// Returns true if the sound still exists. Both playing and paused sounds are valid. A finished or
+// stopped sound is not.
+sound_is_valid :: proc(sound: Sound) -> bool {
 	return hm.is_valid(&s.sounds, sound)
 }
 
@@ -2729,6 +2759,9 @@ play_audio_stream :: proc(
 		bus = bus,
 		stream = stream,
 
+		// Start reading at the write head, so that playback continues from the decode cursor.
+		offset = sd.buffer_write_pos,
+
 		// This means that we are looping the buffer itself. We will use this buffer as a circular
 		// buffer, filling it with samples as we stream in more. Thus it needs to be looped to not
 		// stop when the end of the circular buffer is reached.
@@ -3072,6 +3105,11 @@ update_audio_mixer :: proc() {
 		if data == nil {
 			log.error("Trying to play sound with destroyed data")
 			hm.remove(&s.sounds, ps_handle)
+			continue
+		}
+
+		// A paused sound stays in the list but is not mixed.
+		if ps.paused {
 			continue
 		}
 
@@ -4973,6 +5011,9 @@ Sound_Object :: struct {
 	offset_fraction: f32,
 
 	loop: bool,
+
+	// Set using `set_sound_paused`. The mixer skips paused sounds.
+	paused: bool,
 
 	// The bus this is mixed into. The zero value is the master bus.
 	bus: Audio_Bus,


### PR DESCRIPTION
Closes #226.

`Audio_Clip` are fully loaded sounds, like a wav. `Audio_Stream` is audio streaming from disk, such as music or ambience. Both `play_audio_clip` and `play_audio_stream` return a `Sound`. A `Sound` is a playing instance, something that is making sound within the mixer. The same API is used for changing playback settings on these.

```odin
// Clips
load_audio_clip_from_file :: proc(filename: string) -> Audio_Clip
load_audio_clip_from_bytes :: proc(bytes: []u8) -> Audio_Clip
load_audio_clip_from_bytes_raw :: proc(bytes: []u8, format: Raw_Audio_Format, sample_rate: int, channels: Audio_Channels) -> Audio_Clip
destroy_audio_clip :: proc(clip: Audio_Clip)  // also stops sounds playing the clip

play_audio_clip :: proc(
	clip: Audio_Clip,
	volume: f32 = 1,
	pan: f32 = 0,
	pitch: f32 = 1,
	loop := false,
	bus: Audio_Bus = AUDIO_BUS_MASTER,
) -> Sound  // discard the handle for fire-and-forget. Every call is a new sound, never a restart

get_num_sounds_playing_clip :: proc(clip: Audio_Clip) -> int

// Sounds. Work identically on clip-fed and stream-fed sounds.
stop_sound :: proc(sound: Sound)                      // destroys. Rewinds a stream-fed sound
set_sound_paused :: proc(sound: Sound, paused: bool)
sound_is_playing :: proc(sound: Sound) -> bool        // valid and not paused
sound_is_valid :: proc(sound: Sound) -> bool
set_sound_volume :: proc(sound: Sound, volume: f32)
set_sound_pan :: proc(sound: Sound, pan: f32)
set_sound_pitch :: proc(sound: Sound, pitch: f32)
set_sound_loop :: proc(sound: Sound, loop: bool)      // stream-fed sounds loop at the decode level
set_sound_bus :: proc(sound: Sound, bus: Audio_Bus)

// Streams
load_audio_stream_from_file :: proc(filename: string) -> Audio_Stream
load_audio_stream_from_bytes :: proc(bytes: []u8) -> Audio_Stream
destroy_audio_stream :: proc(stream: Audio_Stream)

play_audio_stream :: proc(
	stream: Audio_Stream,
	volume: f32 = 1,
	pan: f32 = 0,
	pitch: f32 = 1,
	loop := false,
	bus: Audio_Bus = AUDIO_BUS_MASTER,
) -> Sound  // starts from the decode cursor. Playing again replaces the previous sound

update_audio_stream :: proc(stream: Audio_Stream)

// Audio buses are unchanged.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
