### PR TITLE
Seek in sounds

### DIFF
--- a/audio_backend_web_audio.js
+++ b/audio_backend_web_audio.js
@@ -13,6 +13,11 @@ const karl2dAudioJsImports = {
 		web_audio_init: function () {
 			this.remaining_samples = 0;
 
+			// Used to count off samples while the browser refuses to play anything. See
+			// `web_audio_remaining_samples`.
+			this.blocked_since = performance.now();
+			this.was_blocked = true;
+
 			async function boot_audio() {
 				this.audio_ctx = new AudioContext({sampleRate: 44100});
 
@@ -75,12 +80,15 @@ const karl2dAudioJsImports = {
 		},
 
 		web_audio_feed: function(samples_f32_ptr, samples_f32_len) {
+			// Count the samples even when they can't be sent anywhere, so that the mixer is fed
+			// at the same rate either way. `web_audio_remaining_samples` counts them off again.
+			this.remaining_samples += samples_f32_len / 2;
+
 			if (this.audio_node == null || this.audio_ctx.state === 'suspended') {
 				return;
 			}
 
 			let samples = new Float32Array(wasmMemory.buffer, samples_f32_ptr, samples_f32_len);
-			this.remaining_samples += samples.length / 2;
 
 			this.audio_node.port.postMessage({
 				type: 'samples',
@@ -89,6 +97,24 @@ const karl2dAudioJsImports = {
 		},
 
 		web_audio_remaining_samples: function() {
+			let now = performance.now();
+			let blocked = this.audio_node == null || this.audio_ctx.state === 'suspended';
+
+			if (blocked) {
+				// The audio processor isn't running, so it isn't telling us that it consumed
+				// anything. Count off what it would have consumed by now, using the clock. That
+				// keeps the mixer running at the rate it will run at once audio starts, so the
+				// game carries on as usual and just can't be heard yet.
+				let consumed = (now - this.blocked_since)*44100/1000;
+				this.remaining_samples = Math.max(this.remaining_samples - consumed, 0);
+			} else if (this.was_blocked) {
+				// Audio just started. Nothing we fed while it was blocked reached the audio
+				// processor, so start counting from nothing.
+				this.remaining_samples = 0;
+			}
+
+			this.blocked_since = now;
+			this.was_blocked = blocked;
 			return this.remaining_samples;
 		}
 	}

--- a/examples/audio/audio.odin
+++ b/examples/audio/audio.odin
@@ -15,6 +15,16 @@ chord_clip: k2.Audio_Clip
 
 music: k2.Audio_Stream
 music_sound: k2.Sound
+
+// True while the left mouse button is dragging the seek bar.
+seeking: bool
+
+// How far along the seek bar the drag currently is, from 0 to 1.
+seek_fraction: f32
+
+// Where the seek bar is drawn. Clicking anywhere in it jumps to that spot in the song.
+SEEK_BAR :: k2.Rect { 20, 330, 800, 30 }
+
 snd_volume: f32
 snd_pan: f32
 snd_pitch: f32 = 1
@@ -136,12 +146,29 @@ step :: proc() -> bool {
 			k2.set_sound_paused(music_sound, k2.sound_is_playing(music_sound))
 		}
 
-		if k2.key_went_down(.Comma) {
-			k2.set_sound_position(music_sound, k2.get_sound_position(music_sound) - 5)
+		// SEEK BAR
+		//
+		// Press inside the bar to start dragging it, then release to jump to that spot. The drag
+		// continues even if the mouse leaves the bar, which is what you'd expect from a scrub bar.
+		//
+		// We only set the position when the button is released, not every frame of the drag.
+		// Seeking backwards in a stream that was loaded from file has to decode the file from the
+		// start, so doing it every frame would make the dragging stutter.
+		if k2.mouse_button_went_down(.Left) && k2.point_in_rect(k2.get_mouse_position(), SEEK_BAR) {
+			seeking = true
 		}
 
-		if k2.key_went_down(.Period) {
-			k2.set_sound_position(music_sound, k2.get_sound_position(music_sound) + 5)
+		if seeking {
+			seek_fraction = clamp((k2.get_mouse_position().x - SEEK_BAR.x) / SEEK_BAR.w, 0, 1)
+
+			if !k2.mouse_button_is_held(.Left) {
+				seeking = false
+				music_length := k2.get_sound_length(music_sound)
+
+				if music_length > 0 {
+					k2.set_sound_position(music_sound, seek_fraction * music_length)
+				}
+			}
 		}
 
 		k2.set_sound_pitch(music_sound, snd_pitch)
@@ -178,15 +205,37 @@ step :: proc() -> bool {
 
 	when HAS_MUSIC {
 		k2.draw_text(
-			"Home plays the music, End stops it, P pauses. Seek with , and .",
+			"Home plays the music, End stops it, P pauses. Drag the bar to seek.",
 			{20, 280},
 			40,
 			k2.BLACK,
 		)
+
+		position := k2.get_sound_position(music_sound)
+		length := k2.get_sound_length(music_sound)
+		fraction: f32
+
+		if length > 0 {
+			fraction = clamp(position/length, 0, 1)
+		}
+
+		// While dragging, the bar follows the mouse instead of the music. The music catches up
+		// when the button is released.
+		if seeking {
+			fraction = seek_fraction
+		}
+
+		k2.draw_rect(SEEK_BAR, k2.LIGHT_GRAY)
+
+		played := SEEK_BAR
+		played.w = SEEK_BAR.w * fraction
+		k2.draw_rect(played, seeking ? k2.LIGHT_BLUE : k2.DARK_GRAY)
+		k2.draw_rect_outline(SEEK_BAR, 1, k2.BLACK)
+
 		k2.draw_text(
-			fmt.tprintf("Music position: %.1f s", k2.get_sound_position(music_sound)),
-			{20, 320},
-			40,
+			fmt.tprintf("%.1f / %.1f s", fraction*length, length),
+			{SEEK_BAR.x, SEEK_BAR.y + SEEK_BAR.h + 8},
+			30,
 			k2.BLACK,
 		)
 	}

--- a/examples/audio/audio.odin
+++ b/examples/audio/audio.odin
@@ -127,7 +127,7 @@ step :: proc() -> bool {
 		k2.update_audio_stream(music)
 
 		// Home starts the music. End stops it, which also rewinds the stream. P pauses and
-		// resumes, keeping the position.
+		// resumes, keeping its place in the song.
 		if k2.key_went_down(.Home) {
 			music_sound = k2.play_audio_stream(
 				music,
@@ -151,7 +151,7 @@ step :: proc() -> bool {
 		// Press inside the bar to start dragging it, then release to jump to that spot. The drag
 		// continues even if the mouse leaves the bar, which is what you'd expect from a scrub bar.
 		//
-		// We only set the position when the button is released, not every frame of the drag.
+		// We only move the music when the button is released, not every frame of the drag.
 		// Seeking backwards in a stream that was loaded from file has to decode the file from the
 		// start, so doing it every frame would make the dragging stutter.
 		if k2.mouse_button_went_down(.Left) && k2.point_in_rect(k2.get_mouse_position(), SEEK_BAR) {
@@ -166,7 +166,7 @@ step :: proc() -> bool {
 				music_length := k2.get_sound_length(music_sound)
 
 				if music_length > 0 {
-					k2.set_sound_position(music_sound, seek_fraction * music_length)
+					k2.set_sound_time(music_sound, seek_fraction * music_length)
 				}
 			}
 		}
@@ -211,12 +211,12 @@ step :: proc() -> bool {
 			k2.BLACK,
 		)
 
-		position := k2.get_sound_position(music_sound)
+		time := k2.get_sound_time(music_sound)
 		length := k2.get_sound_length(music_sound)
 		fraction: f32
 
 		if length > 0 {
-			fraction = clamp(position/length, 0, 1)
+			fraction = clamp(time/length, 0, 1)
 		}
 
 		// While dragging, the bar follows the mouse instead of the music. The music catches up

--- a/examples/audio/audio.odin
+++ b/examples/audio/audio.odin
@@ -136,6 +136,14 @@ step :: proc() -> bool {
 			k2.set_sound_paused(music_sound, k2.sound_is_playing(music_sound))
 		}
 
+		if k2.key_went_down(.Comma) {
+			k2.set_sound_position(music_sound, k2.get_sound_position(music_sound) - 5)
+		}
+
+		if k2.key_went_down(.Period) {
+			k2.set_sound_position(music_sound, k2.get_sound_position(music_sound) + 5)
+		}
+
 		k2.set_sound_pitch(music_sound, snd_pitch)
 		k2.set_sound_pan(music_sound, snd_pan)
 		k2.set_sound_volume(music_sound, snd_volume)
@@ -169,7 +177,18 @@ step :: proc() -> bool {
 	k2.draw_text("Press Enter to also play a 1 second 440 hz sine wave.", {20, 240}, 40, k2.BLACK)
 
 	when HAS_MUSIC {
-		k2.draw_text("Home plays the music, End stops it, P pauses.", {20, 280}, 40, k2.BLACK)
+		k2.draw_text(
+			"Home plays the music, End stops it, P pauses. Seek with , and .",
+			{20, 280},
+			40,
+			k2.BLACK,
+		)
+		k2.draw_text(
+			fmt.tprintf("Music position: %.1f s", k2.get_sound_position(music_sound)),
+			{20, 320},
+			40,
+			k2.BLACK,
+		)
 	}
 
 	k2.present()

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -553,6 +553,11 @@ set_sound_position :: proc(sound: Sound, seconds: f32)
 // exists.
 get_sound_position :: proc(sound: Sound) -> f32
 
+// How long the whole audio of the sound is, in seconds. Use it together with
+// `get_sound_position` to show how far into a song you are. Returns 0 if the sound no longer
+// exists, or if the length could not be figured out.
+get_sound_length :: proc(sound: Sound) -> f32
+
 // Make a sound loop when it reaches the end.
 //
 // Technical note: This also works for sounds started using `play_audio_stream`, but then it
@@ -1444,6 +1449,10 @@ Audio_Stream_Data :: struct {
 	// When more than zero, `update_audio_stream` throws away this many decoded samples instead
 	// of writing them to the clip. Used to seek in From_File mode, where the decoder cannot jump.
 	seek_discard: int,
+
+	// How many samples the whole file holds, in the same units as `decode_cursor`. Worked out
+	// when the stream is loaded. Zero when the length could not be figured out.
+	total_samples: int,
 
 	// Different from `loop` in `Sound_Object`. This says if the whole stream should loop
 	// when it reaches end-of-file. The `loop` in `Sound_Object` just says to loop the

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -542,20 +542,20 @@ set_sound_pan :: proc(sound: Sound, pan: f32)
 // play twice as fast, which also makes it sound higher pitched.
 set_sound_pitch :: proc(sound: Sound, pitch: f32)
 
-// How far into its audio the sound is, in seconds. Works for sounds from clips and from streams.
+// Move the sound to another spot in its audio. `seconds` is how far into the audio it should
+// continue from, so 0 is the start. Works for sounds from clips and from streams.
 //
-// Warning: For a sound playing a stream that was loaded with `load_audio_stream_from_file`,
-// changing the position may cause a brief hiccup, because the file has to be decoded up to the
-// new position.
-set_sound_position :: proc(sound: Sound, seconds: f32)
+// Warning: For a sound playing a stream that was loaded with `load_audio_stream_from_file`, this
+// may cause a brief hiccup, because the file has to be decoded up to the new spot.
+set_sound_time :: proc(sound: Sound, seconds: f32)
 
-// How far into its audio the sound currently is, in seconds. Returns 0 if the sound no longer
-// exists.
-get_sound_position :: proc(sound: Sound) -> f32
+// How far into its audio the sound currently is, in seconds. This is playback time, so a looping
+// sound goes back to 0 each time it starts over. Returns 0 if the sound no longer exists.
+get_sound_time :: proc(sound: Sound) -> f32
 
-// How long the whole audio of the sound is, in seconds. Use it together with
-// `get_sound_position` to show how far into a song you are. Returns 0 if the sound no longer
-// exists, or if the length could not be figured out.
+// How long the whole audio of the sound is, in seconds. Use it together with `get_sound_time` to
+// show how far into a song you are. Returns 0 if the sound no longer exists, or if the length
+// could not be figured out.
 get_sound_length :: proc(sound: Sound) -> f32
 
 // Make a sound loop when it reaches the end.

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -1542,10 +1542,9 @@ Sound_Object :: struct {
 	pending_seek_seconds: f32,
 	has_pending_seek: bool,
 
-	// The fade used when moving a sound. Multiplied into the volume while mixing. Starts at 1,
-	// which the procedures that create sounds take care of.
-	seek_gain: f32,
-	seek_gain_target: f32,
+	// The fade used when moving a sound: 0 is no fade and 1 is completely faded out. The mixer
+	// raises it while a move is pending and lowers it again once the move is done.
+	seek_fade: f32,
 
 	// The bus this is mixed into. The zero value is the master bus.
 	bus: Audio_Bus,

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -545,8 +545,12 @@ set_sound_pitch :: proc(sound: Sound, pitch: f32)
 // Move the sound to another spot in its audio. `seconds` is how far into the audio it should
 // continue from, so 0 is the start. Works for sounds from clips and from streams.
 //
-// Warning: For a sound playing a stream that was loaded with `load_audio_stream_from_file`, this
-// may cause a brief hiccup, because the file has to be decoded up to the new spot.
+// Warning: Moving a sound that plays a stream loaded using `load_audio_stream_from_file`
+// backwards is slow. Such a file cannot be jumped around in, so it is decoded from the start up
+// to the new spot. That costs roughly two milliseconds for every second of audio it has to get
+// through, so going back to a late part of a long song can stall for a moment. Moving forwards
+// only decodes the part being skipped over. Streams loaded using `load_audio_stream_from_bytes`
+// are quick to move in both directions.
 set_sound_time :: proc(sound: Sound, seconds: f32)
 
 // How far into its audio the sound currently is, in seconds. This is playback time, so a looping

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -545,12 +545,9 @@ set_sound_pitch :: proc(sound: Sound, pitch: f32)
 // Move the sound to another spot in its audio. `seconds` is how far into the audio it should
 // continue from, so 0 is the start. Works for sounds from clips and from streams.
 //
-// Warning: Moving a sound that plays a stream loaded using `load_audio_stream_from_file`
-// backwards is slow. Such a file cannot be jumped around in, so it is decoded from the start up
-// to the new spot. That costs roughly two milliseconds for every second of audio it has to get
-// through, so going back to a late part of a long song can stall for a moment. Moving forwards
-// only decodes the part being skipped over. Streams loaded using `load_audio_stream_from_bytes`
-// are quick to move in both directions.
+// Moving a sound that plays an audio stream costs a few milliseconds, because a bit of audio has
+// to be decoded before there is anything to play at the new spot. It costs the same wherever in
+// the audio you move to. Sounds that play an audio clip move instantly.
 set_sound_time :: proc(sound: Sound, seconds: f32)
 
 // How far into its audio the sound currently is, in seconds. This is playback time, so a looping

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -648,10 +648,14 @@ destroy_audio_stream :: proc(stream: Audio_Stream)
 update_audio_stream :: proc(stream: Audio_Stream)
 
 // Start playing an audio stream. Returns a `Sound`, which you can control using
-// `set_sound_volume`, `stop_sound` etc. The playback continues from wherever the stream last was:
-// It starts over from the beginning only if the stream was just loaded, was stopped using
-// `stop_sound` or has finished playing. A stream can only play one sound at a time: Playing again
-// replaces the previous one.
+// `set_sound_volume`, `stop_sound` etc. The playback starts from wherever the stream last was,
+// which is the beginning if the stream was just loaded, was stopped using `stop_sound` or has
+// finished playing.
+//
+// A stream can only play one sound at a time. If it is already playing then this changes nothing
+// and hands back the sound that is already playing, so the settings you pass in are ignored. Use
+// the `set_sound_xxx` procedures to change how that sound plays, or `stop_sound` before this if
+// you want to start over from the beginning. A paused sound does start playing again.
 //
 // Don't forget to call `update_audio_stream` every frame in order to stream in new data.
 play_audio_stream :: proc(

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -542,6 +542,17 @@ set_sound_pan :: proc(sound: Sound, pan: f32)
 // play twice as fast, which also makes it sound higher pitched.
 set_sound_pitch :: proc(sound: Sound, pitch: f32)
 
+// How far into its audio the sound is, in seconds. Works for sounds from clips and from streams.
+//
+// Warning: For a sound playing a stream that was loaded with `load_audio_stream_from_file`,
+// changing the position may cause a brief hiccup, because the file has to be decoded up to the
+// new position.
+set_sound_position :: proc(sound: Sound, seconds: f32)
+
+// How far into its audio the sound currently is, in seconds. Returns 0 if the sound no longer
+// exists.
+get_sound_position :: proc(sound: Sound) -> f32
+
 // Make a sound loop when it reaches the end.
 //
 // Technical note: This also works for sounds started using `play_audio_stream`, but then it
@@ -1424,6 +1435,15 @@ Audio_Stream_Data :: struct {
 	// Where in the audio clip referred to by `clip` that we have most recently written samples.
 	// Together with the `offset` of the Sound_Object, this forms a circular buffer.
 	buffer_write_pos: int,
+
+	// Absolute position in the file of the samples most recently written into the clip, counted
+	// in individual samples (so stereo advances by 2 per frame). `decode_cursor` minus the
+	// unplayed samples in the clip is the position the listener hears.
+	decode_cursor: int,
+
+	// When more than zero, `update_audio_stream` throws away this many decoded samples instead
+	// of writing them to the clip. Used to seek in From_File mode, where the decoder cannot jump.
+	seek_discard: int,
 
 	// Different from `loop` in `Sound_Object`. This says if the whole stream should loop
 	// when it reaches end-of-file. The `loop` in `Sound_Object` just says to loop the

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -1530,6 +1530,16 @@ Sound_Object :: struct {
 	// Set using `set_sound_paused`. The mixer skips paused sounds.
 	paused: bool,
 
+	// A seek waits for the sound to fade out before it moves, so that moving to another spot in
+	// the audio doesn't click. `pending_seek_seconds` is where it is going once the fade is done.
+	pending_seek_seconds: f32,
+	has_pending_seek: bool,
+
+	// The fade used by seeking. It is multiplied into the volume while mixing, so it has to start
+	// at 1 or the sound would be silent. Set by `play_audio_clip` and `play_audio_stream`.
+	seek_gain: f32,
+	seek_gain_target: f32,
+
 	// The bus this is mixed into. The zero value is the master bus.
 	bus: Audio_Bus,
 

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -542,21 +542,20 @@ set_sound_pan :: proc(sound: Sound, pan: f32)
 // play twice as fast, which also makes it sound higher pitched.
 set_sound_pitch :: proc(sound: Sound, pitch: f32)
 
-// Move the sound to another spot in its audio. `seconds` is how far into the audio it should
-// continue from, so 0 is the start. Works for sounds from clips and from streams.
+// Move the sound to another spot in its audio. `seconds` is measured from the start of the audio,
+// so 0 moves it back to the beginning. Use `get_sound_length` to find out how far you can go.
 //
-// Moving a sound that plays an audio stream costs a few milliseconds, because a bit of audio has
-// to be decoded before there is anything to play at the new spot. It costs the same wherever in
-// the audio you move to. Sounds that play an audio clip move instantly.
+// Moving a sound that plays an audio stream is a bit slower than one that plays a clip, since some
+// audio has to be decoded before it can play. Don't do it every frame while dragging a scrub bar,
+// do it when the player lets go.
 set_sound_time :: proc(sound: Sound, seconds: f32)
 
-// How far into its audio the sound currently is, in seconds. This is playback time, so a looping
-// sound goes back to 0 each time it starts over. Returns 0 if the sound no longer exists.
+// Get how far into its audio the sound currently is, in seconds. A looping sound goes back to 0
+// each time it starts over. Returns 0 if the sound doesn't exist.
 get_sound_time :: proc(sound: Sound) -> f32
 
-// How long the whole audio of the sound is, in seconds. Use it together with `get_sound_time` to
-// show how far into a song you are. Returns 0 if the sound no longer exists, or if the length
-// could not be figured out.
+// Get the length of the sound's audio, in seconds. Use it together with `get_sound_time` to show
+// how far into a song you are. Returns 0 if the sound doesn't exist or if the length is unknown.
 get_sound_length :: proc(sound: Sound) -> f32
 
 // Make a sound loop when it reaches the end.
@@ -653,10 +652,10 @@ update_audio_stream :: proc(stream: Audio_Stream)
 // which is the beginning if the stream was just loaded, was stopped using `stop_sound` or has
 // finished playing.
 //
-// A stream can only play one sound at a time. If it is already playing then this changes nothing
-// and hands back the sound that is already playing, so the settings you pass in are ignored. Use
-// the `set_sound_xxx` procedures to change how that sound plays, or `stop_sound` before this if
-// you want to start over from the beginning. A paused sound does start playing again.
+// A stream can only play one sound at a time. If it is already playing, then this hands back the
+// sound that is already playing and ignores the settings you pass in. Use the `set_sound_xxx`
+// procedures to change how it plays. Use `stop_sound` first if you want to start over from the
+// beginning. A paused sound starts playing again.
 //
 // Don't forget to call `update_audio_stream` every frame in order to stream in new data.
 play_audio_stream :: proc(
@@ -1446,17 +1445,19 @@ Audio_Stream_Data :: struct {
 	// Together with the `offset` of the Sound_Object, this forms a circular buffer.
 	buffer_write_pos: int,
 
-	// Absolute position in the file of the samples most recently written into the clip, counted
-	// in individual samples (so stereo advances by 2 per frame). `decode_cursor` minus the
-	// unplayed samples in the clip is the position the listener hears.
+	// How far into the file the samples we most recently wrote into the clip were, counted the
+	// same way as the clip's samples: In the case of stereo, left and right count as one each.
+	// Take away the samples in the clip that haven't played yet and you get the spot the listener
+	// is hearing, which is what `get_sound_time` does.
 	decode_cursor: int,
 
-	// When more than zero, `update_audio_stream` throws away this many decoded samples instead
-	// of writing them to the clip. Used to seek in From_File mode, where the decoder cannot jump.
+	// When above zero, `update_audio_stream` throws this many decoded samples away instead of
+	// writing them to the clip. Used when moving the stream, since the decoder can only move in
+	// steps of a whole ogg page.
 	seek_discard: int,
 
-	// How many samples the whole file holds, in the same units as `decode_cursor`. Worked out
-	// when the stream is loaded. Zero when the length could not be figured out.
+	// How many samples the whole file has, counted the same way as `decode_cursor`. Worked out
+	// when the stream is loaded. Zero if it could not be worked out.
 	total_samples: int,
 
 	// Different from `loop` in `Sound_Object`. This says if the whole stream should loop
@@ -1535,13 +1536,14 @@ Sound_Object :: struct {
 	// Set using `set_sound_paused`. The mixer skips paused sounds.
 	paused: bool,
 
-	// A seek waits for the sound to fade out before it moves, so that moving to another spot in
-	// the audio doesn't click. `pending_seek_seconds` is where it is going once the fade is done.
+	// `set_sound_time` doesn't move the sound straight away. The mixer fades it out first, then
+	// moves it, then fades it back in, so that landing in a completely different part of the
+	// waveform doesn't click. This is where it is going once the fade out is done.
 	pending_seek_seconds: f32,
 	has_pending_seek: bool,
 
-	// The fade used by seeking. It is multiplied into the volume while mixing, so it has to start
-	// at 1 or the sound would be silent. Set by `play_audio_clip` and `play_audio_stream`.
+	// The fade used when moving a sound. Multiplied into the volume while mixing. Starts at 1,
+	// which the procedures that create sounds take care of.
 	seek_gain: f32,
 	seek_gain_target: f32,
 

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1979,17 +1979,19 @@ set_sound_position :: proc(sound: Sound, seconds: f32) {
 
 	target_frame := int(clamped_seconds * f32(ab.sample_rate))
 
+	// Don't go past the end of the audio when we know where that is.
+	if sd.total_samples > 0 {
+		target_frame = min(target_frame, sd.total_samples / channels)
+	}
+
 	switch sd.mode {
 	case .From_Bytes:
-		total_frames := int(stbv.stream_length_in_samples(sd.vorbis))
-		clamped_frame := clamp(target_frame, 0, total_frames)
-
-		if stbv.seek(sd.vorbis, u32(clamped_frame)) == 0 {
+		if stbv.seek(sd.vorbis, u32(target_frame)) == 0 {
 			log.error("Cannot set sound position, seeking in the audio stream failed.")
 			return
 		}
 
-		sd.decode_cursor = clamped_frame * channels
+		sd.decode_cursor = target_frame * channels
 		sd.seek_discard = 0
 
 	case .From_File:
@@ -2054,6 +2056,12 @@ get_sound_position :: proc(sound: Sound) -> f32 {
 		channels = 2
 	}
 
+	// A seek that is still catching up has emptied the buffer, so there is nothing in there to
+	// measure. Report where the sound is about to be instead.
+	if sd.seek_discard > 0 {
+		return f32((sd.decode_cursor + sd.seek_discard) / channels) / f32(ab.sample_rate)
+	}
+
 	// How many decoded samples are still sitting unplayed in the circular staging buffer.
 	remaining := sd.buffer_write_pos - sound_object.offset
 
@@ -2061,8 +2069,53 @@ get_sound_position :: proc(sound: Sound) -> f32 {
 		remaining = len(ab.samples) - sound_object.offset + sd.buffer_write_pos
 	}
 
-	position := sd.decode_cursor - remaining
+	position := max(sd.decode_cursor - remaining, 0)
 	return f32(position / channels) / f32(ab.sample_rate)
+}
+
+// How long the whole audio of the sound is, in seconds. Use it together with
+// `get_sound_position` to show how far into a song you are. Returns 0 if the sound no longer
+// exists, or if the length could not be figured out.
+get_sound_length :: proc(sound: Sound) -> f32 {
+	sound_object := hm.get(&s.sounds, sound)
+
+	if sound_object == nil {
+		return 0
+	}
+
+	if sound_object.stream == AUDIO_STREAM_NONE {
+		clip := hm.get(&s.audio_clips, sound_object.clip)
+
+		if clip == nil {
+			return 0
+		}
+
+		channels := 1
+		if clip.channels == .Stereo {
+			channels = 2
+		}
+
+		return f32(len(clip.samples) / channels) / f32(clip.sample_rate)
+	}
+
+	sd := hm.get(&s.audio_streams, sound_object.stream)
+
+	if sd == nil {
+		return 0
+	}
+
+	ab := hm.get(&s.audio_clips, sd.clip)
+
+	if ab == nil {
+		return 0
+	}
+
+	channels := 1
+	if ab.channels == .Stereo {
+		channels = 2
+	}
+
+	return f32(sd.total_samples / channels) / f32(ab.sample_rate)
 }
 
 // Make a sound loop when it reaches the end.
@@ -2549,6 +2602,7 @@ load_audio_stream_from_file :: proc(filename: string) -> Audio_Stream {
 		vorbis = vorbis_res,
 		vorbis_buffer = vorbis_buffer,
 		clip = audio_clip_handle,
+		total_samples = _ogg_file_total_frames(f) * int(info.channels),
 		file_read_buf = make([dynamic]u8, s.allocator),
 	}
 
@@ -2647,6 +2701,7 @@ load_audio_stream_from_bytes :: proc(bytes: []u8) -> Audio_Stream {
 		vorbis = vorbis_res,
 		clip = audio_clip_handle,
 		vorbis_buffer = vorbis_buffer,
+		total_samples = int(stbv.stream_length_in_samples(vorbis_res)) * int(info.channels),
 	}
 
 	stream, stream_add_err := hm.add(&s.audio_streams, asd)
@@ -5100,6 +5155,10 @@ Audio_Stream_Data :: struct {
 	// of writing them to the clip. Used to seek in From_File mode, where the decoder cannot jump.
 	seek_discard: int,
 
+	// How many samples the whole file holds, in the same units as `decode_cursor`. Worked out
+	// when the stream is loaded. Zero when the length could not be figured out.
+	total_samples: int,
+
 	// Different from `loop` in `Sound_Object`. This says if the whole stream should loop
 	// when it reaches end-of-file. The `loop` in `Sound_Object` just says to loop the
 	// buffer itself. That's something you always want for a stream: We are continously writing
@@ -5659,6 +5718,93 @@ count_text_lines :: proc "contextless" (text: string) -> int {
 
 assert_initialized :: proc(loc := #caller_location) {
 	assert(s != nil, "Call k2.init before using this Karl2D procedure", loc)
+}
+
+// Works out how many audio frames an ogg file holds by looking at the last page in it.
+//
+// An ogg file is a sequence of pages. Each page starts with "OggS" and stores a granule position:
+// The number of frames that have been decoded once that page has been played. The granule position
+// of the last page is therefore the length of the whole file. We do it this way because the
+// decoder cannot tell us the length of a file we feed to it a small piece at a time.
+//
+// The file position is restored before returning. Returns 0 if no length could be found.
+_ogg_file_total_frames :: proc(f: ^File) -> int {
+	// The biggest an ogg page can be. Reading this many bytes from the end of the file means we
+	// are certain to see the start of the last page.
+	MAX_OGG_PAGE_SIZE :: 65307
+
+	// The smallest an ogg page header can be. Reading fewer bytes than this means there is no
+	// page to find.
+	MIN_OGG_PAGE_SIZE :: 27
+
+	restore_pos, restore_pos_err := file_seek(f, 0, .Current)
+
+	if restore_pos_err != nil {
+		return 0
+	}
+
+	file_size, file_size_err := file_seek(f, 0, .End)
+
+	if file_size_err != nil {
+		return 0
+	}
+
+	read_size := min(int(file_size), MAX_OGG_PAGE_SIZE)
+
+	if read_size < MIN_OGG_PAGE_SIZE {
+		file_seek(f, restore_pos, .Start)
+		return 0
+	}
+
+	if _, seek_err := file_seek(f, file_size - i64(read_size), .Start); seek_err != nil {
+		file_seek(f, restore_pos, .Start)
+		return 0
+	}
+
+	buf := make([]u8, read_size, frame_allocator)
+	filled: int
+
+	// A single read may hand back less than we asked for, so keep going until the buffer is full.
+	for filled < read_size {
+		read, read_err := file_read(f, buf[filled:])
+
+		if read <= 0 || read_err != nil {
+			break
+		}
+
+		filled += read
+	}
+
+	file_seek(f, restore_pos, .Start)
+
+	if filled < MIN_OGG_PAGE_SIZE {
+		return 0
+	}
+
+	buf = buf[:filled]
+
+	// Walk backwards until we find a page that tells us where it ends.
+	for idx := len(buf) - MIN_OGG_PAGE_SIZE; idx >= 0; idx -= 1 {
+		if string(buf[idx:idx + 4]) != "OggS" {
+			continue
+		}
+
+		granule, granule_ok := endian.get_u64(buf[idx + 6:idx + 14], .Little)
+
+		if !granule_ok {
+			continue
+		}
+
+		// All ones means that no packet finishes on this page, so it says nothing about the
+		// length. Keep looking at earlier pages.
+		if granule == max(u64) {
+			continue
+		}
+
+		return int(granule)
+	}
+
+	return 0
 }
 
 // Moves the decode cursor of a stream back to the start. Run when a stream-fed sound is stopped

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1928,12 +1928,12 @@ set_sound_pitch :: proc(sound: Sound, pitch: f32) {
 	sound_object.target_settings.pitch = max(pitch, 0.01)
 }
 
-// Move the sound to another spot in its audio. `seconds` is how far into the audio it should
-// continue from, so 0 is the start. Works for sounds from clips and from streams.
+// Move the sound to another spot in its audio. `seconds` is measured from the start of the audio,
+// so 0 moves it back to the beginning. Use `get_sound_length` to find out how far you can go.
 //
-// Moving a sound that plays an audio stream costs a few milliseconds, because a bit of audio has
-// to be decoded before there is anything to play at the new spot. It costs the same wherever in
-// the audio you move to. Sounds that play an audio clip move instantly.
+// Moving a sound that plays an audio stream is a bit slower than one that plays a clip, since some
+// audio has to be decoded before it can play. Don't do it every frame while dragging a scrub bar,
+// do it when the player lets go.
 set_sound_time :: proc(sound: Sound, seconds: f32) {
 	sound_object := hm.get(&s.sounds, sound)
 
@@ -1966,8 +1966,8 @@ set_sound_time :: proc(sound: Sound, seconds: f32) {
 	sound_object.seek_gain_target = 0
 }
 
-// How far into its audio the sound currently is, in seconds. This is playback time, so a looping
-// sound goes back to 0 each time it starts over. Returns 0 if the sound no longer exists.
+// Get how far into its audio the sound currently is, in seconds. A looping sound goes back to 0
+// each time it starts over. Returns 0 if the sound doesn't exist.
 get_sound_time :: proc(sound: Sound) -> f32 {
 	sound_object := hm.get(&s.sounds, sound)
 
@@ -2030,9 +2030,8 @@ get_sound_time :: proc(sound: Sound) -> f32 {
 	return f32(position / channels) / f32(ab.sample_rate)
 }
 
-// How long the whole audio of the sound is, in seconds. Use it together with `get_sound_time` to
-// show how far into a song you are. Returns 0 if the sound no longer exists, or if the length
-// could not be figured out.
+// Get the length of the sound's audio, in seconds. Use it together with `get_sound_time` to show
+// how far into a song you are. Returns 0 if the sound doesn't exist or if the length is unknown.
 get_sound_length :: proc(sound: Sound) -> f32 {
 	sound_object := hm.get(&s.sounds, sound)
 
@@ -2910,10 +2909,10 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 // which is the beginning if the stream was just loaded, was stopped using `stop_sound` or has
 // finished playing.
 //
-// A stream can only play one sound at a time. If it is already playing then this changes nothing
-// and hands back the sound that is already playing, so the settings you pass in are ignored. Use
-// the `set_sound_xxx` procedures to change how that sound plays, or `stop_sound` before this if
-// you want to start over from the beginning. A paused sound does start playing again.
+// A stream can only play one sound at a time. If it is already playing, then this hands back the
+// sound that is already playing and ignores the settings you pass in. Use the `set_sound_xxx`
+// procedures to change how it plays. Use `stop_sound` first if you want to start over from the
+// beginning. A paused sound starts playing again.
 //
 // Don't forget to call `update_audio_stream` every frame in order to stream in new data.
 play_audio_stream :: proc(
@@ -5156,17 +5155,19 @@ Audio_Stream_Data :: struct {
 	// Together with the `offset` of the Sound_Object, this forms a circular buffer.
 	buffer_write_pos: int,
 
-	// Absolute position in the file of the samples most recently written into the clip, counted
-	// in individual samples (so stereo advances by 2 per frame). `decode_cursor` minus the
-	// unplayed samples in the clip is the position the listener hears.
+	// How far into the file the samples we most recently wrote into the clip were, counted the
+	// same way as the clip's samples: In the case of stereo, left and right count as one each.
+	// Take away the samples in the clip that haven't played yet and you get the spot the listener
+	// is hearing, which is what `get_sound_time` does.
 	decode_cursor: int,
 
-	// When more than zero, `update_audio_stream` throws away this many decoded samples instead
-	// of writing them to the clip. Used to seek in From_File mode, where the decoder cannot jump.
+	// When above zero, `update_audio_stream` throws this many decoded samples away instead of
+	// writing them to the clip. Used when moving the stream, since the decoder can only move in
+	// steps of a whole ogg page.
 	seek_discard: int,
 
-	// How many samples the whole file holds, in the same units as `decode_cursor`. Worked out
-	// when the stream is loaded. Zero when the length could not be figured out.
+	// How many samples the whole file has, counted the same way as `decode_cursor`. Worked out
+	// when the stream is loaded. Zero if it could not be worked out.
 	total_samples: int,
 
 	// Different from `loop` in `Sound_Object`. This says if the whole stream should loop
@@ -5245,13 +5246,14 @@ Sound_Object :: struct {
 	// Set using `set_sound_paused`. The mixer skips paused sounds.
 	paused: bool,
 
-	// A seek waits for the sound to fade out before it moves, so that moving to another spot in
-	// the audio doesn't click. `pending_seek_seconds` is where it is going once the fade is done.
+	// `set_sound_time` doesn't move the sound straight away. The mixer fades it out first, then
+	// moves it, then fades it back in, so that landing in a completely different part of the
+	// waveform doesn't click. This is where it is going once the fade out is done.
 	pending_seek_seconds: f32,
 	has_pending_seek: bool,
 
-	// The fade used by seeking. It is multiplied into the volume while mixing, so it has to start
-	// at 1 or the sound would be silent. Set by `play_audio_clip` and `play_audio_stream`.
+	// The fade used when moving a sound. Multiplied into the volume while mixing. Starts at 1,
+	// which the procedures that create sounds take care of.
 	seek_gain: f32,
 	seek_gain_target: f32,
 

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1931,8 +1931,12 @@ set_sound_pitch :: proc(sound: Sound, pitch: f32) {
 // Move the sound to another spot in its audio. `seconds` is how far into the audio it should
 // continue from, so 0 is the start. Works for sounds from clips and from streams.
 //
-// Warning: For a sound playing a stream that was loaded with `load_audio_stream_from_file`, this
-// may cause a brief hiccup, because the file has to be decoded up to the new spot.
+// Warning: Moving a sound that plays a stream loaded using `load_audio_stream_from_file`
+// backwards is slow. Such a file cannot be jumped around in, so it is decoded from the start up
+// to the new spot. That costs roughly two milliseconds for every second of audio it has to get
+// through, so going back to a late part of a long song can stall for a moment. Moving forwards
+// only decodes the part being skipped over. Streams loaded using `load_audio_stream_from_bytes`
+// are quick to move in both directions.
 set_sound_time :: proc(sound: Sound, seconds: f32) {
 	sound_object := hm.get(&s.sounds, sound)
 

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -5748,12 +5748,16 @@ assert_initialized :: proc(loc := #caller_location) {
 // We can't ask the decoder to jump, because it only ever sees the small pieces of the file we hand
 // it. But we can seek the file ourselves and tell the decoder to resynchronize: It then looks for
 // an ogg page it trusts, and once it has decoded a frame it can say how far into the audio that
-// page was. So we guess a spot in the file from how far into the audio we want to be, look at
-// where that guess landed, and guess again if we went too far.
+// page was.
 //
-// The guess is only approximate because an ogg file does not spend the same number of bytes on
-// every second of audio. That's why we aim a little before the wanted spot: The samples in between
-// are decoded and thrown away by `update_audio_stream`, which is much cheaper than guessing again.
+// So we look for the right spot in the file. We keep two known points, one before the wanted spot
+// and one after it, and narrow the gap between them. The first couple of tries assume the bytes
+// are spread evenly over the audio, which lands close on most files. A file that spends very
+// different numbers of bytes on different parts of the audio ruins that assumption, so after that
+// we cut the remaining range in half instead, which always gets there.
+//
+// Landing a little before the wanted spot is fine: `update_audio_stream` decodes the bit in
+// between and throws it away, which is quick. Landing after it is no good at all.
 _seek_file_stream :: proc(sd: ^Audio_Stream_Data, target_frame: int) -> int {
 	ab := hm.get(&s.audio_clips, sd.clip)
 
@@ -5778,37 +5782,24 @@ _seek_file_stream :: proc(sd: ^Audio_Stream_Data, target_frame: int) -> int {
 		return -1
 	}
 
-	// How far before the wanted spot to aim.
-	back_off := 2 * ab.sample_rate
+	// Seeks the file to `offset` and lets the decoder find a page from there. Returns the frame the
+	// decoder ends up at, or -1 if no page turned up.
+	resync_at :: proc(sd: ^Audio_Stream_Data, offset: i64) -> int {
+		// Ogg pages are usually 4 to 8 kilobytes, so reading this much normally turns up a page
+		// right away.
+		READ_SIZE :: 8192
 
-	// Ogg pages are usually 4 to 8 kilobytes, so reading this much normally turns up a page right
-	// away.
-	READ_SIZE :: 8192
+		// A page should turn up long before this many reads. This is here so that a file that is
+		// not what we think it is cannot spin forever.
+		MAX_READS :: 64
 
-	// A guess that overshoots costs us another guess. Give up after this many and let the caller
-	// fall back to decoding from the start.
-	MAX_GUESSES :: 8
-
-	// A page should turn up long before this many reads. This is here so that a file that is not
-	// what we think it is cannot spin forever.
-	MAX_READS :: 64
-
-	aim_frame := target_frame
-
-	for _ in 0..<MAX_GUESSES {
-		aim := max(aim_frame - back_off, 0)
-		guess := i64(f64(file_size) * (f64(aim) / f64(total_frames)))
-		guess = clamp(guess, 0, file_size)
-
-		if _, seek_err := file_seek(sd.file, guess, .Start); seek_err != nil {
+		if _, seek_err := file_seek(sd.file, offset, .Start); seek_err != nil {
 			return -1
 		}
 
 		runtime.clear(&sd.file_read_buf)
 		sd.file_read_buf_offset = 0
 		stbv.flush_pushdata(sd.vorbis)
-
-		landed := -1
 
 		for _ in 0..<MAX_READS {
 			decoded_channels: i32
@@ -5829,8 +5820,7 @@ _seek_file_stream :: proc(sd: ^Audio_Stream_Data, target_frame: int) -> int {
 			if samples > 0 {
 				// The decoder has found a page and decoded a frame from it, so it can now say
 				// where in the audio the next frame starts.
-				landed = int(stbv.get_sample_offset(sd.vorbis))
-				break
+				return int(stbv.get_sample_offset(sd.vorbis))
 			}
 
 			if bytes_used == 0 {
@@ -5846,42 +5836,101 @@ _seek_file_stream :: proc(sd: ^Audio_Stream_Data, target_frame: int) -> int {
 				}
 
 				if read <= 0 || read_err != nil {
-					break
+					return -1
 				}
 			}
 		}
 
-		if landed < 0 {
-			// No page turned up here. Try closer to the start of the file.
-			if aim == 0 {
-				return -1
-			}
+		return -1
+	}
 
-			aim_frame = aim / 2
+	// Landing this far before the wanted spot is close enough to stop looking.
+	close_enough := 2 * ab.sample_rate
+
+	// Once the two known points are this close together there is nothing to gain by narrowing
+	// further: What is left decodes in well under a millisecond.
+	SMALL_RANGE :: 64 * 1024
+
+	// Cutting the range in half each time gets anywhere in a file of any size we might see well
+	// inside this many tries.
+	MAX_TRIES :: 40
+
+	// The two points we know: The audio at `lo_byte` starts at `lo_frame`, and the same for `hi`.
+	lo_byte, hi_byte := i64(0), file_size
+	lo_frame, hi_frame := 0, total_frames
+
+	// The best spot found so far, and where in the file it was.
+	best_frame := -1
+	best_byte := i64(0)
+
+	// Where in the file the decoder was left by the most recent try.
+	decoder_byte := i64(-1)
+
+	for try in 0..<MAX_TRIES {
+		if hi_byte - lo_byte <= SMALL_RANGE {
+			break
+		}
+
+		guess: i64
+
+		if try < 2 && hi_frame > lo_frame {
+			// Assume the bytes are spread evenly over the audio between the two known points.
+			aim := clamp(target_frame - close_enough/2, lo_frame, hi_frame)
+			span := f64(hi_byte - lo_byte)
+			part := f64(aim - lo_frame) / f64(hi_frame - lo_frame)
+			guess = lo_byte + i64(span * part)
+		} else {
+			guess = lo_byte + (hi_byte - lo_byte)/2
+		}
+
+		guess = clamp(guess, lo_byte, hi_byte)
+		landed := resync_at(sd, guess)
+		decoder_byte = guess
+
+		if landed < 0 {
+			// No page turned up here, so there is nothing usable this far in. Look earlier.
+			hi_byte = guess
 			continue
 		}
 
-		if landed <= target_frame {
-			// Move the bytes the decoder hasn't used yet to the start of the read buffer, the same
-			// way `update_audio_stream` does, so that it carries on from here.
-			if len(sd.file_read_buf) > 0 {
-				copy(sd.file_read_buf[:], sd.file_read_buf[sd.file_read_buf_offset:])
-				shrink(&sd.file_read_buf, len(sd.file_read_buf) - sd.file_read_buf_offset)
-				sd.file_read_buf_offset = 0
-			}
-
-			return landed
+		if landed > target_frame {
+			hi_byte = guess
+			hi_frame = landed
+			continue
 		}
 
-		// We went past the wanted spot. Aim earlier by however far we overshot.
-		aim_frame = aim - (landed - target_frame)
+		lo_byte = guess
+		lo_frame = landed
 
-		if aim_frame <= 0 {
-			return -1
+		if landed > best_frame {
+			best_frame = landed
+			best_byte = guess
+		}
+
+		if target_frame - landed <= close_enough {
+			break
 		}
 	}
 
-	return -1
+	if best_frame < 0 {
+		return -1
+	}
+
+	// The last try usually is the best spot, since that is when we stop looking. If it isn't then
+	// the decoder is somewhere else and has to be put back.
+	if decoder_byte != best_byte && best_frame != resync_at(sd, best_byte) {
+		return -1
+	}
+
+	// Move the bytes the decoder hasn't used yet to the start of the read buffer, the same way
+	// `update_audio_stream` does, so that it carries on from here.
+	if len(sd.file_read_buf) > 0 {
+		copy(sd.file_read_buf[:], sd.file_read_buf[sd.file_read_buf_offset:])
+		shrink(&sd.file_read_buf, len(sd.file_read_buf) - sd.file_read_buf_offset)
+		sd.file_read_buf_offset = 0
+	}
+
+	return best_frame
 }
 
 // Works out how many audio frames an ogg file holds by looking at the last page in it.

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -2022,8 +2022,17 @@ get_sound_time :: proc(sound: Sound) -> f32 {
 		remaining = len(ab.samples) - sound_object.offset + sd.buffer_write_pos
 	}
 
-	position := max(sd.decode_cursor - remaining, 0)
-	return f32(position / channels) / f32(ab.sample_rate)
+	position := sd.decode_cursor - remaining
+
+	// A looping stream starts decoding the beginning of the file again before the listener has
+	// heard the end of it, since the end is still sitting in the buffer. Count back into the
+	// previous time round, so that the last bit of the audio is reported instead of jumping to
+	// the start early.
+	for position < 0 && sd.total_samples > 0 {
+		position += sd.total_samples
+	}
+
+	return f32(max(position, 0) / channels) / f32(ab.sample_rate)
 }
 
 // Get the length of the sound's audio, in seconds. Use it together with `get_sound_time` to show

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -2905,10 +2905,14 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 }
 
 // Start playing an audio stream. Returns a `Sound`, which you can control using
-// `set_sound_volume`, `stop_sound` etc. The playback continues from wherever the stream last was:
-// It starts over from the beginning only if the stream was just loaded, was stopped using
-// `stop_sound` or has finished playing. A stream can only play one sound at a time: Playing again
-// replaces the previous one.
+// `set_sound_volume`, `stop_sound` etc. The playback starts from wherever the stream last was,
+// which is the beginning if the stream was just loaded, was stopped using `stop_sound` or has
+// finished playing.
+//
+// A stream can only play one sound at a time. If it is already playing then this changes nothing
+// and hands back the sound that is already playing, so the settings you pass in are ignored. Use
+// the `set_sound_xxx` procedures to change how that sound plays, or `stop_sound` before this if
+// you want to start over from the beginning. A paused sound does start playing again.
 //
 // Don't forget to call `update_audio_stream` every frame in order to stream in new data.
 play_audio_stream :: proc(
@@ -2931,8 +2935,12 @@ play_audio_stream :: proc(
 		return SOUND_NONE
 	}
 
+	// A stream can only feed one sound, and that sound is already playing, so there is nothing to
+	// start. Hand back the sound that is already going. Unpause it though: This procedure is how
+	// you play a stream, so it should be playing when we are done.
 	if existing := hm.get(&s.sounds, sd.sound); existing != nil {
-		hm.remove(&s.sounds, sd.sound)
+		existing.paused = false
+		return sd.sound
 	}
 
 	sd.loop = loop
@@ -2951,9 +2959,6 @@ play_audio_stream :: proc(
 		stream = stream,
 		seek_gain = 1,
 		seek_gain_target = 1,
-
-		// Start reading at the write head, so that playback continues from the decode cursor.
-		offset = sd.buffer_write_pos,
 
 		// This means that we are looping the buffer itself. We will use this buffer as a circular
 		// buffer, filling it with samples as we stream in more. Thus it needs to be looped to not

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -3329,8 +3329,8 @@ update_audio_mixer :: proc() {
 			seek_seconds := ps.pending_seek_seconds
 			ps.has_pending_seek = false
 
-			// This may remove the sound, so don't touch `ps` afterwards. There is nothing to mix
-			// anyway: The fade has taken the volume all the way down.
+			// This may remove the sound, so `continue` makes us avoid using `ps` after this. There
+			// is nothing to mix anyway: The fade has taken the volume all the way down.
 			_apply_sound_time(ps_handle, seek_seconds)
 			continue
 		}

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1838,8 +1838,6 @@ play_audio_clip :: proc(
 		current_settings = playback_settings,
 		loop = loop,
 		bus = bus,
-		seek_gain = 1,
-		seek_gain_target = 1,
 	}
 
 	sound, add_err := hm.add(&s.sounds, sound_object)
@@ -1953,17 +1951,15 @@ set_sound_time :: proc(sound: Sound, seconds: f32) {
 	// back in. A paused sound isn't being mixed, so there is nothing to fade and nothing that
 	// could click. Jump straight away in that case.
 	if sound_object.paused {
-		// Take the gain down so that the sound fades in when it is unpaused, instead of jumping
-		// straight into the middle of the waveform.
-		sound_object.seek_gain = 0
-		sound_object.seek_gain_target = 1
+		// Fade the sound in when it is unpaused, instead of jumping straight into the middle of
+		// the waveform.
+		sound_object.seek_fade = 1
 		_apply_sound_time(sound, wanted_seconds)
 		return
 	}
 
 	sound_object.pending_seek_seconds = wanted_seconds
 	sound_object.has_pending_seek = true
-	sound_object.seek_gain_target = 0
 }
 
 // Get how far into its audio the sound currently is, in seconds. A looping sound goes back to 0
@@ -2957,8 +2953,6 @@ play_audio_stream :: proc(
 		current_settings = playback_settings,
 		bus = bus,
 		stream = stream,
-		seek_gain = 1,
-		seek_gain_target = 1,
 
 		// This means that we are looping the buffer itself. We will use this buffer as a circular
 		// buffer, filling it with samples as we stream in more. Thus it needs to be looped to not
@@ -3323,17 +3317,17 @@ update_audio_mixer :: proc() {
 		// We move it here, once the sound has faded out. Then we fade it back in. That way moving
 		// to a completely different part of the waveform doesn't click.
 
-		seek_gain_start := clamp(ps.seek_gain, 0, 1)
-		seek_gain_moved := move_towards(ps.seek_gain, ps.seek_gain_target, adjust_parameter_delta)
-		seek_gain_end := clamp(seek_gain_moved, 0, 1)
-		ps.seek_gain = seek_gain_end
+		seek_fade_target: f32 = ps.has_pending_seek ? 1 : 0
+		seek_fade_start := clamp(ps.seek_fade, 0, 1)
+		seek_fade_moved := move_towards(ps.seek_fade, seek_fade_target, adjust_parameter_delta)
+		seek_fade_end := clamp(seek_fade_moved, 0, 1)
+		ps.seek_fade = seek_fade_end
 
-		// Wait for `seek_gain_start` rather than `seek_gain_end`: The chunk that takes the gain
-		// down to zero is the one that holds the fade out, so it still has to be mixed.
-		if ps.has_pending_seek && seek_gain_start == 0 {
+		// Wait for `seek_fade_start` rather than `seek_fade_end`: The chunk that fades the sound
+		// all the way out is the one that holds the fade, so it still has to be mixed.
+		if ps.has_pending_seek && seek_fade_start == 1 {
 			seek_seconds := ps.pending_seek_seconds
 			ps.has_pending_seek = false
-			ps.seek_gain_target = 1
 
 			// This may remove the sound, so don't touch `ps` afterwards. There is nothing to mix
 			// anyway: The fade has taken the volume all the way down.
@@ -3347,10 +3341,10 @@ update_audio_mixer :: proc() {
 		// the last one should use. Then we feed those into the `add`/`add_interpolate` procedures.
 		// It will lerp across the range as it is mixing in the samples.
 
-		volume_start := clamp(settings.volume, 0, 1) * seek_gain_start
+		volume_start := clamp(settings.volume, 0, 1) * (1 - seek_fade_start)
 		volume_end := clamp(move_towards(settings.volume, target_settings.volume, adjust_parameter_delta), 0, 1)
 		settings.volume = volume_end
-		volume_end *= seek_gain_end
+		volume_end *= 1 - seek_fade_end
 
 		if volume_start == volume_end && volume_end == 0 {
 			continue
@@ -5252,10 +5246,9 @@ Sound_Object :: struct {
 	pending_seek_seconds: f32,
 	has_pending_seek: bool,
 
-	// The fade used when moving a sound. Multiplied into the volume while mixing. Starts at 1,
-	// which the procedures that create sounds take care of.
-	seek_gain: f32,
-	seek_gain_target: f32,
+	// The fade used when moving a sound: 0 is no fade and 1 is completely faded out. The mixer
+	// raises it while a move is pending and lowers it again once the move is done.
+	seek_fade: f32,
 
 	// The bus this is mixed into. The zero value is the master bus.
 	bus: Audio_Bus,
@@ -6091,7 +6084,7 @@ _apply_sound_time :: proc(sound: Sound, seconds: f32) {
 		// A short step forwards is cheapest to do by decoding the samples in between and throwing
 		// them away, which is what `seek_discard` makes `update_audio_stream` do.
 		if target >= sd.decode_cursor && target - sd.decode_cursor <= 2 * ab.sample_rate * channels {
-			sd.seek_discard += target - sd.decode_cursor
+			sd.seek_discard = target - sd.decode_cursor
 			break
 		}
 

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1926,6 +1926,145 @@ set_sound_pitch :: proc(sound: Sound, pitch: f32) {
 	sound_object.target_settings.pitch = max(pitch, 0.01)
 }
 
+// How far into its audio the sound is, in seconds. Works for sounds from clips and from streams.
+//
+// Warning: For a sound playing a stream that was loaded with `load_audio_stream_from_file`,
+// changing the position may cause a brief hiccup, because the file has to be decoded up to the
+// new position.
+set_sound_position :: proc(sound: Sound, seconds: f32) {
+	sound_object := hm.get(&s.sounds, sound)
+
+	if sound_object == nil {
+		return
+	}
+
+	clamped_seconds := max(seconds, 0)
+
+	if sound_object.stream == AUDIO_STREAM_NONE {
+		clip := hm.get(&s.audio_clips, sound_object.clip)
+
+		if clip == nil {
+			return
+		}
+
+		channels := 1
+		if clip.channels == .Stereo {
+			channels = 2
+		}
+
+		total_frames := len(clip.samples) / channels
+		target_frame := clamp(int(clamped_seconds * f32(clip.sample_rate)), 0, total_frames)
+
+		sound_object.offset = target_frame * channels
+		sound_object.offset_fraction = 0
+		return
+	}
+
+	sd := hm.get(&s.audio_streams, sound_object.stream)
+
+	if sd == nil {
+		return
+	}
+
+	ab := hm.get(&s.audio_clips, sd.clip)
+
+	if ab == nil {
+		return
+	}
+
+	channels := 1
+	if ab.channels == .Stereo {
+		channels = 2
+	}
+
+	target_frame := int(clamped_seconds * f32(ab.sample_rate))
+
+	switch sd.mode {
+	case .From_Bytes:
+		total_frames := int(stbv.stream_length_in_samples(sd.vorbis))
+		clamped_frame := clamp(target_frame, 0, total_frames)
+
+		if stbv.seek(sd.vorbis, u32(clamped_frame)) == 0 {
+			log.error("Cannot set sound position, seeking in the audio stream failed.")
+			return
+		}
+
+		sd.decode_cursor = clamped_frame * channels
+		sd.seek_discard = 0
+
+	case .From_File:
+		target := target_frame * channels
+
+		if target >= sd.decode_cursor {
+			sd.seek_discard += target - sd.decode_cursor
+		} else {
+			file_seek(sd.file, 0, .Start)
+			runtime.clear(&sd.file_read_buf)
+			sd.file_read_buf_offset = 0
+			stbv.flush_pushdata(sd.vorbis)
+			sd.decode_cursor = 0
+			sd.seek_discard = target
+		}
+	}
+
+	slice.zero(ab.samples)
+	sd.buffer_write_pos = 0
+	sound_object.offset = 0
+	sound_object.offset_fraction = 0
+}
+
+// How far into its audio the sound currently is, in seconds. Returns 0 if the sound no longer
+// exists.
+get_sound_position :: proc(sound: Sound) -> f32 {
+	sound_object := hm.get(&s.sounds, sound)
+
+	if sound_object == nil {
+		return 0
+	}
+
+	if sound_object.stream == AUDIO_STREAM_NONE {
+		clip := hm.get(&s.audio_clips, sound_object.clip)
+
+		if clip == nil {
+			return 0
+		}
+
+		channels := 1
+		if clip.channels == .Stereo {
+			channels = 2
+		}
+
+		return f32(sound_object.offset / channels) / f32(clip.sample_rate)
+	}
+
+	sd := hm.get(&s.audio_streams, sound_object.stream)
+
+	if sd == nil {
+		return 0
+	}
+
+	ab := hm.get(&s.audio_clips, sd.clip)
+
+	if ab == nil {
+		return 0
+	}
+
+	channels := 1
+	if ab.channels == .Stereo {
+		channels = 2
+	}
+
+	// How many decoded samples are still sitting unplayed in the circular staging buffer.
+	remaining := sd.buffer_write_pos - sound_object.offset
+
+	if remaining < 0 {
+		remaining = len(ab.samples) - sound_object.offset + sd.buffer_write_pos
+	}
+
+	position := sd.decode_cursor - remaining
+	return f32(position / channels) / f32(ab.sample_rate)
+}
+
 // Make a sound loop when it reaches the end.
 //
 // Technical note: This also works for sounds started using `play_audio_stream`, but then it
@@ -2655,8 +2794,15 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 					mono: [^]f32 = output[0]
 
 					for samp_idx in 0..<samples {
-						ab.samples[sd.buffer_write_pos] = mono[samp_idx]
-						sd.buffer_write_pos = (sd.buffer_write_pos + 1) % len(ab.samples)
+						// A pending seek throws away decoded samples instead of writing them,
+						// until the decoder has caught up to the target position.
+						if sd.seek_discard > 0 {
+							sd.seek_discard -= 1
+						} else {
+							ab.samples[sd.buffer_write_pos] = mono[samp_idx]
+							sd.buffer_write_pos = (sd.buffer_write_pos + 1) % len(ab.samples)
+						}
+
 						sd.decode_cursor += 1
 					}
 				} else if channels == 2 {
@@ -2664,9 +2810,14 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 					right: [^]f32 = output[1]
 
 					for samp_idx in 0..<samples {
-						ab.samples[sd.buffer_write_pos] = left[samp_idx]
-						ab.samples[sd.buffer_write_pos + 1] = right[samp_idx]
-						sd.buffer_write_pos = (sd.buffer_write_pos + 2) % len(ab.samples)
+						if sd.seek_discard > 0 {
+							sd.seek_discard -= 2
+						} else {
+							ab.samples[sd.buffer_write_pos] = left[samp_idx]
+							ab.samples[sd.buffer_write_pos + 1] = right[samp_idx]
+							sd.buffer_write_pos = (sd.buffer_write_pos + 2) % len(ab.samples)
+						}
+
 						sd.decode_cursor += 2
 					}
 				} else {

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -2969,7 +2969,16 @@ play_audio_stream :: proc(
 		return SOUND_NONE
 	}
 
-	return sd.sound
+	sound := sd.sound
+
+	// Decode into the buffer before returning, so that there is something to play right away. The
+	// mixer may well run before the game gets around to calling `update_audio_stream`. A sound
+	// that reads an empty buffer moves its read position past the write position, which makes the
+	// buffer look full rather than empty, so it would not be refilled until the read position had
+	// wrapped all the way around.
+	update_audio_stream(stream)
+
+	return sound
 }
 
 // Create an audio bus: A group of sounds that are mixed together before they reach the master bus.

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1931,12 +1931,9 @@ set_sound_pitch :: proc(sound: Sound, pitch: f32) {
 // Move the sound to another spot in its audio. `seconds` is how far into the audio it should
 // continue from, so 0 is the start. Works for sounds from clips and from streams.
 //
-// Warning: Moving a sound that plays a stream loaded using `load_audio_stream_from_file`
-// backwards is slow. Such a file cannot be jumped around in, so it is decoded from the start up
-// to the new spot. That costs roughly two milliseconds for every second of audio it has to get
-// through, so going back to a late part of a long song can stall for a moment. Moving forwards
-// only decodes the part being skipped over. Streams loaded using `load_audio_stream_from_bytes`
-// are quick to move in both directions.
+// Moving a sound that plays an audio stream costs a few milliseconds, because a bit of audio has
+// to be decoded before there is anything to play at the new spot. It costs the same wherever in
+// the audio you move to. Sounds that play an audio clip move instantly.
 set_sound_time :: proc(sound: Sound, seconds: f32) {
 	sound_object := hm.get(&s.sounds, sound)
 
@@ -5729,6 +5726,148 @@ assert_initialized :: proc(loc := #caller_location) {
 	assert(s != nil, "Call k2.init before using this Karl2D procedure", loc)
 }
 
+// Moves the decoder of a stream that reads from a file to `target_frame`, or to a little before
+// it. Returns the frame it landed on, or -1 if it could not get there.
+//
+// We can't ask the decoder to jump, because it only ever sees the small pieces of the file we hand
+// it. But we can seek the file ourselves and tell the decoder to resynchronize: It then looks for
+// an ogg page it trusts, and once it has decoded a frame it can say how far into the audio that
+// page was. So we guess a spot in the file from how far into the audio we want to be, look at
+// where that guess landed, and guess again if we went too far.
+//
+// The guess is only approximate because an ogg file does not spend the same number of bytes on
+// every second of audio. That's why we aim a little before the wanted spot: The samples in between
+// are decoded and thrown away by `update_audio_stream`, which is much cheaper than guessing again.
+_seek_file_stream :: proc(sd: ^Audio_Stream_Data, target_frame: int) -> int {
+	ab := hm.get(&s.audio_clips, sd.clip)
+
+	if ab == nil || sd.total_samples <= 0 {
+		return -1
+	}
+
+	channels := 1
+	if ab.channels == .Stereo {
+		channels = 2
+	}
+
+	total_frames := sd.total_samples / channels
+
+	if total_frames <= 0 {
+		return -1
+	}
+
+	file_size, file_size_err := file_seek(sd.file, 0, .End)
+
+	if file_size_err != nil || file_size <= 0 {
+		return -1
+	}
+
+	// How far before the wanted spot to aim.
+	back_off := 2 * ab.sample_rate
+
+	// Ogg pages are usually 4 to 8 kilobytes, so reading this much normally turns up a page right
+	// away.
+	READ_SIZE :: 8192
+
+	// A guess that overshoots costs us another guess. Give up after this many and let the caller
+	// fall back to decoding from the start.
+	MAX_GUESSES :: 8
+
+	// A page should turn up long before this many reads. This is here so that a file that is not
+	// what we think it is cannot spin forever.
+	MAX_READS :: 64
+
+	aim_frame := target_frame
+
+	for _ in 0..<MAX_GUESSES {
+		aim := max(aim_frame - back_off, 0)
+		guess := i64(f64(file_size) * (f64(aim) / f64(total_frames)))
+		guess = clamp(guess, 0, file_size)
+
+		if _, seek_err := file_seek(sd.file, guess, .Start); seek_err != nil {
+			return -1
+		}
+
+		runtime.clear(&sd.file_read_buf)
+		sd.file_read_buf_offset = 0
+		stbv.flush_pushdata(sd.vorbis)
+
+		landed := -1
+
+		for _ in 0..<MAX_READS {
+			decoded_channels: i32
+			samples: i32
+			output: [^]^f32
+
+			bytes_used := stbv.decode_frame_pushdata(
+				sd.vorbis,
+				raw_data(sd.file_read_buf[sd.file_read_buf_offset:]),
+				i32(len(sd.file_read_buf) - sd.file_read_buf_offset),
+				&decoded_channels,
+				&output,
+				&samples,
+			)
+
+			sd.file_read_buf_offset += int(bytes_used)
+
+			if samples > 0 {
+				// The decoder has found a page and decoded a frame from it, so it can now say
+				// where in the audio the next frame starts.
+				landed = int(stbv.get_sample_offset(sd.vorbis))
+				break
+			}
+
+			if bytes_used == 0 {
+				read_buf_size := len(sd.file_read_buf)
+				non_zero_resize(&sd.file_read_buf, read_buf_size + READ_SIZE)
+				read, read_err := file_read(
+					sd.file,
+					sd.file_read_buf[read_buf_size:read_buf_size + READ_SIZE],
+				)
+
+				if read > 0 {
+					shrink(&sd.file_read_buf, read_buf_size + read)
+				}
+
+				if read <= 0 || read_err != nil {
+					break
+				}
+			}
+		}
+
+		if landed < 0 {
+			// No page turned up here. Try closer to the start of the file.
+			if aim == 0 {
+				return -1
+			}
+
+			aim_frame = aim / 2
+			continue
+		}
+
+		if landed <= target_frame {
+			// Move the bytes the decoder hasn't used yet to the start of the read buffer, the same
+			// way `update_audio_stream` does, so that it carries on from here.
+			if len(sd.file_read_buf) > 0 {
+				copy(sd.file_read_buf[:], sd.file_read_buf[sd.file_read_buf_offset:])
+				shrink(&sd.file_read_buf, len(sd.file_read_buf) - sd.file_read_buf_offset)
+				sd.file_read_buf_offset = 0
+			}
+
+			return landed
+		}
+
+		// We went past the wanted spot. Aim earlier by however far we overshot.
+		aim_frame = aim - (landed - target_frame)
+
+		if aim_frame <= 0 {
+			return -1
+		}
+	}
+
+	return -1
+}
+
 // Works out how many audio frames an ogg file holds by looking at the last page in it.
 //
 // An ogg file is a sequence of pages. Each page starts with "OggS" and stores a granule position:
@@ -5884,16 +6023,27 @@ _apply_sound_time :: proc(sound: Sound, seconds: f32) {
 	case .From_File:
 		target := target_frame * channels
 
-		if target >= sd.decode_cursor {
+		// A short step forwards is cheapest to do by decoding the samples in between and throwing
+		// them away, which is what `seek_discard` makes `update_audio_stream` do.
+		if target >= sd.decode_cursor && target - sd.decode_cursor <= 2 * ab.sample_rate * channels {
 			sd.seek_discard += target - sd.decode_cursor
-		} else {
-			file_seek(sd.file, 0, .Start)
-			runtime.clear(&sd.file_read_buf)
-			sd.file_read_buf_offset = 0
-			stbv.flush_pushdata(sd.vorbis)
-			sd.decode_cursor = 0
-			sd.seek_discard = target
+			break
 		}
+
+		// Anything longer is done by seeking the file itself.
+		if landed := _seek_file_stream(sd, target_frame); landed >= 0 {
+			sd.decode_cursor = landed * channels
+			sd.seek_discard = target - sd.decode_cursor
+			break
+		}
+
+		// The file could not be searched, so go back to the start and decode from there.
+		file_seek(sd.file, 0, .Start)
+		runtime.clear(&sd.file_read_buf)
+		sd.file_read_buf_offset = 0
+		stbv.flush_pushdata(sd.vorbis)
+		sd.decode_cursor = 0
+		sd.seek_discard = target
 	}
 
 	slice.zero(ab.samples)

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1838,6 +1838,8 @@ play_audio_clip :: proc(
 		current_settings = playback_settings,
 		loop = loop,
 		bus = bus,
+		seek_gain = 1,
+		seek_gain_target = 1,
 	}
 
 	sound, add_err := hm.add(&s.sounds, sound_object)
@@ -1938,95 +1940,29 @@ set_sound_position :: proc(sound: Sound, seconds: f32) {
 		return
 	}
 
-	clamped_seconds := max(seconds, 0)
+	wanted_seconds := max(seconds, 0)
+	length := get_sound_length(sound)
 
-	// Jumping to another spot makes the waveform jump too, which is heard as a click. Setting the
-	// current volume to zero makes the mixer ramp the volume up from silence instead, the same
-	// way it does when you change the volume of a sound. The volume that was asked for lives in
-	// `target_settings`, so it is not lost.
-	sound_object.current_settings.volume = 0
+	if length > 0 {
+		wanted_seconds = min(wanted_seconds, length)
+	}
 
-	if sound_object.stream == AUDIO_STREAM_NONE {
-		clip := hm.get(&s.audio_clips, sound_object.clip)
-
-		if clip == nil {
-			return
-		}
-
-		channels := 1
-		if clip.channels == .Stereo {
-			channels = 2
-		}
-
-		total_frames := len(clip.samples) / channels
-		target_frame := clamp(int(clamped_seconds * f32(clip.sample_rate)), 0, total_frames)
-
-		sound_object.offset = target_frame * channels
-		sound_object.offset_fraction = 0
+	// Jumping to another spot in the audio makes the waveform jump, which is heard as a click. So
+	// we don't jump right away: The mixer fades the sound out first, then jumps, then fades it
+	// back in. A paused sound isn't being mixed, so there is nothing to fade and nothing that
+	// could click. Jump straight away in that case.
+	if sound_object.paused {
+		// Take the gain down so that the sound fades in when it is unpaused, instead of jumping
+		// straight into the middle of the waveform.
+		sound_object.seek_gain = 0
+		sound_object.seek_gain_target = 1
+		_apply_sound_position(sound, wanted_seconds)
 		return
 	}
 
-	sd := hm.get(&s.audio_streams, sound_object.stream)
-
-	if sd == nil {
-		return
-	}
-
-	ab := hm.get(&s.audio_clips, sd.clip)
-
-	if ab == nil {
-		return
-	}
-
-	channels := 1
-	if ab.channels == .Stereo {
-		channels = 2
-	}
-
-	target_frame := int(clamped_seconds * f32(ab.sample_rate))
-
-	// Don't go past the end of the audio when we know where that is.
-	if sd.total_samples > 0 {
-		target_frame = min(target_frame, sd.total_samples / channels)
-	}
-
-	switch sd.mode {
-	case .From_Bytes:
-		if stbv.seek(sd.vorbis, u32(target_frame)) == 0 {
-			log.error("Cannot set sound position, seeking in the audio stream failed.")
-			return
-		}
-
-		sd.decode_cursor = target_frame * channels
-		sd.seek_discard = 0
-
-	case .From_File:
-		target := target_frame * channels
-
-		if target >= sd.decode_cursor {
-			sd.seek_discard += target - sd.decode_cursor
-		} else {
-			file_seek(sd.file, 0, .Start)
-			runtime.clear(&sd.file_read_buf)
-			sd.file_read_buf_offset = 0
-			stbv.flush_pushdata(sd.vorbis)
-			sd.decode_cursor = 0
-			sd.seek_discard = target
-		}
-	}
-
-	slice.zero(ab.samples)
-	sd.buffer_write_pos = 0
-	sound_object.offset = 0
-	sound_object.offset_fraction = 0
-
-	// Decode into the buffer right away. If we left this to the next `update_audio_stream` then
-	// the mixer would play the silence we just wrote. Worse, once the mixer has moved the read
-	// position past the write position, the buffer looks full rather than empty, so it would not
-	// be refilled until the read position had wrapped all the way around.
-	//
-	// This may remove the sound, so don't touch `sound_object` after it.
-	update_audio_stream(sound_object.stream)
+	sound_object.pending_seek_seconds = wanted_seconds
+	sound_object.has_pending_seek = true
+	sound_object.seek_gain_target = 0
 }
 
 // How far into its audio the sound currently is, in seconds. Returns 0 if the sound no longer
@@ -2036,6 +1972,12 @@ get_sound_position :: proc(sound: Sound) -> f32 {
 
 	if sound_object == nil {
 		return 0
+	}
+
+	// A seek that is still fading out hasn't moved the sound yet, but it is on its way there.
+	// Report where it is going, so that things like a seek bar don't jump backwards for a moment.
+	if sound_object.has_pending_seek {
+		return sound_object.pending_seek_seconds
 	}
 
 	if sound_object.stream == AUDIO_STREAM_NONE {
@@ -3007,6 +2949,8 @@ play_audio_stream :: proc(
 		current_settings = playback_settings,
 		bus = bus,
 		stream = stream,
+		seek_gain = 1,
+		seek_gain_target = 1,
 
 		// Start reading at the write head, so that playback continues from the decode cursor.
 		offset = sd.buffer_write_pos,
@@ -3355,15 +3299,38 @@ update_audio_mixer :: proc() {
 		pitch := settings.pitch
 		adjust_parameter_delta = calc_adjust_parameter_delta(data.sample_rate, pitch)
 
+		// `set_sound_position` doesn't move the sound itself, it just says where the sound should
+		// go. We move it here, once the sound has faded out. Then we fade it back in. That way
+		// moving to a completely different part of the waveform doesn't click.
+
+		seek_gain_start := clamp(ps.seek_gain, 0, 1)
+		seek_gain_moved := move_towards(ps.seek_gain, ps.seek_gain_target, adjust_parameter_delta)
+		seek_gain_end := clamp(seek_gain_moved, 0, 1)
+		ps.seek_gain = seek_gain_end
+
+		// Wait for `seek_gain_start` rather than `seek_gain_end`: The chunk that takes the gain
+		// down to zero is the one that holds the fade out, so it still has to be mixed.
+		if ps.has_pending_seek && seek_gain_start == 0 {
+			seek_seconds := ps.pending_seek_seconds
+			ps.has_pending_seek = false
+			ps.seek_gain_target = 1
+
+			// This may remove the sound, so don't touch `ps` afterwards. There is nothing to mix
+			// anyway: The fade has taken the volume all the way down.
+			_apply_sound_position(ps_handle, seek_seconds)
+			continue
+		}
+
 		// We can't just use the `volume_end` value for the volume. We are going to mix in
 		// `AUDIO_MIX_CHUNK_SIZE` number of samples. We'd still get clicks in the sound if we hopped
 		// to the ending volume. Instead, we calculate what the first sample should use and what
 		// the last one should use. Then we feed those into the `add`/`add_interpolate` procedures.
 		// It will lerp across the range as it is mixing in the samples.
 
-		volume_start := clamp(settings.volume, 0, 1)
+		volume_start := clamp(settings.volume, 0, 1) * seek_gain_start
 		volume_end := clamp(move_towards(settings.volume, target_settings.volume, adjust_parameter_delta), 0, 1)
 		settings.volume = volume_end
+		volume_end *= seek_gain_end
 
 		if volume_start == volume_end && volume_end == 0 {
 			continue
@@ -5249,6 +5216,16 @@ Sound_Object :: struct {
 	// Set using `set_sound_paused`. The mixer skips paused sounds.
 	paused: bool,
 
+	// A seek waits for the sound to fade out before it moves, so that moving to another spot in
+	// the audio doesn't click. `pending_seek_seconds` is where it is going once the fade is done.
+	pending_seek_seconds: f32,
+	has_pending_seek: bool,
+
+	// The fade used by seeking. It is multiplied into the volume while mixing, so it has to start
+	// at 1 or the sound would be silent. Set by `play_audio_clip` and `play_audio_stream`.
+	seek_gain: f32,
+	seek_gain_target: f32,
+
 	// The bus this is mixed into. The zero value is the master bus.
 	bus: Audio_Bus,
 
@@ -5819,6 +5796,100 @@ _ogg_file_total_frames :: proc(f: ^File) -> int {
 	}
 
 	return 0
+}
+
+// Moves a sound to another spot in its audio. Run by the mixer once the sound has faded out, and
+// by `set_sound_position` directly for sounds that are paused.
+_apply_sound_position :: proc(sound: Sound, seconds: f32) {
+	sound_object := hm.get(&s.sounds, sound)
+
+	if sound_object == nil {
+		return
+	}
+
+	clamped_seconds := max(seconds, 0)
+
+	if sound_object.stream == AUDIO_STREAM_NONE {
+		clip := hm.get(&s.audio_clips, sound_object.clip)
+
+		if clip == nil {
+			return
+		}
+
+		channels := 1
+		if clip.channels == .Stereo {
+			channels = 2
+		}
+
+		total_frames := len(clip.samples) / channels
+		target_frame := clamp(int(clamped_seconds * f32(clip.sample_rate)), 0, total_frames)
+
+		sound_object.offset = target_frame * channels
+		sound_object.offset_fraction = 0
+		return
+	}
+
+	sd := hm.get(&s.audio_streams, sound_object.stream)
+
+	if sd == nil {
+		return
+	}
+
+	ab := hm.get(&s.audio_clips, sd.clip)
+
+	if ab == nil {
+		return
+	}
+
+	channels := 1
+	if ab.channels == .Stereo {
+		channels = 2
+	}
+
+	target_frame := int(clamped_seconds * f32(ab.sample_rate))
+
+	// Don't go past the end of the audio when we know where that is.
+	if sd.total_samples > 0 {
+		target_frame = min(target_frame, sd.total_samples / channels)
+	}
+
+	switch sd.mode {
+	case .From_Bytes:
+		if stbv.seek(sd.vorbis, u32(target_frame)) == 0 {
+			log.error("Cannot set sound position, seeking in the audio stream failed.")
+			return
+		}
+
+		sd.decode_cursor = target_frame * channels
+		sd.seek_discard = 0
+
+	case .From_File:
+		target := target_frame * channels
+
+		if target >= sd.decode_cursor {
+			sd.seek_discard += target - sd.decode_cursor
+		} else {
+			file_seek(sd.file, 0, .Start)
+			runtime.clear(&sd.file_read_buf)
+			sd.file_read_buf_offset = 0
+			stbv.flush_pushdata(sd.vorbis)
+			sd.decode_cursor = 0
+			sd.seek_discard = target
+		}
+	}
+
+	slice.zero(ab.samples)
+	sd.buffer_write_pos = 0
+	sound_object.offset = 0
+	sound_object.offset_fraction = 0
+
+	// Decode into the buffer right away. If we left this to the next `update_audio_stream` then
+	// the mixer would play the silence we just wrote. Worse, once the mixer has moved the read
+	// position past the write position, the buffer looks full rather than empty, so it would not
+	// be refilled until the read position had wrapped all the way around.
+	//
+	// This may remove the sound, so don't touch `sound_object` after it.
+	update_audio_stream(sound_object.stream)
 }
 
 // Moves the decode cursor of a stream back to the start. Run when a stream-fed sound is stopped

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -3170,7 +3170,10 @@ update_audio_mixer :: proc() {
 			}
 
 			for samp_idx in 0..<n {
-				t := f32(samp_idx) / f32(n)
+				// Note that this uses `dest_to_write` and not `n`: The ramps run across the whole
+				// chunk. If we run out of samples early then only part of the ramp is used here,
+				// and the caller carries it on from there.
+				t := f32(samp_idx) / f32(dest_to_write)
 				volume := math.lerp(volume_start, volume_end, t)
 				pan := linalg.lerp(pan_start, pan_end, t)
 
@@ -3188,7 +3191,10 @@ update_audio_mixer :: proc() {
 			}
 
 			for samp_idx in 0..<n {
-				t := f32(samp_idx) / f32(n)
+				// Note that this uses `dest_to_write` and not `n`: The ramps run across the whole
+				// chunk. If we run out of samples early then only part of the ramp is used here,
+				// and the caller carries it on from there.
+				t := f32(samp_idx) / f32(dest_to_write)
 				volume := math.lerp(volume_start, volume_end, t)
 				pan := linalg.lerp(pan_start, pan_end, t)
 
@@ -3415,19 +3421,27 @@ update_audio_mixer :: proc() {
 
 				// The sound looped. Make sure to mix in the remaining samples from the start of the
 				// sound!
-				overflow := AUDIO_MIX_CHUNK_SIZE - num_mixed
+				mixed_before_loop := num_mixed
+				overflow := AUDIO_MIX_CHUNK_SIZE - mixed_before_loop
+
+				// Carry the volume and pan ramps on from where the first part of the chunk got to.
+				// Starting them over would jump the volume back up in the middle of the chunk,
+				// which is heard as a click.
+				split := f32(mixed_before_loop) / f32(AUDIO_MIX_CHUNK_SIZE)
+				volume_split := math.lerp(volume_start, volume_end, split)
+				pan_stereo_split := linalg.lerp(pan_stereo_start, pan_stereo_end, split)
 
 				num_mixed = audio_mix(
-					dest[num_mixed:],
+					dest[mixed_before_loop:],
 					data.samples[ps.offset:],
 					data.channels,
 					interpolate,
 					source_dest_ratio,
 					overflow,
 					ps.offset_fraction,
-					volume_start,
+					volume_split,
 					volume_end,
-					pan_stereo_start,
+					pan_stereo_split,
 					pan_stereo_end,
 				)
 				

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -2631,6 +2631,11 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 							}
 
 							stbv.flush_pushdata(sd.vorbis)
+							sd.decode_cursor = 0
+
+							// A discard larger than the file would otherwise spin forever.
+							sd.seek_discard = 0
+
 							continue
 						} else {
 							hm.remove(&s.sounds, sd.sound)
@@ -2652,6 +2657,7 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 					for samp_idx in 0..<samples {
 						ab.samples[sd.buffer_write_pos] = mono[samp_idx]
 						sd.buffer_write_pos = (sd.buffer_write_pos + 1) % len(ab.samples)
+						sd.decode_cursor += 1
 					}
 				} else if channels == 2 {
 					left: [^]f32 = output[0]
@@ -2661,6 +2667,7 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 						ab.samples[sd.buffer_write_pos] = left[samp_idx]
 						ab.samples[sd.buffer_write_pos + 1] = right[samp_idx]
 						sd.buffer_write_pos = (sd.buffer_write_pos + 2) % len(ab.samples)
+						sd.decode_cursor += 2
 					}
 				} else {
 					hm.remove(&s.sounds, sd.sound)
@@ -2692,6 +2699,11 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 			if samples == 0 {
 				if sd.loop {
 					stbv.seek_start(sd.vorbis)
+					sd.decode_cursor = 0
+
+					// A discard larger than the file would otherwise spin forever.
+					sd.seek_discard = 0
+
 					continue
 				} else {
 					// TODO: Stopping here is bad as the samples haven't been mixed in yet. Remove the
@@ -2709,6 +2721,7 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 				for samp_idx in 0..<samples {
 					ab.samples[sd.buffer_write_pos] = mono[samp_idx]
 					sd.buffer_write_pos = (sd.buffer_write_pos + 1) % len(ab.samples)
+					sd.decode_cursor += 1
 				}
 			} else if channels == 2 {
 				left: [^]f32 = output[0]
@@ -2718,6 +2731,7 @@ update_audio_stream :: proc(stream: Audio_Stream) {
 					ab.samples[sd.buffer_write_pos] = left[samp_idx]
 					ab.samples[sd.buffer_write_pos + 1] = right[samp_idx]
 					sd.buffer_write_pos = (sd.buffer_write_pos + 2) % len(ab.samples)
+					sd.decode_cursor += 2
 				}
 			} else {
 				hm.remove(&s.sounds, sd.sound)
@@ -4926,6 +4940,15 @@ Audio_Stream_Data :: struct {
 	// Together with the `offset` of the Sound_Object, this forms a circular buffer.
 	buffer_write_pos: int,
 
+	// Absolute position in the file of the samples most recently written into the clip, counted
+	// in individual samples (so stereo advances by 2 per frame). `decode_cursor` minus the
+	// unplayed samples in the clip is the position the listener hears.
+	decode_cursor: int,
+
+	// When more than zero, `update_audio_stream` throws away this many decoded samples instead
+	// of writing them to the clip. Used to seek in From_File mode, where the decoder cannot jump.
+	seek_discard: int,
+
 	// Different from `loop` in `Sound_Object`. This says if the whole stream should loop
 	// when it reaches end-of-file. The `loop` in `Sound_Object` just says to loop the
 	// buffer itself. That's something you always want for a stream: We are continously writing
@@ -5499,6 +5522,8 @@ _reset_audio_stream :: proc(stream: Audio_Stream) {
 	}
 
 	sd.buffer_write_pos = 0
+	sd.decode_cursor = 0
+	sd.seek_discard = 0
 
 	switch sd.mode {
 	case .From_File:

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1940,6 +1940,12 @@ set_sound_position :: proc(sound: Sound, seconds: f32) {
 
 	clamped_seconds := max(seconds, 0)
 
+	// Jumping to another spot makes the waveform jump too, which is heard as a click. Setting the
+	// current volume to zero makes the mixer ramp the volume up from silence instead, the same
+	// way it does when you change the volume of a sound. The volume that was asked for lives in
+	// `target_settings`, so it is not lost.
+	sound_object.current_settings.volume = 0
+
 	if sound_object.stream == AUDIO_STREAM_NONE {
 		clip := hm.get(&s.audio_clips, sound_object.clip)
 
@@ -2013,6 +2019,14 @@ set_sound_position :: proc(sound: Sound, seconds: f32) {
 	sd.buffer_write_pos = 0
 	sound_object.offset = 0
 	sound_object.offset_fraction = 0
+
+	// Decode into the buffer right away. If we left this to the next `update_audio_stream` then
+	// the mixer would play the silence we just wrote. Worse, once the mixer has moved the read
+	// position past the write position, the buffer looks full rather than empty, so it would not
+	// be refilled until the read position had wrapped all the way around.
+	//
+	// This may remove the sound, so don't touch `sound_object` after it.
+	update_audio_stream(sound_object.stream)
 }
 
 // How far into its audio the sound currently is, in seconds. Returns 0 if the sound no longer

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1928,12 +1928,12 @@ set_sound_pitch :: proc(sound: Sound, pitch: f32) {
 	sound_object.target_settings.pitch = max(pitch, 0.01)
 }
 
-// How far into its audio the sound is, in seconds. Works for sounds from clips and from streams.
+// Move the sound to another spot in its audio. `seconds` is how far into the audio it should
+// continue from, so 0 is the start. Works for sounds from clips and from streams.
 //
-// Warning: For a sound playing a stream that was loaded with `load_audio_stream_from_file`,
-// changing the position may cause a brief hiccup, because the file has to be decoded up to the
-// new position.
-set_sound_position :: proc(sound: Sound, seconds: f32) {
+// Warning: For a sound playing a stream that was loaded with `load_audio_stream_from_file`, this
+// may cause a brief hiccup, because the file has to be decoded up to the new spot.
+set_sound_time :: proc(sound: Sound, seconds: f32) {
 	sound_object := hm.get(&s.sounds, sound)
 
 	if sound_object == nil {
@@ -1956,7 +1956,7 @@ set_sound_position :: proc(sound: Sound, seconds: f32) {
 		// straight into the middle of the waveform.
 		sound_object.seek_gain = 0
 		sound_object.seek_gain_target = 1
-		_apply_sound_position(sound, wanted_seconds)
+		_apply_sound_time(sound, wanted_seconds)
 		return
 	}
 
@@ -1965,9 +1965,9 @@ set_sound_position :: proc(sound: Sound, seconds: f32) {
 	sound_object.seek_gain_target = 0
 }
 
-// How far into its audio the sound currently is, in seconds. Returns 0 if the sound no longer
-// exists.
-get_sound_position :: proc(sound: Sound) -> f32 {
+// How far into its audio the sound currently is, in seconds. This is playback time, so a looping
+// sound goes back to 0 each time it starts over. Returns 0 if the sound no longer exists.
+get_sound_time :: proc(sound: Sound) -> f32 {
 	sound_object := hm.get(&s.sounds, sound)
 
 	if sound_object == nil {
@@ -2029,9 +2029,9 @@ get_sound_position :: proc(sound: Sound) -> f32 {
 	return f32(position / channels) / f32(ab.sample_rate)
 }
 
-// How long the whole audio of the sound is, in seconds. Use it together with
-// `get_sound_position` to show how far into a song you are. Returns 0 if the sound no longer
-// exists, or if the length could not be figured out.
+// How long the whole audio of the sound is, in seconds. Use it together with `get_sound_time` to
+// show how far into a song you are. Returns 0 if the sound no longer exists, or if the length
+// could not be figured out.
 get_sound_length :: proc(sound: Sound) -> f32 {
 	sound_object := hm.get(&s.sounds, sound)
 
@@ -3313,9 +3313,9 @@ update_audio_mixer :: proc() {
 		pitch := settings.pitch
 		adjust_parameter_delta = calc_adjust_parameter_delta(data.sample_rate, pitch)
 
-		// `set_sound_position` doesn't move the sound itself, it just says where the sound should
-		// go. We move it here, once the sound has faded out. Then we fade it back in. That way
-		// moving to a completely different part of the waveform doesn't click.
+		// `set_sound_time` doesn't move the sound itself, it just says where the sound should go.
+		// We move it here, once the sound has faded out. Then we fade it back in. That way moving
+		// to a completely different part of the waveform doesn't click.
 
 		seek_gain_start := clamp(ps.seek_gain, 0, 1)
 		seek_gain_moved := move_towards(ps.seek_gain, ps.seek_gain_target, adjust_parameter_delta)
@@ -3331,7 +3331,7 @@ update_audio_mixer :: proc() {
 
 			// This may remove the sound, so don't touch `ps` afterwards. There is nothing to mix
 			// anyway: The fade has taken the volume all the way down.
-			_apply_sound_position(ps_handle, seek_seconds)
+			_apply_sound_time(ps_handle, seek_seconds)
 			continue
 		}
 
@@ -5813,8 +5813,8 @@ _ogg_file_total_frames :: proc(f: ^File) -> int {
 }
 
 // Moves a sound to another spot in its audio. Run by the mixer once the sound has faded out, and
-// by `set_sound_position` directly for sounds that are paused.
-_apply_sound_position :: proc(sound: Sound, seconds: f32) {
+// by `set_sound_time` directly for sounds that are paused.
+_apply_sound_time :: proc(sound: Sound, seconds: f32) {
 	sound_object := hm.get(&s.sounds, sound)
 
 	if sound_object == nil {


### PR DESCRIPTION
Sounds can now be moved to another spot in their audio. Works the same for sounds played from a clip and from a stream. The audio example got a draggable seek bar.

New API:

```odin
set_sound_time :: proc(sound: Sound, seconds: f32)
get_sound_time :: proc(sound: Sound) -> f32
get_sound_length :: proc(sound: Sound) -> f32
```

Seeking fades the sound out, moves it, then fades it back in, so it does not click. Moving a file stream seeks the file and lets the decoder resynchronize, rather than decoding everything up to the new spot, so it costs a few milliseconds wherever you move to. Stream lengths come from the last ogg page for streams loaded from file, since the decoder cannot report the length of a file it is fed a piece at a time.

Also fixes five things found while testing, all older than this branch:

- On web, everything ran at about twice the speed until the player clicked the page. Browsers play no audio before that, and the backend then reported that nothing was buffered, so the mixer ran once per frame instead of at the rate audio is played. It now counts off what would have been played, using the clock.
- A looping sound clicked when it wrapped round while its volume was ramping. The ramp finished early and then started over in the middle of the mixed chunk.
- A stream was silent for about 0.7 seconds when it started playing. The mixer read the empty buffer before the first `update_audio_stream`, which moved the read position past the write position. That made the buffer look full instead of empty, so it was not refilled until the read position had wrapped all the way around.
- The reported time of a looping stream stopped short of the end and jumped to the start early, since the decoder reads the beginning of the file again while the end of it is still in the buffer waiting to be played.
- Playing a stream that was already playing skipped ahead by however much audio was buffered. It now changes nothing and hands back the sound that is already playing, so the handle you already have stays valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
