### PR TITLE
Unified error handling

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -48,6 +48,16 @@ Write them like a tweet, max 180 characters. Only simple sentences. Only allowed
   	_camera_flip_y(),
   )
   ```
+- The return values get split over several lines too, not just the parameters. When a signature does not fit, `-> (` opens the list, each return value sits on its own line ending with a comma, and `)` closes it with any tag and the opening brace after it. Splitting both lists reads better than keeping the return values packed on the closing line. See `load_audio_stream_from_bytes` in `karl2d.odin`.
+
+  ```
+  load_audio_stream_from_bytes :: proc(
+  	bytes: []u8,
+  ) -> (
+  	_stream: Audio_Stream,
+  	_ok: bool,
+  ) #optional_ok {
+  ```
 - Place `:` and `=` with consistent spacing as in `karl2d.odin`. Opening braces `{` go on the same line as the declaration.
 - Ranges are written without spaces: `for i in 0..<len(pixels)`, not `0 ..< len(pixels)`. Attributes too: `@(private="package")`, not `@(private = "package")`.
 - No single-line `if` bodies: the body goes on its own line, even when it is one statement. (One older example does this; don't copy it.)
@@ -80,6 +90,14 @@ Write them like a tweet, max 180 characters. Only simple sentences. Only allowed
 - It keeps handles assignable and comparable as-is. A `Custom_Cursor` goes straight into a `Cursor` union, so `selected = gauntlet` and `selected == gauntlet` just work. Wrapped in a `Maybe` both sides need unwrapping first, and the comparison needs an explicit `Cursor(...)` conversion. There is nothing to unwrap, so no `x, ok := h.?` before every use, and no temporary to carry the unwrapped value around.
 - Passing a zero handle is safe: procedures that take handles log and carry on rather than misbehaving. They log on every call though, so guard with `!= <TYPE>_NONE` in code that runs each frame.
 - See `examples/cursors/cursors.odin` for how this reads in practice.
+
+### Named return values are for naked returns, and start with `_`
+- A long procedure that can fail in many places ends up repeating `return SOMETHING_NONE, false` a dozen times. Naming the return values turns each of those into a naked `return`, which is shorter and keeps the failure value in one place. `load_audio_clip_from_bytes`, `load_audio_stream_from_file` and `load_static_font_from_bytes` do this.
+- Whether a procedure is long enough to want this is a judgement call, done by feel. Short procedures, and ones with only a couple of failure paths, keep writing the values out: `create_custom_cursor` still returns `CUSTOM_CURSOR_NONE, false`. Do not convert a procedure just to match a neighbour, and do not convert every procedure in a file at once.
+- Name them with a leading underscore: `_clip`, `_stream`, `_font`, `_ok`.
+- The only two things such a procedure does with them is a naked `return` on every failure path and one real `return value, true` at the end. Never assign to `_clip` or `_ok` themselves.
+- That is what the underscore is for. Assigning to a named return part way through is how they turn into bugs: a later naked `return` then hands back whatever was assigned instead of the zero value, and the reader has to track every assignment to know what actually comes out. A name that starts with `_` does not read like a variable you were meant to write to, so it doesn't happen by accident.
+- This works because every `<TYPE>_NONE` is the zero value of its type, so a naked `return` gives back exactly what the explicit `return SOMETHING_NONE, false` did.
 
 ### Avoid `defer`; write the cleanup where it happens
 - `defer` moves work away from the point it runs, so the reader has to reconstruct the order instead of reading top to bottom. Free, release or destroy a thing on the line after it stops being needed.

--- a/agent.md
+++ b/agent.md
@@ -48,15 +48,18 @@ Write them like a tweet, max 180 characters. Only simple sentences. Only allowed
   	_camera_flip_y(),
   )
   ```
-- The return values get split over several lines too, not just the parameters. When a signature does not fit, `-> (` opens the list, each return value sits on its own line ending with a comma, and `)` closes it with any tag and the opening brace after it. Splitting both lists reads better than keeping the return values packed on the closing line. See `load_audio_stream_from_bytes` in `karl2d.odin`.
+- The return values get split over several lines too, not just the parameters. When a signature does not fit, `-> (` opens the list, each return value sits on its own line ending with a comma, and `)` closes it with any tag and the opening brace after it. Splitting both lists reads better than keeping the return values packed on the closing line. This is only about where the line breaks go: it says nothing about naming the return values, which is a separate decision covered further down. See `create_texture` in `render_backend_d3d11.odin`.
 
   ```
-  load_audio_stream_from_bytes :: proc(
-  	bytes: []u8,
+  create_texture :: proc(
+  	width: int,
+  	height: int,
+  	format: Pixel_Format,
+  	data: rawptr,
   ) -> (
-  	_stream: Audio_Stream,
-  	_ok: bool,
-  ) #optional_ok {
+  	Texture_Handle,
+  	bool,
+  ) {
   ```
 - Place `:` and `=` with consistent spacing as in `karl2d.odin`. Opening braces `{` go on the same line as the declaration.
 - Ranges are written without spaces: `for i in 0..<len(pixels)`, not `0 ..< len(pixels)`. Attributes too: `@(private="package")`, not `@(private = "package")`.

--- a/examples/cursors/cursors.odin
+++ b/examples/cursors/cursors.odin
@@ -20,7 +20,14 @@ main :: proc() {
 }
 
 create_custom_cursor :: proc(image_data: []u8, hotspot: [2]int) -> k2.Custom_Cursor {
-	image := k2.load_image_from_bytes(image_data)
+	// The second return value says if the image loaded. There is nothing to make a cursor from if
+	// it didn't, and the code below already knows what to do with CUSTOM_CURSOR_NONE.
+	image, image_ok := k2.load_image_from_bytes(image_data)
+
+	if !image_ok {
+		return k2.CUSTOM_CURSOR_NONE
+	}
+
 	custom_cursor := k2.create_custom_cursor(image, hotspot)
 	k2.destroy_image(image)
 	return custom_cursor

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -428,19 +428,23 @@ draw_text :: proc(
 
 // Create an empty texture.
 //
-// If the texture cannot be created then `handle` is `TEXTURE_NONE` and the failure is logged.
+// The second return value is `true` if the texture was created correctly. It's optional to handle
+// this error, it will also be logged. In case of failure, the returned `Texture` will still be
+// possible to use, but it won't draw anything.
 create_texture :: proc(
 	width: int,
 	height: int,
 	format: Pixel_Format,
-) -> Texture
+) -> (Texture, bool) #optional_ok
 
 // Load a texture from disk and upload it to the GPU so you can draw it to the screen.
 // Supports PNG, BMP, TGA and baseline PNG. Note that progressive PNG files are not supported!
 //
 // The `options` parameter can be used to specify things things such as premultiplication of alpha.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the texture was loaded correctly. It's optional to handle
+// this error, it will also be logged. In case of failure, the returned `Texture` will still be
+// possible to use, but it won't draw anything.
 load_texture_from_file :: proc(
 	filename: string,
 	options: Load_Texture_Options = {},
@@ -451,7 +455,9 @@ load_texture_from_file :: proc(
 //
 // The `options` parameter can be used to specify things things such as premultiplication of alpha.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the texture was loaded correctly. It's optional to handle
+// this error, it will also be logged. In case of failure, the returned `Texture` will still be
+// possible to use, but it won't draw anything.
 load_texture_from_bytes :: proc(
 	bytes: []u8,
 	options: Load_Texture_Options = {},
@@ -461,26 +467,32 @@ load_texture_from_bytes :: proc(
 // This assumes that there is no header in the data. If your data has a header (you read the data
 // from a file on disk), then please use `load_texture_from_bytes` instead.
 //
-// If the texture cannot be created then `handle` is `TEXTURE_NONE` and the failure is logged.
+// The second return value is `true` if the texture was loaded correctly. It's optional to handle
+// this error, it will also be logged. In case of failure, the returned `Texture` will still be
+// possible to use, but it won't draw anything.
 load_texture_from_bytes_raw :: proc(
 	bytes: []u8,
 	width: int,
 	height: int,
 	format: Pixel_Format,
-) -> Texture
+) -> (Texture, bool) #optional_ok
 
 // Create a GPU texture from an image stored in RAM. There are currently no procedures to manipulate
 // the image. However, you can create an `Image` struct manually and fill out the data as needed.
 //
-// If the texture cannot be created then `handle` is `TEXTURE_NONE` and the failure is logged.
-load_texture_from_image :: proc(image: Image) -> Texture
+// The second return value is `true` if the texture was loaded correctly. It's optional to handle
+// this error, it will also be logged. In case of failure, the returned `Texture` will still be
+// possible to use, but it won't draw anything.
+load_texture_from_image :: proc(image: Image) -> (Texture, bool) #optional_ok
 
 // Load an image from disk into RAM. Supports the same formats as `load_texture_from_file`. The
 // image is always RGBA8 with straight (non-premultiplied) alpha.
 //
 // Use `destroy_image` when you are done with it.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the image was loaded correctly. It's optional to handle
+// this error, it will also be logged. In case of failure, the returned `Image` will be empty: it
+// has no pixels and a width and height of zero.
 load_image_from_file :: proc(filename: string) -> (Image, bool) #optional_ok
 
 // Load an image from a byte slice into RAM, for instance from `#load("my_image.png")`. Supports
@@ -489,7 +501,9 @@ load_image_from_file :: proc(filename: string) -> (Image, bool) #optional_ok
 //
 // Use `destroy_image` when you are done with it.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the image was loaded correctly. It's optional to handle
+// this error, it will also be logged. In case of failure, the returned `Image` will be empty: it
+// has no pixels and a width and height of zero.
 load_image_from_bytes :: proc(bytes: []u8) -> (Image, bool) #optional_ok
 
 // Destroy an image previously loaded using `load_image_from_file` or `load_image_from_bytes`.
@@ -609,7 +623,9 @@ get_num_sounds_playing_clip :: proc(clip: Audio_Clip) -> int
 // Supports mono and stereo WAV files with 8, 16, 24 or 32 bit integer samples, or 32 or 64 bit
 // float samples.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the audio clip was loaded correctly. It's optional to
+// handle this error, it will also be logged. In case of failure, the returned `Audio_Clip` will
+// still be possible to use, but it won't play anything.
 load_audio_clip_from_file :: proc(filename: string) -> (Audio_Clip, bool) #optional_ok
 
 // Load a WAV file from some pre-loaded memory (can be loaded using `#load("sound.wav")`). Returns
@@ -619,7 +635,9 @@ load_audio_clip_from_file :: proc(filename: string) -> (Audio_Clip, bool) #optio
 // float samples. Note that the data should be the entire WAV file, including the header. If your
 // data does not include the header, then please use `load_audio_clip_from_bytes_raw`.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the audio clip was loaded correctly. It's optional to
+// handle this error, it will also be logged. In case of failure, the returned `Audio_Clip` will
+// still be possible to use, but it won't play anything.
 load_audio_clip_from_bytes :: proc(bytes: []u8) -> (Audio_Clip, bool) #optional_ok
 
 // Load an audio clip from some raw audio data. You need to specify the data, format and sample
@@ -627,13 +645,15 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> (Audio_Clip, bool) #optional_
 // header (for example, you read a whole WAV file from disk), then please use
 // `load_audio_clip_from_bytes` instead.
 //
-// If the clip cannot be created then `AUDIO_CLIP_NONE` is returned and the failure is logged.
+// The second return value is `true` if the audio clip was loaded correctly. It's optional to
+// handle this error, it will also be logged. In case of failure, the returned `Audio_Clip` will
+// still be possible to use, but it won't play anything.
 load_audio_clip_from_bytes_raw :: proc(
 	bytes: []u8,
 	format: Raw_Audio_Format,
 	sample_rate: int,
 	channels: Audio_Channels,
-) -> Audio_Clip
+) -> (Audio_Clip, bool) #optional_ok
 
 // Destroy an audio clip previously loaded using `load_audio_clip_from_xxx`. Also stops sounds
 // playing this clip.
@@ -648,7 +668,9 @@ destroy_audio_clip :: proc(clip: Audio_Clip)
 // Audio streams do not stream in data automatically from the disk. You need to call
 // `update_audio_stream` every frame to stream in the new data.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the audio stream was loaded correctly. It's optional to
+// handle this error, it will also be logged. In case of failure, the returned `Audio_Stream` will
+// still be possible to use, but it won't play anything.
 load_audio_stream_from_file :: proc(filename: string) -> (Audio_Stream, bool) #optional_ok
 
 // Load an audio stream from a byte slice that is completely in memory. This makes it possible to
@@ -675,7 +697,9 @@ load_audio_stream_from_file :: proc(filename: string) -> (Audio_Stream, bool) #o
 // in the samples. There is no such procedure for audio streams since the whole idea is to stream an
 // encoded file into memory without having to decode the whole thing first.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the audio stream was loaded correctly. It's optional to
+// handle this error, it will also be logged. In case of failure, the returned `Audio_Stream` will
+// still be possible to use, but it won't play anything.
 load_audio_stream_from_bytes :: proc(bytes: []u8) -> (Audio_Stream, bool) #optional_ok
 
 // Destroy an audio stream previously loaded using `load_audio_stream_from_file` or
@@ -762,8 +786,10 @@ update_audio_mixer :: proc()
 // Create a texture that you can render into. Meaning that you can draw into it instead of drawing
 // onto the screen. Use `set_render_texture` to enable this Render Texture for drawing.
 //
-// If it cannot be created then `texture.handle` is `TEXTURE_NONE` and the failure is logged.
-create_render_texture :: proc(width: int, height: int) -> Render_Texture
+// The second return value is `true` if the render texture was created correctly. It's optional to
+// handle this error, it will also be logged. In case of failure, the returned `Render_Texture`
+// will still be possible to use, but setting it does nothing, so drawing stays where it was.
+create_render_texture :: proc(width: int, height: int) -> (Render_Texture, bool) #optional_ok
 
 // Destroy a Render_Texture previously created using `create_render_texture`.
 destroy_render_texture :: proc(render_texture: Render_Texture)
@@ -852,7 +878,9 @@ rotate :: proc(v: Vec2, angle_radians: f32) -> Vec2
 
 // Like `load_static_font_from_bytes` but reads a file from disk using a specified name.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the font was loaded correctly. It's optional to handle this
+// error, it will also be logged. In case of failure, the returned `Font` will still be possible to
+// use, but text drawn with it uses the default font.
 load_static_font_from_file :: proc(
 	filename: string,
 	font_size: f32,
@@ -864,7 +892,9 @@ load_static_font_from_file :: proc(
 // will be of of the specified `font_size`. If you do not specify a list of `codepoints`, then this
 // procedure defaults to using all codepoints between 32 to 127 (ASCII).
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the font was loaded correctly. It's optional to handle this
+// error, it will also be logged. In case of failure, the returned `Font` will still be possible to
+// use, but text drawn with it uses the default font.
 load_static_font_from_bytes :: proc(
 	data: []byte,
 	font_size: f32,
@@ -874,7 +904,9 @@ load_static_font_from_bytes :: proc(
 
 // Like `load_dynamic_font_from_bytes`, but reads a file from disk using a filename.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the font was loaded correctly. It's optional to handle this
+// error, it will also be logged. In case of failure, the returned `Font` will still be possible to
+// use, but text drawn with it uses the default font.
 load_dynamic_font_from_file :: proc(
 	filename: string,
 	options: Font_Options = {},
@@ -883,7 +915,9 @@ load_dynamic_font_from_file :: proc(
 // Load a TTF font stored in `data` as a dynamic font. This means that an atlas will be dynamically
 // built as you draw characters using this font.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the font was loaded correctly. It's optional to handle this
+// error, it will also be logged. In case of failure, the returned `Font` will still be possible to
+// use, but text drawn with it uses the default font.
 load_dynamic_font_from_bytes :: proc(
 	data: []u8,
 	options: Font_Options = {},
@@ -905,8 +939,10 @@ set_cursor :: proc(cursor: Cursor)
 //
 // The cursor does not need `image` after it is created. You may destroy it.
 //
-// If the cursor can't be created, then an error is logged and `CUSTOM_CURSOR_NONE` is returned.
-create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cursor
+// The second return value is `true` if the cursor was created correctly. It's optional to handle
+// this error, it will also be logged. In case of failure, the returned `Custom_Cursor` will still
+// be possible to use, but setting it leaves the cursor as it is.
+create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> (Custom_Cursor, bool) #optional_ok
 
 // Destroy a cursor previously created using `create_custom_cursor`. If it is the cursor currently
 // on screen then Karl2D will restore the default OS cursor.
@@ -935,7 +971,9 @@ is_cursor_hidden :: proc() -> bool
 // `layout_formats` can in many cases be left default initialized. It is used to specify the format
 // of the vertex shader inputs. By formats this means the format that you pass on the CPU side.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the shader was loaded correctly. It's optional to handle
+// this error, it will also be logged. In case of failure, the returned `Shader` will still be
+// possible to use, but setting it does nothing: drawing carries on with the shader already set.
 load_shader_from_file :: proc(
 	vertex_filename: string,
 	fragment_filename: string,
@@ -945,7 +983,9 @@ load_shader_from_file :: proc(
 // Load a vertex and fragment shader from a block of memory. See `load_shader_from_file` for what
 // `layout_formats` means.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the shader was loaded correctly. It's optional to handle
+// this error, it will also be logged. In case of failure, the returned `Shader` will still be
+// possible to use, but setting it does nothing: drawing carries on with the shader already set.
 load_shader_from_bytes :: proc(
 	vertex_shader_bytes: []byte,
 	fragment_shader_bytes: []byte,

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -638,7 +638,7 @@ load_audio_clip_from_file :: proc(filename: string) -> (Audio_Clip, bool) #optio
 // The second return value is `true` if the audio clip was loaded correctly. It's optional to
 // handle this error, it will also be logged. In case of failure, the returned `Audio_Clip` will
 // still be possible to use, but it won't play anything.
-load_audio_clip_from_bytes :: proc(bytes: []u8) -> (_clip: Audio_Clip, _ok: bool) #optional_ok
+load_audio_clip_from_bytes :: proc(bytes: []u8) -> (Audio_Clip, bool) #optional_ok
 
 // Load an audio clip from some raw audio data. You need to specify the data, format and sample
 // rate of the sound yourself. This assumes that there is no header in the data. If your data has a
@@ -673,10 +673,7 @@ destroy_audio_clip :: proc(clip: Audio_Clip)
 // still be possible to use, but it won't play anything.
 load_audio_stream_from_file :: proc(
 	filename: string,
-) -> (
-	_stream: Audio_Stream,
-	_ok: bool,
-) #optional_ok
+) -> (Audio_Stream, bool) #optional_ok
 
 // Load an audio stream from a byte slice that is completely in memory. This makes it possible to
 // have an encoded audio file in memory and decode it, a small bit a time.
@@ -707,10 +704,7 @@ load_audio_stream_from_file :: proc(
 // still be possible to use, but it won't play anything.
 load_audio_stream_from_bytes :: proc(
 	bytes: []u8,
-) -> (
-	_stream: Audio_Stream,
-	_ok: bool,
-) #optional_ok
+) -> (Audio_Stream, bool) #optional_ok
 
 // Destroy an audio stream previously loaded using `load_audio_stream_from_file` or
 // `load_audio_stream_from_bytes`. This cleans up some internal state and closes file handles.
@@ -910,7 +904,7 @@ load_static_font_from_bytes :: proc(
 	font_size: f32,
 	codepoints: []rune = {},
 	options: Font_Options = {},
-) -> (_font: Font, _ok: bool) #optional_ok
+) -> (Font, bool) #optional_ok
 
 // Like `load_dynamic_font_from_bytes`, but reads a file from disk using a filename.
 //

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -638,7 +638,7 @@ load_audio_clip_from_file :: proc(filename: string) -> (Audio_Clip, bool) #optio
 // The second return value is `true` if the audio clip was loaded correctly. It's optional to
 // handle this error, it will also be logged. In case of failure, the returned `Audio_Clip` will
 // still be possible to use, but it won't play anything.
-load_audio_clip_from_bytes :: proc(bytes: []u8) -> (Audio_Clip, bool) #optional_ok
+load_audio_clip_from_bytes :: proc(bytes: []u8) -> (_clip: Audio_Clip, _ok: bool) #optional_ok
 
 // Load an audio clip from some raw audio data. You need to specify the data, format and sample
 // rate of the sound yourself. This assumes that there is no header in the data. If your data has a
@@ -671,7 +671,12 @@ destroy_audio_clip :: proc(clip: Audio_Clip)
 // The second return value is `true` if the audio stream was loaded correctly. It's optional to
 // handle this error, it will also be logged. In case of failure, the returned `Audio_Stream` will
 // still be possible to use, but it won't play anything.
-load_audio_stream_from_file :: proc(filename: string) -> (Audio_Stream, bool) #optional_ok
+load_audio_stream_from_file :: proc(
+	filename: string,
+) -> (
+	_stream: Audio_Stream,
+	_ok: bool,
+) #optional_ok
 
 // Load an audio stream from a byte slice that is completely in memory. This makes it possible to
 // have an encoded audio file in memory and decode it, a small bit a time.
@@ -700,7 +705,12 @@ load_audio_stream_from_file :: proc(filename: string) -> (Audio_Stream, bool) #o
 // The second return value is `true` if the audio stream was loaded correctly. It's optional to
 // handle this error, it will also be logged. In case of failure, the returned `Audio_Stream` will
 // still be possible to use, but it won't play anything.
-load_audio_stream_from_bytes :: proc(bytes: []u8) -> (Audio_Stream, bool) #optional_ok
+load_audio_stream_from_bytes :: proc(
+	bytes: []u8,
+) -> (
+	_stream: Audio_Stream,
+	_ok: bool,
+) #optional_ok
 
 // Destroy an audio stream previously loaded using `load_audio_stream_from_file` or
 // `load_audio_stream_from_bytes`. This cleans up some internal state and closes file handles.
@@ -900,7 +910,7 @@ load_static_font_from_bytes :: proc(
 	font_size: f32,
 	codepoints: []rune = {},
 	options: Font_Options = {},
-) -> (Font, bool) #optional_ok
+) -> (_font: Font, _ok: bool) #optional_ok
 
 // Like `load_dynamic_font_from_bytes`, but reads a file from disk using a filename.
 //

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -427,43 +427,72 @@ draw_text :: proc(
 //--------------------//
 
 // Create an empty texture.
-create_texture :: proc(width: int, height: int, format: Pixel_Format) -> Texture
+//
+// If the texture cannot be created then `handle` is `TEXTURE_NONE` and the failure is logged.
+create_texture :: proc(
+	width: int,
+	height: int,
+	format: Pixel_Format,
+) -> Texture
 
 // Load a texture from disk and upload it to the GPU so you can draw it to the screen.
 // Supports PNG, BMP, TGA and baseline PNG. Note that progressive PNG files are not supported!
 //
 // The `options` parameter can be used to specify things things such as premultiplication of alpha.
-load_texture_from_file :: proc(filename: string, options: Load_Texture_Options = {}) -> Texture
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_texture_from_file :: proc(
+	filename: string,
+	options: Load_Texture_Options = {},
+) -> (Texture, bool) #optional_ok
 
 // Load a texture from a byte slice and upload it to the GPU so you can draw it to the screen.
 // Supports PNG, BMP, TGA and baseline PNG. Note that progressive PNG files are not supported!
 //
 // The `options` parameter can be used to specify things things such as premultiplication of alpha.
-load_texture_from_bytes :: proc(bytes: []u8, options: Load_Texture_Options = {}) -> Texture
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_texture_from_bytes :: proc(
+	bytes: []u8,
+	options: Load_Texture_Options = {},
+) -> (Texture, bool) #optional_ok
 
 // Load raw texture data. You need to specify the data, size and format of the texture yourself.
 // This assumes that there is no header in the data. If your data has a header (you read the data
 // from a file on disk), then please use `load_texture_from_bytes` instead.
-load_texture_from_bytes_raw :: proc(bytes: []u8, width: int, height: int, format: Pixel_Format) -> Texture
+//
+// If the texture cannot be created then `handle` is `TEXTURE_NONE` and the failure is logged.
+load_texture_from_bytes_raw :: proc(
+	bytes: []u8,
+	width: int,
+	height: int,
+	format: Pixel_Format,
+) -> Texture
 
 // Create a GPU texture from an image stored in RAM. There are currently no procedures to manipulate
 // the image. However, you can create an `Image` struct manually and fill out the data as needed.
+//
+// If the texture cannot be created then `handle` is `TEXTURE_NONE` and the failure is logged.
 load_texture_from_image :: proc(image: Image) -> Texture
 
 // Load an image from disk into RAM. Supports the same formats as `load_texture_from_file`. The
 // image is always RGBA8 with straight (non-premultiplied) alpha.
 //
 // Use `destroy_image` when you are done with it.
-load_image :: proc(filename: string) -> Image
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_image_from_file :: proc(filename: string) -> (Image, bool) #optional_ok
 
 // Load an image from a byte slice into RAM, for instance from `#load("my_image.png")`. Supports
 // the same formats as `load_texture_from_bytes`. The image is always RGBA8 with straight
 // (non-premultiplied) alpha.
 //
 // Use `destroy_image` when you are done with it.
-load_image_from_bytes :: proc(bytes: []u8) -> Image
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_image_from_bytes :: proc(bytes: []u8) -> (Image, bool) #optional_ok
 
-// Destroy an image previously loaded using `load_image` or `load_image_from_bytes`.
+// Destroy an image previously loaded using `load_image_from_file` or `load_image_from_bytes`.
 destroy_image :: proc(img: Image)
 
 // Get a rectangle that spans the whole texture. Coordinates will be (x, y) = (0, 0) and size
@@ -579,7 +608,9 @@ get_num_sounds_playing_clip :: proc(clip: Audio_Clip) -> int
 //
 // Supports mono and stereo WAV files with 8, 16, 24 or 32 bit integer samples, or 32 or 64 bit
 // float samples.
-load_audio_clip_from_file :: proc(filename: string) -> Audio_Clip
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_audio_clip_from_file :: proc(filename: string) -> (Audio_Clip, bool) #optional_ok
 
 // Load a WAV file from some pre-loaded memory (can be loaded using `#load("sound.wav")`). Returns
 // an `Audio_Clip` which can be played using `play_audio_clip`.
@@ -587,12 +618,16 @@ load_audio_clip_from_file :: proc(filename: string) -> Audio_Clip
 // Supports mono and stereo WAV data with 8, 16, 24 or 32 bit integer samples, or 32 or 64 bit
 // float samples. Note that the data should be the entire WAV file, including the header. If your
 // data does not include the header, then please use `load_audio_clip_from_bytes_raw`.
-load_audio_clip_from_bytes :: proc(bytes: []u8) -> Audio_Clip
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_audio_clip_from_bytes :: proc(bytes: []u8) -> (Audio_Clip, bool) #optional_ok
 
 // Load an audio clip from some raw audio data. You need to specify the data, format and sample
 // rate of the sound yourself. This assumes that there is no header in the data. If your data has a
 // header (for example, you read a whole WAV file from disk), then please use
 // `load_audio_clip_from_bytes` instead.
+//
+// If the clip cannot be created then `AUDIO_CLIP_NONE` is returned and the failure is logged.
 load_audio_clip_from_bytes_raw :: proc(
 	bytes: []u8,
 	format: Raw_Audio_Format,
@@ -612,7 +647,9 @@ destroy_audio_clip :: proc(clip: Audio_Clip)
 //
 // Audio streams do not stream in data automatically from the disk. You need to call
 // `update_audio_stream` every frame to stream in the new data.
-load_audio_stream_from_file :: proc(filename: string) -> Audio_Stream
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_audio_stream_from_file :: proc(filename: string) -> (Audio_Stream, bool) #optional_ok
 
 // Load an audio stream from a byte slice that is completely in memory. This makes it possible to
 // have an encoded audio file in memory and decode it, a small bit a time.
@@ -637,7 +674,9 @@ load_audio_stream_from_file :: proc(filename: string) -> Audio_Stream
 // disk. For normal sounds there is a `load_audio_clip_from_bytes_raw` procedure where you just send
 // in the samples. There is no such procedure for audio streams since the whole idea is to stream an
 // encoded file into memory without having to decode the whole thing first.
-load_audio_stream_from_bytes :: proc(bytes: []u8) -> Audio_Stream
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_audio_stream_from_bytes :: proc(bytes: []u8) -> (Audio_Stream, bool) #optional_ok
 
 // Destroy an audio stream previously loaded using `load_audio_stream_from_file` or
 // `load_audio_stream_from_bytes`. This cleans up some internal state and closes file handles.
@@ -722,6 +761,8 @@ update_audio_mixer :: proc()
 
 // Create a texture that you can render into. Meaning that you can draw into it instead of drawing
 // onto the screen. Use `set_render_texture` to enable this Render Texture for drawing.
+//
+// If it cannot be created then `texture.handle` is `TEXTURE_NONE` and the failure is logged.
 create_render_texture :: proc(width: int, height: int) -> Render_Texture
 
 // Destroy a Render_Texture previously created using `create_render_texture`.
@@ -810,24 +851,43 @@ rotate :: proc(v: Vec2, angle_radians: f32) -> Vec2
 //-------//
 
 // Like `load_static_font_from_bytes` but reads a file from disk using a specified name.
-load_static_font_from_file :: proc(filename: string, font_size: f32, codepoints: []rune = {}, options: Font_Options = {}) -> Font
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_static_font_from_file :: proc(
+	filename: string,
+	font_size: f32,
+	codepoints: []rune = {},
+	options: Font_Options = {},
+) -> (Font, bool) #optional_ok
 
 // Load the TTF font contained in `data` and bake it into a texture. The characters in the texture
 // will be of of the specified `font_size`. If you do not specify a list of `codepoints`, then this
 // procedure defaults to using all codepoints between 32 to 127 (ASCII).
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
 load_static_font_from_bytes :: proc(
 	data: []byte,
 	font_size: f32,
 	codepoints: []rune = {},
 	options: Font_Options = {},
-) -> Font
+) -> (Font, bool) #optional_ok
 
 // Like `load_dynamic_font_from_bytes`, but reads a file from disk using a filename.
-load_dynamic_font_from_file :: proc(filename: string, options: Font_Options = {}) -> Font
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_dynamic_font_from_file :: proc(
+	filename: string,
+	options: Font_Options = {},
+) -> (Font, bool) #optional_ok
 
 // Load a TTF font stored in `data` as a dynamic font. This means that an atlas will be dynamically
 // built as you draw characters using this font.
-load_dynamic_font_from_bytes :: proc(data: []u8, options: Font_Options = {}) -> Font
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_dynamic_font_from_bytes :: proc(
+	data: []u8,
+	options: Font_Options = {},
+) -> (Font, bool) #optional_ok
 
 // Destroy a font previously loaded using `load_font_from_file` or `load_font_from_bytes`.
 destroy_font :: proc(font: Font)
@@ -874,19 +934,23 @@ is_cursor_hidden :: proc() -> bool
 //
 // `layout_formats` can in many cases be left default initialized. It is used to specify the format
 // of the vertex shader inputs. By formats this means the format that you pass on the CPU side.
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
 load_shader_from_file :: proc(
 	vertex_filename: string,
 	fragment_filename: string,
 	layout_formats: []Pixel_Format = {}
-) -> Shader
+) -> (Shader, bool) #optional_ok
 
 // Load a vertex and fragment shader from a block of memory. See `load_shader_from_file` for what
 // `layout_formats` means.
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
 load_shader_from_bytes :: proc(
 	vertex_shader_bytes: []byte,
 	fragment_shader_bytes: []byte,
 	layout_formats: []Pixel_Format = {},
-) -> Shader
+) -> (Shader, bool) #optional_ok
 
 // Destroy a shader previously loaded using `load_shader_from_file` or `load_shader_from_bytes`
 destroy_shader :: proc(shader: Shader)

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -157,7 +157,14 @@ init :: proc(
 	// shader for textured drawing and shape drawing. It's just a white box.
 	white_rect: [16*16*4]u8
 	slice.fill(white_rect[:], 255)
-	s.shape_drawing_texture = rb.load_texture(white_rect[:], 16, 16, .RGBA_8_Norm)
+	shape_drawing_texture, shape_drawing_texture_ok := rb.load_texture(
+		white_rect[:],
+		16,
+		16,
+		.RGBA_8_Norm,
+	)
+	log.assertf(shape_drawing_texture_ok, "Failed loading shape drawing texture")
+	s.shape_drawing_texture = shape_drawing_texture
 
 	// The default shader will arrive in a different format depending on backend. GLSL for GL,
 	// HLSL for d3d etc.
@@ -1601,8 +1608,18 @@ draw_text_ex :: proc(font_handle: Font, text: string, pos: Vec2, font_size: f32,
 //--------------------//
 
 // Create an empty texture.
-create_texture :: proc(width: int, height: int, format: Pixel_Format) -> Texture {
-	h := rb.create_texture(width, height, format)
+//
+// If the texture cannot be created then `handle` is `TEXTURE_NONE` and the failure is logged.
+create_texture :: proc(
+	width: int,
+	height: int,
+	format: Pixel_Format,
+) -> Texture {
+	h, h_ok := rb.create_texture(width, height, format)
+
+	if !h_ok {
+		return {}
+	}
 
 	return {
 		handle = h,
@@ -1615,12 +1632,17 @@ create_texture :: proc(width: int, height: int, format: Pixel_Format) -> Texture
 // Supports PNG, BMP, TGA and baseline PNG. Note that progressive PNG files are not supported!
 //
 // The `options` parameter can be used to specify things things such as premultiplication of alpha.
-load_texture_from_file :: proc(filename: string, options: Load_Texture_Options = {}) -> Texture {
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_texture_from_file :: proc(
+	filename: string,
+	options: Load_Texture_Options = {},
+) -> (Texture, bool) #optional_ok {
 	data, data_ok := read_entire_file(filename, frame_allocator)
 
 	if !data_ok {
 		log.errorf("Failed loading texture %s", filename)
-		return {}
+		return {}, false
 	}
 
 	load_options := image.Options {
@@ -1635,17 +1657,23 @@ load_texture_from_file :: proc(filename: string, options: Load_Texture_Options =
 
 	if img_err != nil {
 		log.errorf("Error loading texture '%v': %v", filename, img_err)
-		return {}
+		return {}, false
 	}
 
-	return load_texture_from_bytes_raw(img.pixels.buf[:], img.width, img.height, .RGBA_8_Norm)
+	tex := load_texture_from_bytes_raw(img.pixels.buf[:], img.width, img.height, .RGBA_8_Norm)
+	return tex, tex.handle != TEXTURE_NONE
 }
 
 // Load a texture from a byte slice and upload it to the GPU so you can draw it to the screen.
 // Supports PNG, BMP, TGA and baseline PNG. Note that progressive PNG files are not supported!
 //
 // The `options` parameter can be used to specify things things such as premultiplication of alpha.
-load_texture_from_bytes :: proc(bytes: []u8, options: Load_Texture_Options = {}) -> Texture {
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_texture_from_bytes :: proc(
+	bytes: []u8,
+	options: Load_Texture_Options = {},
+) -> (Texture, bool) #optional_ok {
 	load_options := image.Options {
 		.alpha_add_if_missing,
 	}
@@ -1658,19 +1686,27 @@ load_texture_from_bytes :: proc(bytes: []u8, options: Load_Texture_Options = {})
 
 	if img_err != nil {
 		log.errorf("Error loading texture: %v", img_err)
-		return {}
+		return {}, false
 	}
 
-	return load_texture_from_bytes_raw(img.pixels.buf[:], img.width, img.height, .RGBA_8_Norm)
+	tex := load_texture_from_bytes_raw(img.pixels.buf[:], img.width, img.height, .RGBA_8_Norm)
+	return tex, tex.handle != TEXTURE_NONE
 }
 
 // Load raw texture data. You need to specify the data, size and format of the texture yourself.
 // This assumes that there is no header in the data. If your data has a header (you read the data
 // from a file on disk), then please use `load_texture_from_bytes` instead.
-load_texture_from_bytes_raw :: proc(bytes: []u8, width: int, height: int, format: Pixel_Format) -> Texture {
-	backend_tex := rb.load_texture(bytes[:], width, height, format)
+//
+// If the texture cannot be created then `handle` is `TEXTURE_NONE` and the failure is logged.
+load_texture_from_bytes_raw :: proc(
+	bytes: []u8,
+	width: int,
+	height: int,
+	format: Pixel_Format,
+) -> Texture {
+	backend_tex, backend_tex_ok := rb.load_texture(bytes[:], width, height, format)
 
-	if backend_tex == TEXTURE_NONE {
+	if !backend_tex_ok {
 		return {}
 	}
 
@@ -1683,6 +1719,8 @@ load_texture_from_bytes_raw :: proc(bytes: []u8, width: int, height: int, format
 
 // Create a GPU texture from an image stored in RAM. There are currently no procedures to manipulate
 // the image. However, you can create an `Image` struct manually and fill out the data as needed.
+//
+// If the texture cannot be created then `handle` is `TEXTURE_NONE` and the failure is logged.
 load_texture_from_image :: proc(image: Image) -> Texture {
 	if image.width == 0 || image.height == 0 {
 		log.error("Invalid image: Height or width is zero")
@@ -1694,9 +1732,14 @@ load_texture_from_image :: proc(image: Image) -> Texture {
 		return {}
 	}
 
-	backend_tex := rb.load_texture(slice.reinterpret([]u8, image.pixels[:]), image.width, image.height, .RGBA_8_Norm)
+	backend_tex, backend_tex_ok := rb.load_texture(
+		slice.reinterpret([]u8, image.pixels[:]),
+		image.width,
+		image.height,
+		.RGBA_8_Norm,
+	)
 
-	if backend_tex == TEXTURE_NONE {
+	if !backend_tex_ok {
 		return {}
 	}
 
@@ -1711,12 +1754,14 @@ load_texture_from_image :: proc(image: Image) -> Texture {
 // image is always RGBA8 with straight (non-premultiplied) alpha.
 //
 // Use `destroy_image` when you are done with it.
-load_image :: proc(filename: string) -> Image {
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_image_from_file :: proc(filename: string) -> (Image, bool) #optional_ok {
 	data, data_ok := read_entire_file(filename, frame_allocator)
 
 	if !data_ok {
 		log.errorf("Failed loading image %s", filename)
-		return {}
+		return {}, false
 	}
 
 	return load_image_from_bytes(data)
@@ -1727,7 +1772,9 @@ load_image :: proc(filename: string) -> Image {
 // (non-premultiplied) alpha.
 //
 // Use `destroy_image` when you are done with it.
-load_image_from_bytes :: proc(bytes: []u8) -> Image {
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_image_from_bytes :: proc(bytes: []u8) -> (Image, bool) #optional_ok {
 	img, img_err := image.load_from_bytes(
 		bytes,
 		options = {.alpha_add_if_missing},
@@ -1736,7 +1783,7 @@ load_image_from_bytes :: proc(bytes: []u8) -> Image {
 
 	if img_err != nil {
 		log.errorf("Error loading image: %v", img_err)
-		return {}
+		return {}, false
 	}
 
 	if img.depth != 8 || img.channels != 4 {
@@ -1745,7 +1792,7 @@ load_image_from_bytes :: proc(bytes: []u8) -> Image {
 			img.depth, img.channels,
 		)
 		image.destroy(img, s.frame_allocator)
-		return {}
+		return {}, false
 	}
 
 	pixels := make([]Color, img.width*img.height, s.allocator)
@@ -1758,10 +1805,15 @@ load_image_from_bytes :: proc(bytes: []u8) -> Image {
 	}
 
 	image.destroy(img, s.frame_allocator)
-	return res
+	return res, true
 }
 
-// Destroy an image previously loaded using `load_image` or `load_image_from_bytes`.
+@(deprecated="Use load_image_from_file instead")
+load_image :: proc(filename: string) -> (Image, bool) #optional_ok {
+	return load_image_from_file(filename)
+}
+
+// Destroy an image previously loaded using `load_image_from_file` or `load_image_from_bytes`.
 destroy_image :: proc(img: Image) {
 	delete(img.pixels, s.allocator)
 }
@@ -2160,12 +2212,14 @@ get_num_sounds_playing_clip :: proc(clip: Audio_Clip) -> int {
 //
 // Supports mono and stereo WAV files with 8, 16, 24 or 32 bit integer samples, or 32 or 64 bit
 // float samples.
-load_audio_clip_from_file :: proc(filename: string) -> Audio_Clip {
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_audio_clip_from_file :: proc(filename: string) -> (Audio_Clip, bool) #optional_ok {
 	data, data_ok := read_entire_file(filename, frame_allocator)
 
 	if !data_ok {
 		log.errorf("Failed to load audio clip from file '%v'", filename)
-		return AUDIO_CLIP_NONE
+		return AUDIO_CLIP_NONE, false
 	}
 
 	return load_audio_clip_from_bytes(data)
@@ -2177,16 +2231,18 @@ load_audio_clip_from_file :: proc(filename: string) -> Audio_Clip {
 // Supports mono and stereo WAV data with 8, 16, 24 or 32 bit integer samples, or 32 or 64 bit
 // float samples. Note that the data should be the entire WAV file, including the header. If your
 // data does not include the header, then please use `load_audio_clip_from_bytes_raw`.
-load_audio_clip_from_bytes :: proc(bytes: []u8) -> Audio_Clip {
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_audio_clip_from_bytes :: proc(bytes: []u8) -> (Audio_Clip, bool) #optional_ok {
 	// A WAV file is a RIFF file: A 12 byte header followed by any number of chunks.
 	if len(bytes) < 12 {
 		log.error("Invalid wav file: Too small to contain a RIFF header")
-		return AUDIO_CLIP_NONE
+		return AUDIO_CLIP_NONE, false
 	}
 
 	if string(bytes[:4]) != "RIFF" {
 		log.error("Invalid wav file: No RIFF identifier")
-		return AUDIO_CLIP_NONE
+		return AUDIO_CLIP_NONE, false
 	}
 
 	// This size can only fail to read if there are less than four bytes left, which the check above
@@ -2195,7 +2251,7 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> Audio_Clip {
 
 	if string(bytes[8:12]) != "WAVE" {
 		log.error("Invalid wav file: Not WAVE format")
-		return AUDIO_CLIP_NONE
+		return AUDIO_CLIP_NONE, false
 	}
 
 	// `riff_size` counts everything after itself. Some programs write a size that doesn't match the
@@ -2247,7 +2303,7 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> Audio_Clip {
 			//	bits_per_sample: u16
 			if len(content) < 16 {
 				log.errorf("Invalid wav fmt chunk: Size is %v, expected at least 16", len(content))
-				return AUDIO_CLIP_NONE
+				return AUDIO_CLIP_NONE, false
 			}
 
 			audio_format, _ := endian.get_u16(content[0:2], .Little)
@@ -2264,7 +2320,7 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> Audio_Clip {
 				if len(content) < 26 {
 					log.errorf("Invalid wav fmt chunk: Size is %v, too small for an extensible " +
 						"sub format", len(content))
-					return AUDIO_CLIP_NONE
+					return AUDIO_CLIP_NONE, false
 				}
 
 				audio_format, _ = endian.get_u16(content[24:26], .Little)
@@ -2272,7 +2328,7 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> Audio_Clip {
 
 			if fmt_sample_rate == 0 {
 				log.error("Invalid wav fmt chunk: Sample rate is zero")
-				return AUDIO_CLIP_NONE
+				return AUDIO_CLIP_NONE, false
 			}
 
 			switch num_channels {
@@ -2282,7 +2338,7 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> Audio_Clip {
 				channels = .Stereo
 			case:
 				log.errorf("Unsupported number of channels in wav fmt chunk: %v", num_channels)
-				return AUDIO_CLIP_NONE
+				return AUDIO_CLIP_NONE, false
 			}
 
 			switch audio_format {
@@ -2298,7 +2354,7 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> Audio_Clip {
 					format = .Integer32
 				case:
 					log.errorf("Unsupported bits per sample in wav fmt chunk: %v", bits_per_sample)
-					return AUDIO_CLIP_NONE
+					return AUDIO_CLIP_NONE, false
 				}
 
 			case WAV_FORMAT_FLOAT:
@@ -2312,12 +2368,12 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> Audio_Clip {
 						"Unsupported bits per sample in float wav fmt chunk: %v",
 						bits_per_sample,
 					)
-					return AUDIO_CLIP_NONE
+					return AUDIO_CLIP_NONE, false
 				}
 
 			case:
 				log.errorf("Unsupported format in wav fmt chunk: %v", audio_format)
-				return AUDIO_CLIP_NONE
+				return AUDIO_CLIP_NONE, false
 			}
 
 			sample_rate = int(fmt_sample_rate)
@@ -2340,21 +2396,24 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> Audio_Clip {
 
 	if !has_fmt {
 		log.error("Invalid wav file: No fmt chunk")
-		return AUDIO_CLIP_NONE
+		return AUDIO_CLIP_NONE, false
 	}
 
 	if !has_data {
 		log.error("Invalid wav file: No data chunk")
-		return AUDIO_CLIP_NONE
+		return AUDIO_CLIP_NONE, false
 	}
 
-	return load_audio_clip_from_bytes_raw(samples, format, sample_rate, channels)
+	clip := load_audio_clip_from_bytes_raw(samples, format, sample_rate, channels)
+	return clip, clip != AUDIO_CLIP_NONE
 }
 
 // Load an audio clip from some raw audio data. You need to specify the data, format and sample
 // rate of the sound yourself. This assumes that there is no header in the data. If your data has a
 // header (for example, you read a whole WAV file from disk), then please use
 // `load_audio_clip_from_bytes` instead.
+//
+// If the clip cannot be created then `AUDIO_CLIP_NONE` is returned and the failure is logged.
 load_audio_clip_from_bytes_raw :: proc(
 	bytes: []u8,
 	format: Raw_Audio_Format,
@@ -2456,12 +2515,14 @@ destroy_audio_clip :: proc(clip: Audio_Clip)  {
 //
 // Audio streams do not stream in data automatically from the disk. You need to call
 // `update_audio_stream` every frame to stream in the new data.
-load_audio_stream_from_file :: proc(filename: string) -> Audio_Stream {
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_audio_stream_from_file :: proc(filename: string) -> (Audio_Stream, bool) #optional_ok {
 	f, f_err := file_open(filename)
 
 	if f_err != nil {
 		log.errorf("Failed opening file %v. Error: %v", filename, f_err)
-		return AUDIO_STREAM_NONE
+		return AUDIO_STREAM_NONE, false
 	}
 
 	buf := make([dynamic]u8, frame_allocator)
@@ -2475,7 +2536,7 @@ load_audio_stream_from_file :: proc(filename: string) -> Audio_Stream {
 			log.errorf("Failed closing file. Error: %v", close_err)
 		}
 		
-		return AUDIO_STREAM_NONE
+		return AUDIO_STREAM_NONE, false
 	}
 
 	vorbis_buffer := stbv.vorbis_alloc {
@@ -2509,7 +2570,7 @@ load_audio_stream_from_file :: proc(filename: string) -> Audio_Stream {
 				log.errorf("Failed seeking in audio stream file %v. Error: %v", filename, seek_err)
 				file_close(f)
 				free(vorbis_buffer.alloc_buffer, s.allocator)
-				return AUDIO_STREAM_NONE
+				return AUDIO_STREAM_NONE, false
 			}
 
 			break
@@ -2522,14 +2583,14 @@ load_audio_stream_from_file :: proc(filename: string) -> Audio_Stream {
 				log.errorf("Failed reading from audio stream file %v. Error: %v", filename, read_err)
 				file_close(f)
 				free(vorbis_buffer.alloc_buffer, s.allocator)
-				return AUDIO_STREAM_NONE
+				return AUDIO_STREAM_NONE, false
 			}
 
 			if nbytes_read == 0 {
 				log.errorf("Failed to load audio stream. Reached end of file before stream could be loaded.")
 				file_close(f)
 				free(vorbis_buffer.alloc_buffer, s.allocator)
-				return AUDIO_STREAM_NONE
+				return AUDIO_STREAM_NONE, false
 			}
 
 			append(&buf, ..read_buf[:nbytes_read])
@@ -2537,7 +2598,7 @@ load_audio_stream_from_file :: proc(filename: string) -> Audio_Stream {
 			log.errorf("Failed to load audio stream. Error: %v", vorbis_err)
 			file_close(f)
 			free(vorbis_buffer.alloc_buffer, s.allocator)
-			return AUDIO_STREAM_NONE
+			return AUDIO_STREAM_NONE, false
 		}
 	}
 
@@ -2556,7 +2617,7 @@ load_audio_stream_from_file :: proc(filename: string) -> Audio_Stream {
 		}
 				
 		free(vorbis_buffer.alloc_buffer, s.allocator)
-		return AUDIO_STREAM_NONE
+		return AUDIO_STREAM_NONE, false
 	}
 
 	audio_clip := Audio_Clip_Object {
@@ -2576,7 +2637,7 @@ load_audio_stream_from_file :: proc(filename: string) -> Audio_Stream {
 
 		delete(audio_clip.samples, s.allocator)
 		free(vorbis_buffer.alloc_buffer, s.allocator)
-		return AUDIO_STREAM_NONE
+		return AUDIO_STREAM_NONE, false
 	}
 
 	asd := Audio_Stream_Data {
@@ -2598,10 +2659,10 @@ load_audio_stream_from_file :: proc(filename: string) -> Audio_Stream {
 		delete(audio_clip.samples, s.allocator)
 		hm.remove(&s.audio_clips, audio_clip_handle)
 		free(vorbis_buffer.alloc_buffer, s.allocator)
-		return AUDIO_STREAM_NONE
+		return AUDIO_STREAM_NONE, false
 	}
 
-	return stream
+	return stream, true
 }
 
 // Load an audio stream from a byte slice that is completely in memory. This makes it possible to
@@ -2627,7 +2688,9 @@ load_audio_stream_from_file :: proc(filename: string) -> Audio_Stream {
 // disk. For normal sounds there is a `load_audio_clip_from_bytes_raw` procedure where you just send
 // in the samples. There is no such procedure for audio streams since the whole idea is to stream an
 // encoded file into memory without having to decode the whole thing first.
-load_audio_stream_from_bytes :: proc(bytes: []u8) -> Audio_Stream {
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_audio_stream_from_bytes :: proc(bytes: []u8) -> (Audio_Stream, bool) #optional_ok {
 	vorbis_err: stbv.Error
 
 	vorbis_buffer := stbv.vorbis_alloc {
@@ -2647,7 +2710,7 @@ load_audio_stream_from_bytes :: proc(bytes: []u8) -> Audio_Stream {
 	if vorbis_err != nil {
 		log.errorf("Failed opening audio stream from bytes. Error: %v", vorbis_err)
 		free(vorbis_buffer.alloc_buffer, s.allocator)
-		return AUDIO_STREAM_NONE
+		return AUDIO_STREAM_NONE, false
 	}
 
 	info := stbv.get_info(vorbis_res)
@@ -2660,7 +2723,7 @@ load_audio_stream_from_bytes :: proc(bytes: []u8) -> Audio_Stream {
 	} else{
 		log.errorf("Unsupported number of channels: %v", info.channels)
 		free(vorbis_buffer.alloc_buffer, s.allocator)
-		return AUDIO_STREAM_NONE
+		return AUDIO_STREAM_NONE, false
 	}
 
 	audio_clip := Audio_Clip_Object {
@@ -2675,7 +2738,7 @@ load_audio_stream_from_bytes :: proc(bytes: []u8) -> Audio_Stream {
 		log.errorf("Failed to load audio stream. Error: %v", audio_clip_handle_add_err)
 		delete(audio_clip.samples, s.allocator)
 		free(vorbis_buffer.alloc_buffer, s.allocator)
-		return AUDIO_STREAM_NONE
+		return AUDIO_STREAM_NONE, false
 	}
 
 	asd := Audio_Stream_Data {
@@ -2694,10 +2757,10 @@ load_audio_stream_from_bytes :: proc(bytes: []u8) -> Audio_Stream {
 		delete(audio_clip.samples, s.allocator)
 		hm.remove(&s.audio_clips, audio_clip_handle)
 		free(vorbis_buffer.alloc_buffer, s.allocator)
-		return AUDIO_STREAM_NONE
+		return AUDIO_STREAM_NONE, false
 	}
 
-	return stream
+	return stream, true
 }
 
 // Destroy an audio stream previously loaded using `load_audio_stream_from_file` or
@@ -3583,8 +3646,14 @@ update_audio_mixer :: proc() {
 
 // Create a texture that you can render into. Meaning that you can draw into it instead of drawing
 // onto the screen. Use `set_render_texture` to enable this Render Texture for drawing.
+//
+// If it cannot be created then `texture.handle` is `TEXTURE_NONE` and the failure is logged.
 create_render_texture :: proc(width: int, height: int) -> Render_Texture {
-	texture, render_target := rb.create_render_texture(width, height)
+	texture, render_target, render_texture_ok := rb.create_render_texture(width, height)
+
+	if !render_texture_ok {
+		return {}
+	}
 
 	return {
 		texture = { 
@@ -3822,12 +3891,19 @@ rotate :: proc(v: Vec2, angle_radians: f32) -> Vec2 {
 //-------//
 
 // Like `load_static_font_from_bytes` but reads a file from disk using a specified name.
-load_static_font_from_file :: proc(filename: string, font_size: f32, codepoints: []rune = {}, options: Font_Options = {}) -> Font {
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_static_font_from_file :: proc(
+	filename: string,
+	font_size: f32,
+	codepoints: []rune = {},
+	options: Font_Options = {},
+) -> (Font, bool) #optional_ok {
 	data, data_ok := read_entire_file(filename, s.frame_allocator)
 
 	if !data_ok {
 		log.errorf("Failed loading font %s", filename)
-		return FONT_NONE
+		return FONT_NONE, false
 	}
 
 	return load_static_font_from_bytes(data, font_size, codepoints, options)
@@ -3836,12 +3912,14 @@ load_static_font_from_file :: proc(filename: string, font_size: f32, codepoints:
 // Load the TTF font contained in `data` and bake it into a texture. The characters in the texture
 // will be of of the specified `font_size`. If you do not specify a list of `codepoints`, then this
 // procedure defaults to using all codepoints between 32 to 127 (ASCII).
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
 load_static_font_from_bytes :: proc(
 	data: []byte,
 	font_size: f32,
 	codepoints: []rune = {},
 	options: Font_Options = {},
-) -> Font {
+) -> (Font, bool) #optional_ok {
 	codepoints := codepoints
 	font_info: stbtt.fontinfo
 	font_offset := stbtt.GetFontOffsetForIndex(raw_data(data), 0)
@@ -3849,7 +3927,7 @@ load_static_font_from_bytes :: proc(
 
 	if !init_ok {
 		log.error("Failed loading TTF/TTC font")
-		return FONT_NONE
+		return FONT_NONE, false
 	}
 
 	scale_factor := stbtt.ScaleForPixelHeight(&font_info, font_size)
@@ -3987,7 +4065,7 @@ load_static_font_from_bytes :: proc(
 
 	if !atlas_packed {
 		log.error("Failed packing font atlas")
-		return {}
+		return {}, false
 	}
 
 	atlas := make([]Color, atlas_size*atlas_size, s.frame_allocator)
@@ -4090,16 +4168,21 @@ load_static_font_from_bytes :: proc(
 
 	font_handle := Font(len(s.fonts))
 	append(&s.fonts, font)
-	return font_handle
+	return font_handle, true
 }
 
 // Like `load_dynamic_font_from_bytes`, but reads a file from disk using a filename.
-load_dynamic_font_from_file :: proc(filename: string, options: Font_Options = {}) -> Font {
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_dynamic_font_from_file :: proc(
+	filename: string,
+	options: Font_Options = {},
+) -> (Font, bool) #optional_ok {
 	data, data_ok := read_entire_file(filename, s.frame_allocator)
 
 	if !data_ok {
 		log.errorf("Failed loading font %s", filename)
-		return FONT_NONE
+		return FONT_NONE, false
 	}
 
 	return load_dynamic_font_from_bytes(data, options)
@@ -4107,14 +4190,38 @@ load_dynamic_font_from_file :: proc(filename: string, options: Font_Options = {}
 
 // Load a TTF font stored in `data` as a dynamic font. This means that an atlas will be dynamically
 // built as you draw characters using this font.
-load_dynamic_font_from_bytes :: proc(data: []u8, options: Font_Options = {}) -> Font {
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+load_dynamic_font_from_bytes :: proc(
+	data: []u8,
+	options: Font_Options = {},
+) -> (Font, bool) #optional_ok {
+	font_info: stbtt.fontinfo
+	font_offset := stbtt.GetFontOffsetForIndex(raw_data(data), 0)
+	init_ok := stbtt.InitFont(&font_info, raw_data(data), font_offset)
+
+	if !init_ok {
+		log.error("Failed loading TTF/TTC font")
+		return FONT_NONE, false
+	}
+
 	fontstash_handle := fs.AddFontMem(&s.fs, "", slice.clone(data, s.allocator), false)
 	h := Font(len(s.fonts))
+
+	atlas_texture, atlas_texture_ok := rb.create_texture(
+		FONT_DEFAULT_ATLAS_SIZE,
+		FONT_DEFAULT_ATLAS_SIZE,
+		.RGBA_8_Norm,
+	)
+
+	if !atlas_texture_ok {
+		return FONT_NONE, false
+	}
 
 	data := Font_Data {
 		dynamic_fontstash_handle = fontstash_handle,
 		atlas = {
-			handle = rb.create_texture(FONT_DEFAULT_ATLAS_SIZE, FONT_DEFAULT_ATLAS_SIZE, .RGBA_8_Norm),
+			handle = atlas_texture,
 			width = FONT_DEFAULT_ATLAS_SIZE,
 			height = FONT_DEFAULT_ATLAS_SIZE,
 		},
@@ -4124,16 +4231,19 @@ load_dynamic_font_from_bytes :: proc(data: []u8, options: Font_Options = {}) -> 
 
 	set_texture_filter(data.atlas, options.filter)
 	append(&s.fonts, data)
-	return h
+	return h, true
 }
 
 @(deprecated="Use load_dynamic_font_from_file or load_static_font_from_file.")
-load_font_from_file :: proc(filename: string, options: Font_Options = {}) -> Font {
+load_font_from_file :: proc(
+	filename: string,
+	options: Font_Options = {},
+) -> (Font, bool) #optional_ok {
 	return load_dynamic_font_from_file(filename, options)
 }
 
 @(deprecated="Use load_dynamic_font_from_bytes or load_static_font_from_bytes")
-load_font_from_bytes :: proc(data: []u8, options: Font_Options = {}) -> Font {
+load_font_from_bytes :: proc(data: []u8, options: Font_Options = {}) -> (Font, bool) #optional_ok {
 	return load_dynamic_font_from_bytes(data, options)
 }
 
@@ -4197,7 +4307,13 @@ create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cursor {
 		return {}
 	}
 
-	return pf.create_custom_cursor(image, hotspot)
+	cursor, cursor_ok := pf.create_custom_cursor(image, hotspot)
+
+	if !cursor_ok {
+		return {}
+	}
+
+	return cursor
 }
 
 // Destroy a cursor previously created using `create_custom_cursor`. If it is the cursor currently
@@ -4232,16 +4348,18 @@ is_cursor_hidden :: proc() -> bool {
 //
 // `layout_formats` can in many cases be left default initialized. It is used to specify the format
 // of the vertex shader inputs. By formats this means the format that you pass on the CPU side.
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
 load_shader_from_file :: proc(
 	vertex_filename: string,
 	fragment_filename: string,
 	layout_formats: []Pixel_Format = {}
-) -> Shader {
+) -> (Shader, bool) #optional_ok {
 	vertex_source, vertex_source_ok := read_entire_file(vertex_filename, frame_allocator)
 
 	if !vertex_source_ok {
 		log.errorf("Failed loading shader %s", vertex_filename)
-		return {}
+		return {}, false
 	}
 
 	fragment_source: []byte
@@ -4254,7 +4372,7 @@ load_shader_from_file :: proc(
 
 		if !fragment_source_ok {
 			log.errorf("Failed loading shader %s", fragment_filename)
-			return {}
+			return {}, false
 		}
 	}
 
@@ -4263,21 +4381,22 @@ load_shader_from_file :: proc(
 
 // Load a vertex and fragment shader from a block of memory. See `load_shader_from_file` for what
 // `layout_formats` means.
+//
+// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
 load_shader_from_bytes :: proc(
 	vertex_shader_bytes: []byte,
 	fragment_shader_bytes: []byte,
 	layout_formats: []Pixel_Format = {},
-) -> Shader {
-	handle, desc := rb.load_shader(
+) -> (Shader, bool) #optional_ok {
+	handle, desc, shader_ok := rb.load_shader(
 		vertex_shader_bytes,
 		fragment_shader_bytes,
 		s.frame_allocator,
 		layout_formats,
 	)
 
-	if handle == SHADER_NONE {
-		log.error("Failed loading shader")
-		return {}
+	if !shader_ok {
+		return {}, false
 	}
 
 	constants_size: int
@@ -4349,7 +4468,7 @@ load_shader_from_bytes :: proc(
 	}
 
 	shd.vertex_size = input_offset
-	return shd
+	return shd, true
 }
 
 // Destroy a shader previously loaded using `load_shader_from_file` or `load_shader_from_bytes`

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1620,6 +1620,13 @@ create_texture :: proc(
 	h, h_ok := rb.create_texture(width, height, format)
 
 	if !h_ok {
+		log.errorf(
+			"Failed creating texture with dimensions %v x %v and pixel format %v",
+			width,
+			height,
+			format,
+		)
+		
 		return {}, false
 	}
 

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -3956,7 +3956,7 @@ load_static_font_from_bytes :: proc(
 	font_size: f32,
 	codepoints: []rune = {},
 	options: Font_Options = {},
-) -> (Font, bool) #optional_ok {
+) -> (_font: Font, _ok: bool) #optional_ok {
 	codepoints := codepoints
 	font_info: stbtt.fontinfo
 	font_offset := stbtt.GetFontOffsetForIndex(raw_data(data), 0)
@@ -3964,7 +3964,7 @@ load_static_font_from_bytes :: proc(
 
 	if !init_ok {
 		log.error("Failed loading TTF/TTC font")
-		return FONT_NONE, false
+		return
 	}
 
 	scale_factor := stbtt.ScaleForPixelHeight(&font_info, font_size)
@@ -4102,7 +4102,7 @@ load_static_font_from_bytes :: proc(
 
 	if !atlas_packed {
 		log.error("Failed packing font atlas")
-		return {}, false
+		return
 	}
 
 	atlas := make([]Color, atlas_size*atlas_size, s.frame_allocator)
@@ -4342,18 +4342,18 @@ set_cursor :: proc(cursor: Cursor) {
 create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> (Custom_Cursor, bool) #optional_ok {
 	if image.width == 0 || image.height == 0 {
 		log.error("Invalid cursor image: height or width is zero")
-		return {}, false
+		return CUSTOM_CURSOR_NONE, false
 	}
 
 	if len(image.pixels) != image.width*image.height {
 		log.error("Invalid cursor image: the pixels array is not of size image.width*image.height")
-		return {}, false
+		return CUSTOM_CURSOR_NONE, false
 	}
 
 	cursor, cursor_ok := pf.create_custom_cursor(image, hotspot)
 
 	if !cursor_ok {
-		return {}, false
+		return CUSTOM_CURSOR_NONE, false
 	}
 
 	return cursor, true

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -2536,12 +2536,17 @@ destroy_audio_clip :: proc(clip: Audio_Clip)  {
 // The second return value is `true` if the audio stream was loaded correctly. It's optional to
 // handle this error, it will also be logged. In case of failure, the returned `Audio_Stream` will
 // still be possible to use, but it won't play anything.
-load_audio_stream_from_file :: proc(filename: string) -> (Audio_Stream, bool) #optional_ok {
+load_audio_stream_from_file :: proc(
+	filename: string,
+) -> (
+	stream: Audio_Stream,
+	ok: bool,
+) #optional_ok {
 	f, f_err := file_open(filename)
 
 	if f_err != nil {
 		log.errorf("Failed opening file %v. Error: %v", filename, f_err)
-		return AUDIO_STREAM_NONE, false
+		return
 	}
 
 	buf := make([dynamic]u8, frame_allocator)
@@ -2555,7 +2560,7 @@ load_audio_stream_from_file :: proc(filename: string) -> (Audio_Stream, bool) #o
 			log.errorf("Failed closing file. Error: %v", close_err)
 		}
 		
-		return AUDIO_STREAM_NONE, false
+		return
 	}
 
 	vorbis_buffer := stbv.vorbis_alloc {
@@ -2589,7 +2594,7 @@ load_audio_stream_from_file :: proc(filename: string) -> (Audio_Stream, bool) #o
 				log.errorf("Failed seeking in audio stream file %v. Error: %v", filename, seek_err)
 				file_close(f)
 				free(vorbis_buffer.alloc_buffer, s.allocator)
-				return AUDIO_STREAM_NONE, false
+				return
 			}
 
 			break
@@ -2602,14 +2607,14 @@ load_audio_stream_from_file :: proc(filename: string) -> (Audio_Stream, bool) #o
 				log.errorf("Failed reading from audio stream file %v. Error: %v", filename, read_err)
 				file_close(f)
 				free(vorbis_buffer.alloc_buffer, s.allocator)
-				return AUDIO_STREAM_NONE, false
+				return
 			}
 
 			if nbytes_read == 0 {
 				log.errorf("Failed to load audio stream. Reached end of file before stream could be loaded.")
 				file_close(f)
 				free(vorbis_buffer.alloc_buffer, s.allocator)
-				return AUDIO_STREAM_NONE, false
+				return
 			}
 
 			append(&buf, ..read_buf[:nbytes_read])
@@ -2617,7 +2622,7 @@ load_audio_stream_from_file :: proc(filename: string) -> (Audio_Stream, bool) #o
 			log.errorf("Failed to load audio stream. Error: %v", vorbis_err)
 			file_close(f)
 			free(vorbis_buffer.alloc_buffer, s.allocator)
-			return AUDIO_STREAM_NONE, false
+			return
 		}
 	}
 
@@ -2636,7 +2641,7 @@ load_audio_stream_from_file :: proc(filename: string) -> (Audio_Stream, bool) #o
 		}
 				
 		free(vorbis_buffer.alloc_buffer, s.allocator)
-		return AUDIO_STREAM_NONE, false
+		return
 	}
 
 	audio_clip := Audio_Clip_Object {
@@ -2656,7 +2661,7 @@ load_audio_stream_from_file :: proc(filename: string) -> (Audio_Stream, bool) #o
 
 		delete(audio_clip.samples, s.allocator)
 		free(vorbis_buffer.alloc_buffer, s.allocator)
-		return AUDIO_STREAM_NONE, false
+		return
 	}
 
 	asd := Audio_Stream_Data {
@@ -2669,7 +2674,7 @@ load_audio_stream_from_file :: proc(filename: string) -> (Audio_Stream, bool) #o
 		file_read_buf = make([dynamic]u8, s.allocator),
 	}
 
-	stream, stream_add_err := hm.add(&s.audio_streams, asd)
+	added_stream, stream_add_err := hm.add(&s.audio_streams, asd)
 
 	if stream_add_err != nil {
 		log.errorf("Failed to create audio stream from file. Error: %v", stream_add_err)
@@ -2678,10 +2683,10 @@ load_audio_stream_from_file :: proc(filename: string) -> (Audio_Stream, bool) #o
 		delete(audio_clip.samples, s.allocator)
 		hm.remove(&s.audio_clips, audio_clip_handle)
 		free(vorbis_buffer.alloc_buffer, s.allocator)
-		return AUDIO_STREAM_NONE, false
+		return
 	}
 
-	return stream, true
+	return added_stream, true
 }
 
 // Load an audio stream from a byte slice that is completely in memory. This makes it possible to

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1609,23 +1609,25 @@ draw_text_ex :: proc(font_handle: Font, text: string, pos: Vec2, font_size: f32,
 
 // Create an empty texture.
 //
-// If the texture cannot be created then `handle` is `TEXTURE_NONE` and the failure is logged.
+// The second return value is `true` if the texture was created correctly. It's optional to handle
+// this error, it will also be logged. In case of failure, the returned `Texture` will still be
+// possible to use, but it won't draw anything.
 create_texture :: proc(
 	width: int,
 	height: int,
 	format: Pixel_Format,
-) -> Texture {
+) -> (Texture, bool) #optional_ok {
 	h, h_ok := rb.create_texture(width, height, format)
 
 	if !h_ok {
-		return {}
+		return {}, false
 	}
 
 	return {
 		handle = h,
 		width = width,
 		height = height,
-	}
+	}, true
 }
 
 // Load a texture from disk and upload it to the GPU so you can draw it to the screen.
@@ -1633,7 +1635,9 @@ create_texture :: proc(
 //
 // The `options` parameter can be used to specify things things such as premultiplication of alpha.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the texture was loaded correctly. It's optional to handle
+// this error, it will also be logged. In case of failure, the returned `Texture` will still be
+// possible to use, but it won't draw anything.
 load_texture_from_file :: proc(
 	filename: string,
 	options: Load_Texture_Options = {},
@@ -1660,8 +1664,7 @@ load_texture_from_file :: proc(
 		return {}, false
 	}
 
-	tex := load_texture_from_bytes_raw(img.pixels.buf[:], img.width, img.height, .RGBA_8_Norm)
-	return tex, tex.handle != TEXTURE_NONE
+	return load_texture_from_bytes_raw(img.pixels.buf[:], img.width, img.height, .RGBA_8_Norm)
 }
 
 // Load a texture from a byte slice and upload it to the GPU so you can draw it to the screen.
@@ -1669,7 +1672,9 @@ load_texture_from_file :: proc(
 //
 // The `options` parameter can be used to specify things things such as premultiplication of alpha.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the texture was loaded correctly. It's optional to handle
+// this error, it will also be logged. In case of failure, the returned `Texture` will still be
+// possible to use, but it won't draw anything.
 load_texture_from_bytes :: proc(
 	bytes: []u8,
 	options: Load_Texture_Options = {},
@@ -1689,47 +1694,50 @@ load_texture_from_bytes :: proc(
 		return {}, false
 	}
 
-	tex := load_texture_from_bytes_raw(img.pixels.buf[:], img.width, img.height, .RGBA_8_Norm)
-	return tex, tex.handle != TEXTURE_NONE
+	return load_texture_from_bytes_raw(img.pixels.buf[:], img.width, img.height, .RGBA_8_Norm)
 }
 
 // Load raw texture data. You need to specify the data, size and format of the texture yourself.
 // This assumes that there is no header in the data. If your data has a header (you read the data
 // from a file on disk), then please use `load_texture_from_bytes` instead.
 //
-// If the texture cannot be created then `handle` is `TEXTURE_NONE` and the failure is logged.
+// The second return value is `true` if the texture was loaded correctly. It's optional to handle
+// this error, it will also be logged. In case of failure, the returned `Texture` will still be
+// possible to use, but it won't draw anything.
 load_texture_from_bytes_raw :: proc(
 	bytes: []u8,
 	width: int,
 	height: int,
 	format: Pixel_Format,
-) -> Texture {
+) -> (Texture, bool) #optional_ok {
 	backend_tex, backend_tex_ok := rb.load_texture(bytes[:], width, height, format)
 
 	if !backend_tex_ok {
-		return {}
+		return {}, false
 	}
 
 	return {
 		handle = backend_tex,
 		width = width,
 		height = height,
-	}
+	}, true
 }
 
 // Create a GPU texture from an image stored in RAM. There are currently no procedures to manipulate
 // the image. However, you can create an `Image` struct manually and fill out the data as needed.
 //
-// If the texture cannot be created then `handle` is `TEXTURE_NONE` and the failure is logged.
-load_texture_from_image :: proc(image: Image) -> Texture {
+// The second return value is `true` if the texture was loaded correctly. It's optional to handle
+// this error, it will also be logged. In case of failure, the returned `Texture` will still be
+// possible to use, but it won't draw anything.
+load_texture_from_image :: proc(image: Image) -> (Texture, bool) #optional_ok {
 	if image.width == 0 || image.height == 0 {
 		log.error("Invalid image: Height or width is zero")
-		return {}
+		return {}, false
 	}
 
 	if len(image.pixels) != (image.width*image.height) {
 		log.error("Invalid image: the pixels array is not of size image.width*image.height")
-		return {}
+		return {}, false
 	}
 
 	backend_tex, backend_tex_ok := rb.load_texture(
@@ -1740,14 +1748,14 @@ load_texture_from_image :: proc(image: Image) -> Texture {
 	)
 
 	if !backend_tex_ok {
-		return {}
+		return {}, false
 	}
 
 	return {
 		handle = backend_tex,
 		width = image.width,
 		height = image.height,
-	}
+	}, true
 }
 
 // Load an image from disk into RAM. Supports the same formats as `load_texture_from_file`. The
@@ -1755,7 +1763,9 @@ load_texture_from_image :: proc(image: Image) -> Texture {
 //
 // Use `destroy_image` when you are done with it.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the image was loaded correctly. It's optional to handle
+// this error, it will also be logged. In case of failure, the returned `Image` will be empty: it
+// has no pixels and a width and height of zero.
 load_image_from_file :: proc(filename: string) -> (Image, bool) #optional_ok {
 	data, data_ok := read_entire_file(filename, frame_allocator)
 
@@ -1773,7 +1783,9 @@ load_image_from_file :: proc(filename: string) -> (Image, bool) #optional_ok {
 //
 // Use `destroy_image` when you are done with it.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the image was loaded correctly. It's optional to handle
+// this error, it will also be logged. In case of failure, the returned `Image` will be empty: it
+// has no pixels and a width and height of zero.
 load_image_from_bytes :: proc(bytes: []u8) -> (Image, bool) #optional_ok {
 	img, img_err := image.load_from_bytes(
 		bytes,
@@ -2213,7 +2225,9 @@ get_num_sounds_playing_clip :: proc(clip: Audio_Clip) -> int {
 // Supports mono and stereo WAV files with 8, 16, 24 or 32 bit integer samples, or 32 or 64 bit
 // float samples.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the audio clip was loaded correctly. It's optional to
+// handle this error, it will also be logged. In case of failure, the returned `Audio_Clip` will
+// still be possible to use, but it won't play anything.
 load_audio_clip_from_file :: proc(filename: string) -> (Audio_Clip, bool) #optional_ok {
 	data, data_ok := read_entire_file(filename, frame_allocator)
 
@@ -2232,7 +2246,9 @@ load_audio_clip_from_file :: proc(filename: string) -> (Audio_Clip, bool) #optio
 // float samples. Note that the data should be the entire WAV file, including the header. If your
 // data does not include the header, then please use `load_audio_clip_from_bytes_raw`.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the audio clip was loaded correctly. It's optional to
+// handle this error, it will also be logged. In case of failure, the returned `Audio_Clip` will
+// still be possible to use, but it won't play anything.
 load_audio_clip_from_bytes :: proc(bytes: []u8) -> (Audio_Clip, bool) #optional_ok {
 	// A WAV file is a RIFF file: A 12 byte header followed by any number of chunks.
 	if len(bytes) < 12 {
@@ -2404,8 +2420,7 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> (Audio_Clip, bool) #optional_
 		return AUDIO_CLIP_NONE, false
 	}
 
-	clip := load_audio_clip_from_bytes_raw(samples, format, sample_rate, channels)
-	return clip, clip != AUDIO_CLIP_NONE
+	return load_audio_clip_from_bytes_raw(samples, format, sample_rate, channels)
 }
 
 // Load an audio clip from some raw audio data. You need to specify the data, format and sample
@@ -2413,13 +2428,15 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> (Audio_Clip, bool) #optional_
 // header (for example, you read a whole WAV file from disk), then please use
 // `load_audio_clip_from_bytes` instead.
 //
-// If the clip cannot be created then `AUDIO_CLIP_NONE` is returned and the failure is logged.
+// The second return value is `true` if the audio clip was loaded correctly. It's optional to
+// handle this error, it will also be logged. In case of failure, the returned `Audio_Clip` will
+// still be possible to use, but it won't play anything.
 load_audio_clip_from_bytes_raw :: proc(
 	bytes: []u8,
 	format: Raw_Audio_Format,
 	sample_rate: int,
 	channels: Audio_Channels,
-) -> Audio_Clip {
+) -> (Audio_Clip, bool) #optional_ok {
 	samples: []Audio_Sample
 
 	switch format{
@@ -2481,10 +2498,10 @@ load_audio_clip_from_bytes_raw :: proc(
 
 	if audio_clip_add_error != nil {
 		log.errorf("Failed to load audio clip. Error: %v", audio_clip_add_error)
-		return AUDIO_CLIP_NONE
+		return AUDIO_CLIP_NONE, false
 	}
 
-	return audio_clip
+	return audio_clip, true
 }
 
 // Destroy an audio clip previously loaded using `load_audio_clip_from_xxx`. Also stops sounds
@@ -2516,7 +2533,9 @@ destroy_audio_clip :: proc(clip: Audio_Clip)  {
 // Audio streams do not stream in data automatically from the disk. You need to call
 // `update_audio_stream` every frame to stream in the new data.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the audio stream was loaded correctly. It's optional to
+// handle this error, it will also be logged. In case of failure, the returned `Audio_Stream` will
+// still be possible to use, but it won't play anything.
 load_audio_stream_from_file :: proc(filename: string) -> (Audio_Stream, bool) #optional_ok {
 	f, f_err := file_open(filename)
 
@@ -2689,7 +2708,9 @@ load_audio_stream_from_file :: proc(filename: string) -> (Audio_Stream, bool) #o
 // in the samples. There is no such procedure for audio streams since the whole idea is to stream an
 // encoded file into memory without having to decode the whole thing first.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the audio stream was loaded correctly. It's optional to
+// handle this error, it will also be logged. In case of failure, the returned `Audio_Stream` will
+// still be possible to use, but it won't play anything.
 load_audio_stream_from_bytes :: proc(bytes: []u8) -> (Audio_Stream, bool) #optional_ok {
 	vorbis_err: stbv.Error
 
@@ -3647,12 +3668,14 @@ update_audio_mixer :: proc() {
 // Create a texture that you can render into. Meaning that you can draw into it instead of drawing
 // onto the screen. Use `set_render_texture` to enable this Render Texture for drawing.
 //
-// If it cannot be created then `texture.handle` is `TEXTURE_NONE` and the failure is logged.
-create_render_texture :: proc(width: int, height: int) -> Render_Texture {
+// The second return value is `true` if the render texture was created correctly. It's optional to
+// handle this error, it will also be logged. In case of failure, the returned `Render_Texture`
+// will still be possible to use, but setting it does nothing, so drawing stays where it was.
+create_render_texture :: proc(width: int, height: int) -> (Render_Texture, bool) #optional_ok {
 	texture, render_target, render_texture_ok := rb.create_render_texture(width, height)
 
 	if !render_texture_ok {
-		return {}
+		return {}, false
 	}
 
 	return {
@@ -3662,7 +3685,7 @@ create_render_texture :: proc(width: int, height: int) -> Render_Texture {
 			height = height,
 		},
 		render_target = render_target,
-	}
+	}, true
 }
 
 // Destroy a Render_Texture previously created using `create_render_texture`.
@@ -3892,7 +3915,9 @@ rotate :: proc(v: Vec2, angle_radians: f32) -> Vec2 {
 
 // Like `load_static_font_from_bytes` but reads a file from disk using a specified name.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the font was loaded correctly. It's optional to handle this
+// error, it will also be logged. In case of failure, the returned `Font` will still be possible to
+// use, but text drawn with it uses the default font.
 load_static_font_from_file :: proc(
 	filename: string,
 	font_size: f32,
@@ -3913,7 +3938,9 @@ load_static_font_from_file :: proc(
 // will be of of the specified `font_size`. If you do not specify a list of `codepoints`, then this
 // procedure defaults to using all codepoints between 32 to 127 (ASCII).
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the font was loaded correctly. It's optional to handle this
+// error, it will also be logged. In case of failure, the returned `Font` will still be possible to
+// use, but text drawn with it uses the default font.
 load_static_font_from_bytes :: proc(
 	data: []byte,
 	font_size: f32,
@@ -4173,7 +4200,9 @@ load_static_font_from_bytes :: proc(
 
 // Like `load_dynamic_font_from_bytes`, but reads a file from disk using a filename.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the font was loaded correctly. It's optional to handle this
+// error, it will also be logged. In case of failure, the returned `Font` will still be possible to
+// use, but text drawn with it uses the default font.
 load_dynamic_font_from_file :: proc(
 	filename: string,
 	options: Font_Options = {},
@@ -4191,7 +4220,9 @@ load_dynamic_font_from_file :: proc(
 // Load a TTF font stored in `data` as a dynamic font. This means that an atlas will be dynamically
 // built as you draw characters using this font.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the font was loaded correctly. It's optional to handle this
+// error, it will also be logged. In case of failure, the returned `Font` will still be possible to
+// use, but text drawn with it uses the default font.
 load_dynamic_font_from_bytes :: proc(
 	data: []u8,
 	options: Font_Options = {},
@@ -4295,25 +4326,27 @@ set_cursor :: proc(cursor: Cursor) {
 //
 // The cursor does not need `image` after it is created. You may destroy it.
 //
-// If the cursor can't be created, then an error is logged and `CUSTOM_CURSOR_NONE` is returned.
-create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cursor {
+// The second return value is `true` if the cursor was created correctly. It's optional to handle
+// this error, it will also be logged. In case of failure, the returned `Custom_Cursor` will still
+// be possible to use, but setting it leaves the cursor as it is.
+create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> (Custom_Cursor, bool) #optional_ok {
 	if image.width == 0 || image.height == 0 {
 		log.error("Invalid cursor image: height or width is zero")
-		return {}
+		return {}, false
 	}
 
 	if len(image.pixels) != image.width*image.height {
 		log.error("Invalid cursor image: the pixels array is not of size image.width*image.height")
-		return {}
+		return {}, false
 	}
 
 	cursor, cursor_ok := pf.create_custom_cursor(image, hotspot)
 
 	if !cursor_ok {
-		return {}
+		return {}, false
 	}
 
-	return cursor
+	return cursor, true
 }
 
 // Destroy a cursor previously created using `create_custom_cursor`. If it is the cursor currently
@@ -4349,7 +4382,9 @@ is_cursor_hidden :: proc() -> bool {
 // `layout_formats` can in many cases be left default initialized. It is used to specify the format
 // of the vertex shader inputs. By formats this means the format that you pass on the CPU side.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the shader was loaded correctly. It's optional to handle
+// this error, it will also be logged. In case of failure, the returned `Shader` will still be
+// possible to use, but setting it does nothing: drawing carries on with the shader already set.
 load_shader_from_file :: proc(
 	vertex_filename: string,
 	fragment_filename: string,
@@ -4382,7 +4417,9 @@ load_shader_from_file :: proc(
 // Load a vertex and fragment shader from a block of memory. See `load_shader_from_file` for what
 // `layout_formats` means.
 //
-// The second return value tells you if it worked. Ignoring it is fine, failures are also logged.
+// The second return value is `true` if the shader was loaded correctly. It's optional to handle
+// this error, it will also be logged. In case of failure, the returned `Shader` will still be
+// possible to use, but setting it does nothing: drawing carries on with the shader already set.
 load_shader_from_bytes :: proc(
 	vertex_shader_bytes: []byte,
 	fragment_shader_bytes: []byte,

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -2249,7 +2249,7 @@ load_audio_clip_from_file :: proc(filename: string) -> (Audio_Clip, bool) #optio
 // The second return value is `true` if the audio clip was loaded correctly. It's optional to
 // handle this error, it will also be logged. In case of failure, the returned `Audio_Clip` will
 // still be possible to use, but it won't play anything.
-load_audio_clip_from_bytes :: proc(bytes: []u8) -> (clip: Audio_Clip, ok: bool) #optional_ok {
+load_audio_clip_from_bytes :: proc(bytes: []u8) -> (_clip: Audio_Clip, _ok: bool) #optional_ok {
 	// A WAV file is a RIFF file: A 12 byte header followed by any number of chunks.
 	if len(bytes) < 12 {
 		log.error("Invalid wav file: Too small to contain a RIFF header")
@@ -2539,8 +2539,8 @@ destroy_audio_clip :: proc(clip: Audio_Clip)  {
 load_audio_stream_from_file :: proc(
 	filename: string,
 ) -> (
-	stream: Audio_Stream,
-	ok: bool,
+	_stream: Audio_Stream,
+	_ok: bool,
 ) #optional_ok {
 	f, f_err := file_open(filename)
 
@@ -2674,7 +2674,7 @@ load_audio_stream_from_file :: proc(
 		file_read_buf = make([dynamic]u8, s.allocator),
 	}
 
-	added_stream, stream_add_err := hm.add(&s.audio_streams, asd)
+	stream, stream_add_err := hm.add(&s.audio_streams, asd)
 
 	if stream_add_err != nil {
 		log.errorf("Failed to create audio stream from file. Error: %v", stream_add_err)
@@ -2686,7 +2686,7 @@ load_audio_stream_from_file :: proc(
 		return
 	}
 
-	return added_stream, true
+	return stream, true
 }
 
 // Load an audio stream from a byte slice that is completely in memory. This makes it possible to
@@ -2716,7 +2716,12 @@ load_audio_stream_from_file :: proc(
 // The second return value is `true` if the audio stream was loaded correctly. It's optional to
 // handle this error, it will also be logged. In case of failure, the returned `Audio_Stream` will
 // still be possible to use, but it won't play anything.
-load_audio_stream_from_bytes :: proc(bytes: []u8) -> (Audio_Stream, bool) #optional_ok {
+load_audio_stream_from_bytes :: proc(
+	bytes: []u8,
+) -> (
+	_stream: Audio_Stream,
+	_ok: bool,
+) #optional_ok {
 	vorbis_err: stbv.Error
 
 	vorbis_buffer := stbv.vorbis_alloc {
@@ -2736,7 +2741,7 @@ load_audio_stream_from_bytes :: proc(bytes: []u8) -> (Audio_Stream, bool) #optio
 	if vorbis_err != nil {
 		log.errorf("Failed opening audio stream from bytes. Error: %v", vorbis_err)
 		free(vorbis_buffer.alloc_buffer, s.allocator)
-		return AUDIO_STREAM_NONE, false
+		return
 	}
 
 	info := stbv.get_info(vorbis_res)
@@ -2749,7 +2754,7 @@ load_audio_stream_from_bytes :: proc(bytes: []u8) -> (Audio_Stream, bool) #optio
 	} else{
 		log.errorf("Unsupported number of channels: %v", info.channels)
 		free(vorbis_buffer.alloc_buffer, s.allocator)
-		return AUDIO_STREAM_NONE, false
+		return
 	}
 
 	audio_clip := Audio_Clip_Object {
@@ -2764,7 +2769,7 @@ load_audio_stream_from_bytes :: proc(bytes: []u8) -> (Audio_Stream, bool) #optio
 		log.errorf("Failed to load audio stream. Error: %v", audio_clip_handle_add_err)
 		delete(audio_clip.samples, s.allocator)
 		free(vorbis_buffer.alloc_buffer, s.allocator)
-		return AUDIO_STREAM_NONE, false
+		return
 	}
 
 	asd := Audio_Stream_Data {
@@ -2783,7 +2788,7 @@ load_audio_stream_from_bytes :: proc(bytes: []u8) -> (Audio_Stream, bool) #optio
 		delete(audio_clip.samples, s.allocator)
 		hm.remove(&s.audio_clips, audio_clip_handle)
 		free(vorbis_buffer.alloc_buffer, s.allocator)
-		return AUDIO_STREAM_NONE, false
+		return
 	}
 
 	return stream, true

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1626,7 +1626,7 @@ create_texture :: proc(
 			height,
 			format,
 		)
-		
+
 		return {}, false
 	}
 
@@ -1720,6 +1720,13 @@ load_texture_from_bytes_raw :: proc(
 	backend_tex, backend_tex_ok := rb.load_texture(bytes[:], width, height, format)
 
 	if !backend_tex_ok {
+		log.errorf(
+			"Failed loading texture with dimensions %v x %v and pixel format %v",
+			width,
+			height,
+			format,
+		)
+
 		return {}, false
 	}
 
@@ -3692,6 +3699,7 @@ create_render_texture :: proc(width: int, height: int) -> (Render_Texture, bool)
 	texture, render_target, render_texture_ok := rb.create_render_texture(width, height)
 
 	if !render_texture_ok {
+		log.errorf("Failed creating render texture with dimensions %v x %v", width, height)
 		return {}, false
 	}
 

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -2249,16 +2249,16 @@ load_audio_clip_from_file :: proc(filename: string) -> (Audio_Clip, bool) #optio
 // The second return value is `true` if the audio clip was loaded correctly. It's optional to
 // handle this error, it will also be logged. In case of failure, the returned `Audio_Clip` will
 // still be possible to use, but it won't play anything.
-load_audio_clip_from_bytes :: proc(bytes: []u8) -> (Audio_Clip, bool) #optional_ok {
+load_audio_clip_from_bytes :: proc(bytes: []u8) -> (clip: Audio_Clip, ok: bool) #optional_ok {
 	// A WAV file is a RIFF file: A 12 byte header followed by any number of chunks.
 	if len(bytes) < 12 {
 		log.error("Invalid wav file: Too small to contain a RIFF header")
-		return AUDIO_CLIP_NONE, false
+		return
 	}
 
 	if string(bytes[:4]) != "RIFF" {
 		log.error("Invalid wav file: No RIFF identifier")
-		return AUDIO_CLIP_NONE, false
+		return
 	}
 
 	// This size can only fail to read if there are less than four bytes left, which the check above
@@ -2267,7 +2267,7 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> (Audio_Clip, bool) #optional_
 
 	if string(bytes[8:12]) != "WAVE" {
 		log.error("Invalid wav file: Not WAVE format")
-		return AUDIO_CLIP_NONE, false
+		return
 	}
 
 	// `riff_size` counts everything after itself. Some programs write a size that doesn't match the
@@ -2319,7 +2319,7 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> (Audio_Clip, bool) #optional_
 			//	bits_per_sample: u16
 			if len(content) < 16 {
 				log.errorf("Invalid wav fmt chunk: Size is %v, expected at least 16", len(content))
-				return AUDIO_CLIP_NONE, false
+				return
 			}
 
 			audio_format, _ := endian.get_u16(content[0:2], .Little)
@@ -2336,7 +2336,7 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> (Audio_Clip, bool) #optional_
 				if len(content) < 26 {
 					log.errorf("Invalid wav fmt chunk: Size is %v, too small for an extensible " +
 						"sub format", len(content))
-					return AUDIO_CLIP_NONE, false
+					return
 				}
 
 				audio_format, _ = endian.get_u16(content[24:26], .Little)
@@ -2344,7 +2344,7 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> (Audio_Clip, bool) #optional_
 
 			if fmt_sample_rate == 0 {
 				log.error("Invalid wav fmt chunk: Sample rate is zero")
-				return AUDIO_CLIP_NONE, false
+				return
 			}
 
 			switch num_channels {
@@ -2354,7 +2354,7 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> (Audio_Clip, bool) #optional_
 				channels = .Stereo
 			case:
 				log.errorf("Unsupported number of channels in wav fmt chunk: %v", num_channels)
-				return AUDIO_CLIP_NONE, false
+				return
 			}
 
 			switch audio_format {
@@ -2370,7 +2370,7 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> (Audio_Clip, bool) #optional_
 					format = .Integer32
 				case:
 					log.errorf("Unsupported bits per sample in wav fmt chunk: %v", bits_per_sample)
-					return AUDIO_CLIP_NONE, false
+					return
 				}
 
 			case WAV_FORMAT_FLOAT:
@@ -2384,12 +2384,12 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> (Audio_Clip, bool) #optional_
 						"Unsupported bits per sample in float wav fmt chunk: %v",
 						bits_per_sample,
 					)
-					return AUDIO_CLIP_NONE, false
+					return
 				}
 
 			case:
 				log.errorf("Unsupported format in wav fmt chunk: %v", audio_format)
-				return AUDIO_CLIP_NONE, false
+				return
 			}
 
 			sample_rate = int(fmt_sample_rate)
@@ -2412,12 +2412,12 @@ load_audio_clip_from_bytes :: proc(bytes: []u8) -> (Audio_Clip, bool) #optional_
 
 	if !has_fmt {
 		log.error("Invalid wav file: No fmt chunk")
-		return AUDIO_CLIP_NONE, false
+		return
 	}
 
 	if !has_data {
 		log.error("Invalid wav file: No data chunk")
-		return AUDIO_CLIP_NONE, false
+		return
 	}
 
 	return load_audio_clip_from_bytes_raw(samples, format, sample_rate, channels)

--- a/platform_interface.odin
+++ b/platform_interface.odin
@@ -30,7 +30,7 @@ Platform_Interface :: struct #all_or_none {
 	is_cursor_hidden: proc() -> bool,
 	set_mouse_locked: proc(locked: bool),
 	is_mouse_locked: proc() -> bool,
-	create_custom_cursor: proc(image: Image, hotspot: [2]int) -> Custom_Cursor,
+	create_custom_cursor: proc(image: Image, hotspot: [2]int) -> (Custom_Cursor, bool),
 	set_cursor: proc(cursor: Cursor),
 	destroy_custom_cursor: proc(custom_cursor: Custom_Cursor),
 

--- a/platform_linux.odin
+++ b/platform_linux.odin
@@ -630,7 +630,7 @@ linux_is_mouse_locked :: proc() -> bool {
 	return s.win.is_mouse_locked()
 }
 
-linux_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cursor {
+linux_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> (Custom_Cursor, bool) {
 	return s.win.create_custom_cursor(image, hotspot)
 }
 
@@ -707,7 +707,7 @@ Linux_Window_Interface :: struct #all_or_none {
 	set_mouse_locked: proc(locked: bool),
 	is_mouse_locked: proc() -> bool,
 
-	create_custom_cursor: proc(image: Image, hotspot: [2]int) -> Custom_Cursor,
+	create_custom_cursor: proc(image: Image, hotspot: [2]int) -> (Custom_Cursor, bool),
 	set_cursor: proc(cursor: Cursor),
 	destroy_custom_cursor: proc(custom_cursor: Custom_Cursor),
 

--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -1019,14 +1019,14 @@ wl_apply_cursor :: proc() {
 	wl.surface_commit(s.cursor_surface)
 }
 
-wl_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cursor {
+wl_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> (Custom_Cursor, bool) {
 	stride := image.width * 4
 	size := stride * image.height
 
 	fd, fd_err := linux.memfd_create("cursor", {})
 	if fd_err != .NONE {
 		log.errorf("Failed to create Wayland cursor: memfd failed with %v", fd_err)
-		return {}
+		return {}, false
 	}
 
 	// The compositor dups the fd in shm_create_pool, so we don't have to keep ours around.
@@ -1034,13 +1034,13 @@ wl_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cursor 
 
 	if trunc_err := linux.ftruncate(fd, i64(size)); trunc_err != .NONE {
 		log.errorf("Failed to create Wayland cursor: ftruncate failed with %v", trunc_err)
-		return {}
+		return {}, false
 	}
 
 	data, mmap_err := linux.mmap(0, uint(size), {.READ, .WRITE}, {.SHARED}, fd, 0)
 	if mmap_err != .NONE {
 		log.errorf("Failed to create Wayland cursor: mmap failed with %v", mmap_err)
-		return {}
+		return {}, false
 	}
 
 	// Convert to ARGB and premultiply alpha
@@ -1090,10 +1090,10 @@ wl_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cursor 
 		wl.surface_destroy(cursor.surface)
 		wl.buffer_destroy(cursor.buffer)
 		linux.munmap(cursor.data, uint(cursor.data_size))
-		return {}
+		return {}, false
 	}
 
-	return handle
+	return handle, true
 }
 
 // A cursor image is sized in physical pixels, like everything else in Karl2D, but a Wayland surface

--- a/platform_linux_window_x11.odin
+++ b/platform_linux_window_x11.odin
@@ -642,12 +642,12 @@ _x11_teleport_cursor_to_center :: proc() {
 	})
 }
 
-x11_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cursor {
+x11_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> (Custom_Cursor, bool) {
 	img := X.cursorImageCreate(i32(image.width), i32(image.height))
 
 	if img == nil {
 		log.error("cursorImageCreate failed")
-		return {}
+		return {}, false
 	}
 
 	// Convert to ARGB and premultiply alpha, straight into the buffer Xcursor allocated for us.
@@ -672,7 +672,7 @@ x11_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cursor
 
 	if cursor == 0 {
 		log.error("cursorImageLoadCursor failed")
-		return {}
+		return {}, false
 	}
 
 	handle, add_err := hm.add(&s.custom_cursors, X11_Cursor{cursor = cursor})
@@ -680,10 +680,10 @@ x11_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cursor
 	if add_err != nil {
 		log.errorf("Failed to create cursor. Error: %v", add_err)
 		X.FreeCursor(s.display, cursor)
-		return {}
+		return {}, false
 	}
 
-	return handle
+	return handle, true
 }
 
 x11_set_cursor :: proc(cursor: Cursor) {

--- a/platform_mac.odin
+++ b/platform_mac.odin
@@ -794,7 +794,7 @@ mac_set_window_mode :: proc(window_mode: Window_Mode) {
 	}
 }
 
-mac_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cursor {
+mac_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> (Custom_Cursor, bool) {
 	cursor := Mac_Cursor {
 		pixels  = slice.clone(image.pixels, s.allocator),
 		width   = image.width,
@@ -809,10 +809,10 @@ mac_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cursor
 		log.errorf("Failed to create cursor. Error: %v", add_err)
 		cursor.cursor->release()
 		delete(cursor.pixels, s.allocator)
-		return {}
+		return {}, false
 	}
 
-	return handle
+	return handle, true
 }
 
 // Cursor images are in physical pixels, like the rest of Karl2D, but an NSImage is sized in

--- a/platform_web.odin
+++ b/platform_web.odin
@@ -449,14 +449,14 @@ web_is_mouse_locked :: proc() -> bool {
 	return s.mouse_locked
 }
 
-web_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cursor {
+web_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> (Custom_Cursor, bool) {
 	// There is no hardware cursor API on the web, so we hand the browser a PNG as a data URI and
 	// let CSS do the work. core:image/png can only decode, not encode, so we encode it ourselves;
 	// see encode_png's own comment for why that is fine here.
 	png_bytes, encode_ok := encode_png(image, frame_allocator)
 	if !encode_ok {
 		log.error("Failed to encode cursor image as PNG")
-		return {}
+		return {}, false
 	}
 
 	// Browsers cap `cursor` images at 128 CSS pixels; anything bigger is either clamped or, in
@@ -491,10 +491,10 @@ web_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cursor
 		delete(cursor.data_uri, s.allocator)
 		delete(cursor.style_value, s.allocator)
 		delete(cursor.style_value_scaled, s.allocator)
-		return {}
+		return {}, false
 	}
 
-	return handle
+	return handle, true
 }
 
 // The `cursor` property sizes its image in CSS pixels, but the rest of Karl2D works in device

--- a/platform_windows.odin
+++ b/platform_windows.odin
@@ -574,7 +574,7 @@ _windows_teleport_cursor_to_center :: proc() {
 	})
 }
 
-windows_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cursor {
+windows_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> (Custom_Cursor, bool) {
 	// CreateBitmap makes a device-dependent bitmap, which is not documented to support a real
 	// alpha channel. A 32-bit cursor with alpha needs a DIB section instead: CreateDIBSection with
 	// a BITMAPV5HEADER and explicit channel masks, which is also what GLFW and SDL do for this.
@@ -608,7 +608,7 @@ windows_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cu
 
 	if h_color == nil || dib_pixels == nil {
 		log.errorf("CreateDIBSection failed with %v", win32.GetLastError())
-		return {}
+		return {}, false
 	}
 
 	// We receive RGBA but the DIB, like GDI generally, wants BGRA.
@@ -641,7 +641,7 @@ windows_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cu
 
 	if hcursor == nil {
 		log.errorf("CreateIconIndirect failed with %v", win32.GetLastError())
-		return {}
+		return {}, false
 	}
 
 	handle, add_err := hm.add(&s.custom_cursors, Windows_Cursor{hcursor = hcursor})
@@ -649,10 +649,10 @@ windows_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> Custom_Cu
 	if add_err != nil {
 		log.errorf("Failed to create cursor. Error: %v", add_err)
 		win32.DestroyCursor(hcursor)
-		return {}
+		return {}, false
 	}
 
-	return handle
+	return handle, true
 }
 
 windows_set_cursor :: proc(cursor: Cursor) {

--- a/render_backend_d3d11.odin
+++ b/render_backend_d3d11.odin
@@ -850,10 +850,15 @@ d3d11_load_shader :: proc(
 	desc_allocator := frame_allocator,
 	layout_formats: []Pixel_Format = {},
 ) -> (
-	handle: Shader_Handle,
-	desc: Shader_Desc,
-	ok: bool,
+	_handle: Shader_Handle,
+	_desc: Shader_Desc,
+	_ok: bool,
 ) {
+	// Built up as the two shaders are reflected over, and only handed back once everything worked.
+	// Filling in a named return value instead would mean the naked returns above hand out a
+	// half-built description alongside their `false`.
+	desc: Shader_Desc
+
 	vs_blob: ^d3d11.IBlob
 	vs_blob_errors: ^d3d11.IBlob
 	vs_compile_res := ch(d3d_compiler.Compile(
@@ -1130,7 +1135,7 @@ d3d11_load_shader :: proc(
 		input_layout->Release()
 		vertex_shader->Release()
 		pixel_shader->Release()
-		return SHADER_NONE, {}, false
+		return
 	}
 
 	return h, desc, true

--- a/render_backend_d3d11.odin
+++ b/render_backend_d3d11.odin
@@ -856,7 +856,19 @@ d3d11_load_shader :: proc(
 ) {
 	vs_blob: ^d3d11.IBlob
 	vs_blob_errors: ^d3d11.IBlob
-	ch(d3d_compiler.Compile(raw_data(vs_source), len(vs_source), nil, nil, nil, "vs_main", "vs_5_0", 0, 0, &vs_blob, &vs_blob_errors))
+	vs_compile_res := ch(d3d_compiler.Compile(
+		raw_data(vs_source),
+		len(vs_source),
+		nil,
+		nil,
+		nil,
+		"vs_main",
+		"vs_5_0",
+		0,
+		0,
+		&vs_blob,
+		&vs_blob_errors,
+	))
 
 	if vs_blob_errors != nil {
 		log.error("Failed compiling shader:")
@@ -864,14 +876,40 @@ d3d11_load_shader :: proc(
 		return
 	}
 
+	// The compiler can fail without producing an error blob, for example when it cannot even start
+	// on the source. There is no bytecode in that case, so there is nothing to make a shader from.
+	if vs_compile_res < 0 || vs_blob == nil {
+		log.error("Failed compiling vertex shader.")
+		return
+	}
+
 	// VERTEX SHADER
 
 	vertex_shader: ^d3d11.IVertexShader
-	ch(s.device->CreateVertexShader(vs_blob->GetBufferPointer(), vs_blob->GetBufferSize(), nil, &vertex_shader))
+
+	if ch(s.device->CreateVertexShader(
+		vs_blob->GetBufferPointer(),
+		vs_blob->GetBufferSize(),
+		nil,
+		&vertex_shader,
+	)) < 0 {
+		vs_blob->Release()
+		return
+	}
 
 	vs_ref: ^d3d11.IShaderReflection
-	ch(d3d_compiler.Reflect(vs_blob->GetBufferPointer(), vs_blob->GetBufferSize(), d3d11.ID3D11ShaderReflection_UUID, (^rawptr)(&vs_ref)))
-	
+
+	if ch(d3d_compiler.Reflect(
+		vs_blob->GetBufferPointer(),
+		vs_blob->GetBufferSize(),
+		d3d11.ID3D11ShaderReflection_UUID,
+		(^rawptr)(&vs_ref),
+	)) < 0 {
+		vertex_shader->Release()
+		vs_blob->Release()
+		return
+	}
+
 	vs_desc: d3d11.SHADER_DESC
 	ch(vs_ref->GetDesc(&vs_desc))
 
@@ -950,26 +988,86 @@ d3d11_load_shader :: proc(
 	}
 
 	input_layout: ^d3d11.IInputLayout
-	ch(s.device->CreateInputLayout(raw_data(input_layout_desc), u32(len(input_layout_desc)), vs_blob->GetBufferPointer(), vs_blob->GetBufferSize(), &input_layout))
+
+	if ch(s.device->CreateInputLayout(
+		raw_data(input_layout_desc),
+		u32(len(input_layout_desc)),
+		vs_blob->GetBufferPointer(),
+		vs_blob->GetBufferSize(),
+		&input_layout,
+	)) < 0 {
+		vertex_shader->Release()
+		vs_blob->Release()
+		return
+	}
+
+	// The blob only holds the compiled bytecode. Nothing needs it after the input layout is made.
+	vs_blob->Release()
 
 	// PIXEL SHADER
 
 	ps_blob: ^d3d11.IBlob
 	ps_blob_errors: ^d3d11.IBlob
-	ch(d3d_compiler.Compile(raw_data(ps_source), len(ps_source), nil, nil, nil, "ps_main", "ps_5_0", 0, 0, &ps_blob, &ps_blob_errors))
+	ps_compile_res := ch(d3d_compiler.Compile(
+		raw_data(ps_source),
+		len(ps_source),
+		nil,
+		nil,
+		nil,
+		"ps_main",
+		"ps_5_0",
+		0,
+		0,
+		&ps_blob,
+		&ps_blob_errors,
+	))
 
 	if ps_blob_errors != nil {
 		log.error("Failed compiling shader:")
 		log.error(strings.string_from_ptr((^u8)(ps_blob_errors->GetBufferPointer()), int(ps_blob_errors->GetBufferSize())))
+		input_layout->Release()
+		vertex_shader->Release()
+		return
+	}
+
+	if ps_compile_res < 0 || ps_blob == nil {
+		log.error("Failed compiling pixel shader.")
+		input_layout->Release()
+		vertex_shader->Release()
 		return
 	}
 
 	pixel_shader: ^d3d11.IPixelShader
-	ch(s.device->CreatePixelShader(ps_blob->GetBufferPointer(), ps_blob->GetBufferSize(), nil, &pixel_shader))
+
+	if ch(s.device->CreatePixelShader(
+		ps_blob->GetBufferPointer(),
+		ps_blob->GetBufferSize(),
+		nil,
+		&pixel_shader,
+	)) < 0 {
+		ps_blob->Release()
+		input_layout->Release()
+		vertex_shader->Release()
+		return
+	}
 
 	ps_ref: ^d3d11.IShaderReflection
-	ch(d3d_compiler.Reflect(ps_blob->GetBufferPointer(), ps_blob->GetBufferSize(), d3d11.ID3D11ShaderReflection_UUID, (^rawptr)(&ps_ref)))
-	
+
+	if ch(d3d_compiler.Reflect(
+		ps_blob->GetBufferPointer(),
+		ps_blob->GetBufferSize(),
+		d3d11.ID3D11ShaderReflection_UUID,
+		(^rawptr)(&ps_ref),
+	)) < 0 {
+		pixel_shader->Release()
+		ps_blob->Release()
+		input_layout->Release()
+		vertex_shader->Release()
+		return
+	}
+
+	ps_blob->Release()
+
 	ps_desc: d3d11.SHADER_DESC
 	ch(ps_ref->GetDesc(&ps_desc))
 
@@ -1003,6 +1101,16 @@ d3d11_load_shader :: proc(
 
 	if h_add_err != nil {
 		log.errorf("Failed to add shader. Error: %v", h_add_err)
+
+		for c in d3d_constant_buffers {
+			if c.gpu_data != nil {
+				c.gpu_data->Release()
+			}
+		}
+
+		input_layout->Release()
+		vertex_shader->Release()
+		pixel_shader->Release()
 		return SHADER_NONE, {}, false
 	}
 

--- a/render_backend_d3d11.odin
+++ b/render_backend_d3d11.odin
@@ -537,6 +537,7 @@ create_texture :: proc(
 	data: rawptr,
 ) -> (
 	Texture_Handle,
+	bool,
 ) {
 	texture_desc := d3d11.TEXTURE2D_DESC{
 		Width      = u32(width),
@@ -557,13 +558,21 @@ create_texture :: proc(
 			SysMemPitch = u32(width * pixel_format_size(format)),
 		}
 
-		s.device->CreateTexture2D(&texture_desc, &texture_data, &texture)
+		if ch(s.device->CreateTexture2D(&texture_desc, &texture_data, &texture)) < 0 {
+			return {}, false
+		}
 	} else {
-		s.device->CreateTexture2D(&texture_desc, nil, &texture)
+		if ch(s.device->CreateTexture2D(&texture_desc, nil, &texture)) < 0 {
+			return {}, false
+		}
 	}
-	
+
 	texture_view: ^d3d11.IShaderResourceView
-	s.device->CreateShaderResourceView(texture, nil, &texture_view)
+
+	if ch(s.device->CreateShaderResourceView(texture, nil, &texture_view)) < 0 {
+		texture->Release()
+		return {}, false
+	}
 
 	tex := D3D11_Texture {
 		tex = texture,
@@ -576,17 +585,26 @@ create_texture :: proc(
 
 	if tex_add_err != nil {
 		log.errorf("Failed to add texture. Error: %v", tex_add_err)
-		return TEXTURE_NONE
+		texture_view->Release()
+		texture->Release()
+		return TEXTURE_NONE, false
 	}
 
-	return tex_handle
+	return tex_handle, true
 }
 
-d3d11_create_texture :: proc(width: int, height: int, format: Pixel_Format) -> Texture_Handle {
+d3d11_create_texture :: proc(
+	width: int,
+	height: int,
+	format: Pixel_Format,
+) -> (Texture_Handle, bool) {
 	return create_texture(width, height, format, nil)
 }
 
-d3d11_create_render_texture :: proc(width: int, height: int) -> (Texture_Handle, Render_Target_Handle) {
+d3d11_create_render_texture :: proc(
+	width: int,
+	height: int,
+) -> (Texture_Handle, Render_Target_Handle, bool) {
 	texture_desc := d3d11.TEXTURE2D_DESC{
 		Width      = u32(width),
 		Height     = u32(height),
@@ -599,11 +617,18 @@ d3d11_create_render_texture :: proc(width: int, height: int) -> (Texture_Handle,
 	}
 
 	texture: ^d3d11.ITexture2D
-	ch(s.device->CreateTexture2D(&texture_desc, nil, &texture))
+
+	if ch(s.device->CreateTexture2D(&texture_desc, nil, &texture)) < 0 {
+		return TEXTURE_NONE, RENDER_TARGET_NONE, false
+	}
 
 	texture_view: ^d3d11.IShaderResourceView
-	ch(s.device->CreateShaderResourceView(texture, nil, &texture_view))
-	
+
+	if ch(s.device->CreateShaderResourceView(texture, nil, &texture_view)) < 0 {
+		texture->Release()
+		return TEXTURE_NONE, RENDER_TARGET_NONE, false
+	}
+
 	render_target_view_desc := d3d11.RENDER_TARGET_VIEW_DESC {
 		Format = texture_desc.Format,
 		ViewDimension = .TEXTURE2D,
@@ -611,7 +636,13 @@ d3d11_create_render_texture :: proc(width: int, height: int) -> (Texture_Handle,
 
 	render_target_view: ^d3d11.IRenderTargetView
 
-	ch(s.device->CreateRenderTargetView(texture, &render_target_view_desc, &render_target_view))
+	if ch(s.device->CreateRenderTargetView(
+		texture, &render_target_view_desc, &render_target_view,
+	)) < 0 {
+		texture_view->Release()
+		texture->Release()
+		return TEXTURE_NONE, RENDER_TARGET_NONE, false
+	}
 
 	d3d11_texture := D3D11_Texture {
 		tex = texture,
@@ -638,30 +669,59 @@ d3d11_create_render_texture :: proc(width: int, height: int) -> (Texture_Handle,
 			BindFlags  = {.DEPTH_STENCIL},
 		}
 
-		ch(s.device->CreateTexture2D(&depth_buffer_desc, nil, &d3d11_render_target.depth_buffer))
+		if ch(s.device->CreateTexture2D(&depth_buffer_desc, nil, &d3d11_render_target.depth_buffer)) < 0 {
+			render_target_view->Release()
+			texture_view->Release()
+			texture->Release()
+			return TEXTURE_NONE, RENDER_TARGET_NONE, false
+		}
 
-		ch(s.device->CreateDepthStencilView(
+		if ch(s.device->CreateDepthStencilView(
 			d3d11_render_target.depth_buffer,
 			nil,
 			&d3d11_render_target.depth_buffer_view,
-		))
+		)) < 0 {
+			d3d11_render_target.depth_buffer->Release()
+			render_target_view->Release()
+			texture_view->Release()
+			texture->Release()
+			return TEXTURE_NONE, RENDER_TARGET_NONE, false
+		}
 	}
 
 	tex_handle, tex_add_err := hm.add(&s.textures, d3d11_texture)
 
 	if tex_add_err != nil {
 		log.errorf("Failed to add texture. Error: %v", tex_add_err)
-		return TEXTURE_NONE, RENDER_TARGET_NONE
+
+		if s.depth_test {
+			d3d11_render_target.depth_buffer_view->Release()
+			d3d11_render_target.depth_buffer->Release()
+		}
+
+		render_target_view->Release()
+		texture_view->Release()
+		texture->Release()
+		return TEXTURE_NONE, RENDER_TARGET_NONE, false
 	}
 
 	rt_handle, rt_add_err := hm.add(&s.render_targets, d3d11_render_target)
 
 	if rt_add_err != nil {
 		log.errorf("Failed to add render target. Error: %v", rt_add_err)
-		return TEXTURE_NONE, RENDER_TARGET_NONE
+
+		if s.depth_test {
+			d3d11_render_target.depth_buffer_view->Release()
+			d3d11_render_target.depth_buffer->Release()
+		}
+
+		render_target_view->Release()
+		texture_view->Release()
+		texture->Release()
+		return TEXTURE_NONE, RENDER_TARGET_NONE, false
 	}
 
-	return tex_handle, rt_handle
+	return tex_handle, rt_handle, true
 }
 
 d3d11_destroy_render_target :: proc(render_target: Render_Target_Handle) {
@@ -677,7 +737,12 @@ d3d11_destroy_render_target :: proc(render_target: Render_Target_Handle) {
 	hm.remove(&s.render_targets, render_target)
 }
 
-d3d11_load_texture :: proc(data: []u8, width: int, height: int, format: Pixel_Format) -> Texture_Handle {
+d3d11_load_texture :: proc(
+	data: []u8,
+	width: int,
+	height: int,
+	format: Pixel_Format,
+) -> (Texture_Handle, bool) {
 	return create_texture(width, height, format, raw_data(data))
 }
 
@@ -787,6 +852,7 @@ d3d11_load_shader :: proc(
 ) -> (
 	handle: Shader_Handle,
 	desc: Shader_Desc,
+	ok: bool,
 ) {
 	vs_blob: ^d3d11.IBlob
 	vs_blob_errors: ^d3d11.IBlob
@@ -937,10 +1003,10 @@ d3d11_load_shader :: proc(
 
 	if h_add_err != nil {
 		log.errorf("Failed to add shader. Error: %v", h_add_err)
-		return SHADER_NONE, {}
+		return SHADER_NONE, {}, false
 	}
 
-	return h, desc
+	return h, desc, true
 }
 
 D3D11_Shader_Type :: enum {

--- a/render_backend_d3d11.odin
+++ b/render_backend_d3d11.odin
@@ -963,7 +963,7 @@ d3d11_load_shader :: proc(
 	d3d_constant_buffers := make([dynamic]D3D11_Shader_Constant_Buffer, s.allocator)
 	d3d_texture_bindings := make([dynamic]D3D11_Texture_Binding, s.allocator)
 	texture_bindpoint_descs := make([dynamic]Shader_Texture_Bindpoint_Desc, desc_allocator)
-	reflect_shader_constants(
+	vs_constants_ok := reflect_shader_constants(
 		vs_desc,
 		vs_ref,
 		&constant_descs,
@@ -974,6 +974,16 @@ d3d11_load_shader :: proc(
 		desc_allocator,
 		.Vertex,
 	)
+
+	// Everything the reflection had to say has been copied out by now, names included.
+	vs_ref->Release()
+
+	if !vs_constants_ok {
+		release_constant_buffers(d3d_constant_buffers[:])
+		vertex_shader->Release()
+		vs_blob->Release()
+		return
+	}
 
 	input_layout_desc := make([]d3d11.INPUT_ELEMENT_DESC, len(desc.inputs), frame_allocator)
 
@@ -996,6 +1006,7 @@ d3d11_load_shader :: proc(
 		vs_blob->GetBufferSize(),
 		&input_layout,
 	)) < 0 {
+		release_constant_buffers(d3d_constant_buffers[:])
 		vertex_shader->Release()
 		vs_blob->Release()
 		return
@@ -1025,6 +1036,7 @@ d3d11_load_shader :: proc(
 	if ps_blob_errors != nil {
 		log.error("Failed compiling shader:")
 		log.error(strings.string_from_ptr((^u8)(ps_blob_errors->GetBufferPointer()), int(ps_blob_errors->GetBufferSize())))
+		release_constant_buffers(d3d_constant_buffers[:])
 		input_layout->Release()
 		vertex_shader->Release()
 		return
@@ -1032,6 +1044,7 @@ d3d11_load_shader :: proc(
 
 	if ps_compile_res < 0 || ps_blob == nil {
 		log.error("Failed compiling pixel shader.")
+		release_constant_buffers(d3d_constant_buffers[:])
 		input_layout->Release()
 		vertex_shader->Release()
 		return
@@ -1045,6 +1058,7 @@ d3d11_load_shader :: proc(
 		nil,
 		&pixel_shader,
 	)) < 0 {
+		release_constant_buffers(d3d_constant_buffers[:])
 		ps_blob->Release()
 		input_layout->Release()
 		vertex_shader->Release()
@@ -1059,6 +1073,7 @@ d3d11_load_shader :: proc(
 		d3d11.ID3D11ShaderReflection_UUID,
 		(^rawptr)(&ps_ref),
 	)) < 0 {
+		release_constant_buffers(d3d_constant_buffers[:])
 		pixel_shader->Release()
 		ps_blob->Release()
 		input_layout->Release()
@@ -1071,7 +1086,7 @@ d3d11_load_shader :: proc(
 	ps_desc: d3d11.SHADER_DESC
 	ch(ps_ref->GetDesc(&ps_desc))
 
-	reflect_shader_constants(
+	ps_constants_ok := reflect_shader_constants(
 		ps_desc,
 		ps_ref,
 		&constant_descs,
@@ -1082,6 +1097,16 @@ d3d11_load_shader :: proc(
 		desc_allocator,
 		.Pixel,
 	)
+
+	ps_ref->Release()
+
+	if !ps_constants_ok {
+		release_constant_buffers(d3d_constant_buffers[:])
+		pixel_shader->Release()
+		input_layout->Release()
+		vertex_shader->Release()
+		return
+	}
 
 	// Done with vertex and pixel shader. Just combine all the state.
 
@@ -1101,13 +1126,7 @@ d3d11_load_shader :: proc(
 
 	if h_add_err != nil {
 		log.errorf("Failed to add shader. Error: %v", h_add_err)
-
-		for c in d3d_constant_buffers {
-			if c.gpu_data != nil {
-				c.gpu_data->Release()
-			}
-		}
-
+		release_constant_buffers(d3d_constant_buffers[:])
 		input_layout->Release()
 		vertex_shader->Release()
 		pixel_shader->Release()
@@ -1122,6 +1141,16 @@ D3D11_Shader_Type :: enum {
 	Pixel,
 }
 
+// Shader loading creates constant buffers as it reflects over the vertex shader, so anything that
+// gives up after that point has to hand them back.
+release_constant_buffers :: proc(constant_buffers: []D3D11_Shader_Constant_Buffer) {
+	for c in constant_buffers {
+		if c.gpu_data != nil {
+			c.gpu_data->Release()
+		}
+	}
+}
+
 reflect_shader_constants :: proc(
 	d3d_desc: d3d11.SHADER_DESC,
 	ref: ^d3d11.IShaderReflection,
@@ -1132,7 +1161,7 @@ reflect_shader_constants :: proc(
 	texture_bindpoint_descs: ^[dynamic]Shader_Texture_Bindpoint_Desc,
 	desc_allocator: runtime.Allocator,
 	shader_type: D3D11_Shader_Type,
-) {
+) -> bool {
 	found_sampler_bindpoints := make([dynamic]u32, frame_allocator)
 
 	for br_idx in 0..<d3d_desc.BoundResources {
@@ -1189,7 +1218,13 @@ reflect_shader_constants :: proc(
 					bound_shaders = {shader_type},
 				}
 
-				ch(s.device->CreateBuffer(&constant_buffer_desc, nil, &buf.gpu_data))
+				// Without this buffer the shader never receives its constants, not even the
+				// view-projection matrix, so it would draw in the wrong place rather than fail.
+				if ch(s.device->CreateBuffer(&constant_buffer_desc, nil, &buf.gpu_data)) < 0 {
+					log.errorf("Failed creating constant buffer '%v'.", bind_desc.Name)
+					return false
+				}
+
 				buf.size = int(cb_desc.Size)
 				buf.bind_point = bind_desc.BindPoint
 				append(d3d_constant_buffers, buf)
@@ -1248,6 +1283,8 @@ reflect_shader_constants :: proc(
 			)
 		}
 	}
+
+	return true
 }
 
 d3d11_destroy_shader :: proc(h: Shader_Handle) {

--- a/render_backend_gl.odin
+++ b/render_backend_gl.odin
@@ -469,26 +469,35 @@ create_texture :: proc(width: int, height: int, format: Pixel_Format, data: rawp
 	}
 }
 
-gl_create_texture :: proc(width: int, height: int, format: Pixel_Format) -> Texture_Handle {
+gl_create_texture :: proc(
+	width: int,
+	height: int,
+	format: Pixel_Format,
+) -> (Texture_Handle, bool) {
 	tex, tex_add_err := hm.add(&s.textures, create_texture(width, height, format, nil))
 
 	if tex_add_err != nil {
 		log.errorf("Failed to create texture. Error: %v", tex_add_err)
-		return {}
+		return {}, false
 	}
 
-	return tex
+	return tex, true
 }
 
-gl_load_texture :: proc(data: []u8, width: int, height: int, format: Pixel_Format) -> Texture_Handle {
+gl_load_texture :: proc(
+	data: []u8,
+	width: int,
+	height: int,
+	format: Pixel_Format,
+) -> (Texture_Handle, bool) {
 	tex, tex_add_err := hm.add(&s.textures, create_texture(width, height, format, raw_data(data)))
 
 	if tex_add_err != nil {
 		log.errorf("Failed to load texture. Error: %v", tex_add_err)
-		return {}
+		return {}, false
 	}
 
-	return tex
+	return tex, true
 }
 
 gl_update_texture :: proc(th: Texture_Handle, data: []u8, rect: Rect) -> bool {
@@ -524,7 +533,10 @@ gl_texture_needs_vertical_flip :: proc(th: Texture_Handle) -> bool {
 	return tex.needs_vertical_flip
 }
 
-gl_create_render_texture :: proc(width: int, height: int) -> (Texture_Handle, Render_Target_Handle) {
+gl_create_render_texture :: proc(
+	width: int,
+	height: int,
+) -> (Texture_Handle, Render_Target_Handle, bool) {
 	texture := create_texture(width, height, .RGBA_32_Float, nil)
 	texture.needs_vertical_flip = true
 	
@@ -550,7 +562,7 @@ gl_create_render_texture :: proc(width: int, height: int) -> (Texture_Handle, Re
 
 	if gl.CheckFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE {
 		log.errorf("Failed creating frame buffer of size %v x %v", width, height)
-		return {}, {}
+		return {}, {}, false
 	}
 
 	gl.BindFramebuffer(gl.FRAMEBUFFER, 0)
@@ -567,16 +579,16 @@ gl_create_render_texture :: proc(width: int, height: int) -> (Texture_Handle, Re
 
 	if tex_add_err != nil {
 		log.errorf("Failed to create texture. Error: %v", tex_add_err)
-		return {}, {}
+		return {}, {}, false
 	}
 
 	rt_handle, rt_add_err := hm.add(&s.render_targets, rt)
 	if rt_add_err != nil {
 		log.errorf("Failed to create render target. Error: %v", rt_add_err)
-		return {}, {}
+		return {}, {}, false
 	}
 
-	return tex_handle, rt_handle
+	return tex_handle, rt_handle, true
 }
 
 gl_destroy_render_target :: proc(render_target: Render_Target_Handle) {
@@ -661,28 +673,33 @@ link_shader :: proc(vs_shader: u32, fs_shader: u32, err_buf: []u8, err_msg: ^str
 	return program_id, true
 }
 
-gl_load_shader :: proc(vs_source: []byte, fs_source: []byte, desc_allocator := frame_allocator, layout_formats: []Pixel_Format = {}) -> (handle: Shader_Handle, desc: Shader_Desc) {
+gl_load_shader :: proc(
+	vs_source: []byte,
+	fs_source: []byte,
+	desc_allocator := frame_allocator,
+	layout_formats: []Pixel_Format = {},
+) -> (handle: Shader_Handle, desc: Shader_Desc, ok: bool) {
 	@static err: [1024]u8
 	err_msg: string
 	vs_shader, vs_shader_ok := compile_shader_from_source(vs_source, gl.Shader_Type.VERTEX_SHADER, err[:], &err_msg)
 
 	if !vs_shader_ok  {
 		log.error(err_msg)
-		return {}, {}
+		return {}, {}, false
 	}
 	
 	fs_shader, fs_shader_ok := compile_shader_from_source(fs_source, gl.Shader_Type.FRAGMENT_SHADER, err[:], &err_msg)
 
 	if !fs_shader_ok {
 		log.error(err_msg)
-		return {}, {}
+		return {}, {}, false
 	}
 
 	program, program_ok := link_shader(vs_shader, fs_shader, err[:], &err_msg)
 
 	if !program_ok {
 		log.error(err_msg)
-		return {}, {}
+		return {}, {}, false
 	}
 
 	stride: int
@@ -897,10 +914,10 @@ gl_load_shader :: proc(vs_source: []byte, fs_source: []byte, desc_allocator := f
 	shader_handle, shader_add_err := hm.add(&s.shaders, gl_shd)
 	if shader_add_err != nil {
 		log.errorf("Failed to add shader. Error: %v", shader_add_err)
-		return SHADER_NONE, {}
+		return SHADER_NONE, {}, false
 	}
 
-	return shader_handle, desc
+	return shader_handle, desc, true
 }
 
 // I might have missed something. But it doesn't seem like GL gives you this information.

--- a/render_backend_gl.odin
+++ b/render_backend_gl.odin
@@ -562,6 +562,15 @@ gl_create_render_texture :: proc(
 
 	if gl.CheckFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE {
 		log.errorf("Failed creating frame buffer of size %v x %v", width, height)
+		gl.BindFramebuffer(gl.FRAMEBUFFER, 0)
+		gl.BindRenderbuffer(gl.RENDERBUFFER, 0)
+		gl.DeleteTextures(1, &texture.id)
+		gl.DeleteFramebuffers(1, &framebuffer)
+
+		if s.depth_test {
+			gl.DeleteRenderbuffers(1, &depth_renderbuffer)
+		}
+
 		return {}, {}, false
 	}
 
@@ -579,12 +588,27 @@ gl_create_render_texture :: proc(
 
 	if tex_add_err != nil {
 		log.errorf("Failed to create texture. Error: %v", tex_add_err)
+		gl.DeleteTextures(1, &texture.id)
+		gl.DeleteFramebuffers(1, &framebuffer)
+
+		if s.depth_test {
+			gl.DeleteRenderbuffers(1, &depth_renderbuffer)
+		}
+
 		return {}, {}, false
 	}
 
 	rt_handle, rt_add_err := hm.add(&s.render_targets, rt)
 	if rt_add_err != nil {
 		log.errorf("Failed to create render target. Error: %v", rt_add_err)
+		hm.remove(&s.textures, tex_handle)
+		gl.DeleteTextures(1, &texture.id)
+		gl.DeleteFramebuffers(1, &framebuffer)
+
+		if s.depth_test {
+			gl.DeleteRenderbuffers(1, &depth_renderbuffer)
+		}
+
 		return {}, {}, false
 	}
 

--- a/render_backend_gl.odin
+++ b/render_backend_gl.odin
@@ -450,7 +450,25 @@ gl_set_internal_state :: proc(state: rawptr) {
 	s = (^GL_State)(state)
 }
 
-create_texture :: proc(width: int, height: int, format: Pixel_Format, data: rawptr) -> GL_Texture {
+// GL hands out errors through a queue instead of return values, and nothing else in this backend
+// reads it, so it can hold something an earlier call left behind. Empty it, so that a check right
+// after a call only sees what that call did. The bound stops a lost context spinning here forever.
+GL_ERROR_QUEUE_DRAIN_LIMIT :: 32
+
+drain_gl_errors :: proc() {
+	for _ in 0..<GL_ERROR_QUEUE_DRAIN_LIMIT {
+		if gl.GetError() == gl.NO_ERROR {
+			return
+		}
+	}
+}
+
+create_texture :: proc(
+	width: int,
+	height: int,
+	format: Pixel_Format,
+	data: rawptr,
+) -> (GL_Texture, bool) {
 	id: u32
 	gl.GenTextures(1, &id)
 	gl.BindTexture(gl.TEXTURE_2D, id)
@@ -460,13 +478,23 @@ create_texture :: proc(width: int, height: int, format: Pixel_Format, data: rawp
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
 
+	drain_gl_errors()
+
 	pf := gl_translate_pixel_format(format)
 	gl.TexImage2D(gl.TEXTURE_2D, 0, pf, i32(width), i32(height), 0, gl.RGBA, gl.UNSIGNED_BYTE, data)
+
+	// This is where a texture that is too big for the GPU, or one the GPU has no memory left for,
+	// gets caught. Without the check it would become a texture that silently draws nothing.
+	if err := gl.GetError(); err != gl.NO_ERROR {
+		log.errorf("Failed creating %v x %v texture. GL error: 0x%x", width, height, err)
+		gl.DeleteTextures(1, &id)
+		return {}, false
+	}
 
 	return {
 		id = id,
 		format = format,
-	}
+	}, true
 }
 
 gl_create_texture :: proc(
@@ -474,10 +502,17 @@ gl_create_texture :: proc(
 	height: int,
 	format: Pixel_Format,
 ) -> (Texture_Handle, bool) {
-	tex, tex_add_err := hm.add(&s.textures, create_texture(width, height, format, nil))
+	gl_tex, gl_tex_ok := create_texture(width, height, format, nil)
+
+	if !gl_tex_ok {
+		return {}, false
+	}
+
+	tex, tex_add_err := hm.add(&s.textures, gl_tex)
 
 	if tex_add_err != nil {
 		log.errorf("Failed to create texture. Error: %v", tex_add_err)
+		gl.DeleteTextures(1, &gl_tex.id)
 		return {}, false
 	}
 
@@ -490,10 +525,17 @@ gl_load_texture :: proc(
 	height: int,
 	format: Pixel_Format,
 ) -> (Texture_Handle, bool) {
-	tex, tex_add_err := hm.add(&s.textures, create_texture(width, height, format, raw_data(data)))
+	gl_tex, gl_tex_ok := create_texture(width, height, format, raw_data(data))
+
+	if !gl_tex_ok {
+		return {}, false
+	}
+
+	tex, tex_add_err := hm.add(&s.textures, gl_tex)
 
 	if tex_add_err != nil {
 		log.errorf("Failed to load texture. Error: %v", tex_add_err)
+		gl.DeleteTextures(1, &gl_tex.id)
 		return {}, false
 	}
 
@@ -537,7 +579,12 @@ gl_create_render_texture :: proc(
 	width: int,
 	height: int,
 ) -> (Texture_Handle, Render_Target_Handle, bool) {
-	texture := create_texture(width, height, .RGBA_32_Float, nil)
+	texture, texture_ok := create_texture(width, height, .RGBA_32_Float, nil)
+
+	if !texture_ok {
+		return {}, {}, false
+	}
+
 	texture.needs_vertical_flip = true
 	
 	framebuffer: u32

--- a/render_backend_gl.odin
+++ b/render_backend_gl.odin
@@ -749,28 +749,37 @@ gl_load_shader :: proc(
 	fs_source: []byte,
 	desc_allocator := frame_allocator,
 	layout_formats: []Pixel_Format = {},
-) -> (handle: Shader_Handle, desc: Shader_Desc, ok: bool) {
+) -> (
+	_handle: Shader_Handle,
+	_desc: Shader_Desc,
+	_ok: bool,
+) {
+	// Built up as the shaders are reflected over, and only handed back once everything worked.
+	// Filling in a named return value instead would mean the naked returns below hand out a
+	// half-built description alongside their `false`.
+	desc: Shader_Desc
+
 	@static err: [1024]u8
 	err_msg: string
 	vs_shader, vs_shader_ok := compile_shader_from_source(vs_source, gl.Shader_Type.VERTEX_SHADER, err[:], &err_msg)
 
 	if !vs_shader_ok  {
 		log.error(err_msg)
-		return {}, {}, false
+		return
 	}
 	
 	fs_shader, fs_shader_ok := compile_shader_from_source(fs_source, gl.Shader_Type.FRAGMENT_SHADER, err[:], &err_msg)
 
 	if !fs_shader_ok {
 		log.error(err_msg)
-		return {}, {}, false
+		return
 	}
 
 	program, program_ok := link_shader(vs_shader, fs_shader, err[:], &err_msg)
 
 	if !program_ok {
 		log.error(err_msg)
-		return {}, {}, false
+		return
 	}
 
 	stride: int
@@ -985,7 +994,7 @@ gl_load_shader :: proc(
 	shader_handle, shader_add_err := hm.add(&s.shaders, gl_shd)
 	if shader_add_err != nil {
 		log.errorf("Failed to add shader. Error: %v", shader_add_err)
-		return SHADER_NONE, {}, false
+		return
 	}
 
 	return shader_handle, desc, true

--- a/render_backend_interface.odin
+++ b/render_backend_interface.odin
@@ -86,13 +86,21 @@ Render_Backend_Interface :: struct #all_or_none {
 
 	set_internal_state: proc(state: rawptr),
 
-	create_texture: proc(width: int, height: int, format: Pixel_Format) -> Texture_Handle,
-	load_texture: proc(data: []u8, width: int, height: int, format: Pixel_Format) -> Texture_Handle,
+	create_texture: proc(width: int, height: int, format: Pixel_Format) -> (Texture_Handle, bool),
+	load_texture: proc(
+		data: []u8,
+		width: int,
+		height: int,
+		format: Pixel_Format,
+	) -> (Texture_Handle, bool),
 	update_texture: proc(handle: Texture_Handle, data: []u8, rect: Rect) -> bool,
 	destroy_texture: proc(handle: Texture_Handle),
 	texture_needs_vertical_flip: proc(handle: Texture_Handle) -> bool,
 
-	create_render_texture: proc(width: int, height: int) -> (Texture_Handle, Render_Target_Handle),
+	create_render_texture: proc(
+		width: int,
+		height: int,
+	) -> (Texture_Handle, Render_Target_Handle, bool),
 	destroy_render_target: proc(render_texture: Render_Target_Handle),
 	
 	set_texture_filter: proc(
@@ -110,6 +118,7 @@ Render_Backend_Interface :: struct #all_or_none {
 	) -> (
 		handle: Shader_Handle,
 		desc: Shader_Desc,
+		ok: bool,
 	),
 
 	destroy_shader: proc(shader: Shader_Handle),

--- a/render_backend_nil.odin
+++ b/render_backend_nil.odin
@@ -94,12 +94,21 @@ rbnil_get_swapchain_height :: proc() -> int {
 rbnil_set_internal_state :: proc(state: rawptr) {
 }
 
-rbnil_create_texture :: proc(width: int, height: int, format: Pixel_Format) -> Texture_Handle {
-	return Texture_Handle(rbnil_handle())
+rbnil_create_texture :: proc(
+	width: int,
+	height: int,
+	format: Pixel_Format,
+) -> (Texture_Handle, bool) {
+	return Texture_Handle(rbnil_handle()), true
 }
 
-rbnil_load_texture :: proc(data: []u8, width: int, height: int, format: Pixel_Format) -> Texture_Handle {
-	return Texture_Handle(rbnil_handle())
+rbnil_load_texture :: proc(
+	data: []u8,
+	width: int,
+	height: int,
+	format: Pixel_Format,
+) -> (Texture_Handle, bool) {
+	return Texture_Handle(rbnil_handle()), true
 }
 
 rbnil_update_texture :: proc(th: Texture_Handle, data: []u8, rect: Rect) -> bool {
@@ -113,8 +122,11 @@ rbnil_texture_needs_vertical_flip :: proc(th: Texture_Handle) -> bool {
 	return false
 }
 
-rbnil_create_render_texture :: proc(width: int, height: int) -> (Texture_Handle, Render_Target_Handle) {
-	return Texture_Handle(rbnil_handle()), Render_Target_Handle(rbnil_handle())
+rbnil_create_render_texture :: proc(
+	width: int,
+	height: int,
+) -> (Texture_Handle, Render_Target_Handle, bool) {
+	return Texture_Handle(rbnil_handle()), Render_Target_Handle(rbnil_handle()), true
 }
 
 rbnil_destroy_render_target :: proc(render_target: Render_Target_Handle) {
@@ -141,6 +153,7 @@ rbnil_load_shader :: proc(
 ) -> (
 	handle: Shader_Handle,
 	desc: Shader_Desc,
+	ok: bool,
 ) {
 	inputs := make([]Shader_Input, 3, desc_allocator)
 	inputs[0] = { name = "position", register = 0, type = .Vec2, format = .RG_32_Float }
@@ -163,7 +176,7 @@ rbnil_load_shader :: proc(
 		constants = constants,
 		texture_bindpoints = texture_bindpoints,
 		inputs = inputs,
-	}
+	}, true
 }
 
 rbnil_destroy_shader :: proc(h: Shader_Handle) {

--- a/render_backend_webgl.odin
+++ b/render_backend_webgl.odin
@@ -541,6 +541,15 @@ webgl_create_render_texture :: proc(
 
 	if gl.CheckFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE {
 		log.errorf("Failed creating frame buffer of size %v x %v", width, height)
+		gl.BindFramebuffer(gl.FRAMEBUFFER, 0)
+		gl.BindRenderbuffer(gl.RENDERBUFFER, 0)
+		gl.DeleteTexture(texture.id)
+		gl.DeleteFramebuffer(framebuffer)
+
+		if s.depth_test {
+			gl.DeleteRenderbuffer(depth_renderbuffer)
+		}
+
 		return TEXTURE_NONE, RENDER_TARGET_NONE, false
 	}
 
@@ -560,6 +569,11 @@ webgl_create_render_texture :: proc(
 		log.errorf("Failed adding texture to handle map: %v", texture_handle_err)
 		gl.DeleteTexture(texture.id)
 		gl.DeleteFramebuffer(framebuffer)
+
+		if s.depth_test {
+			gl.DeleteRenderbuffer(depth_renderbuffer)
+		}
+
 		return TEXTURE_NONE, RENDER_TARGET_NONE, false
 	}
 
@@ -567,8 +581,14 @@ webgl_create_render_texture :: proc(
 
 	if render_target_handle_err != nil {
 		log.errorf("Failed adding render target to handle map: %v", render_target_handle_err)
+		hm.remove(&s.textures, texture_handle)
 		gl.DeleteTexture(texture.id)
 		gl.DeleteFramebuffer(framebuffer)
+
+		if s.depth_test {
+			gl.DeleteRenderbuffer(depth_renderbuffer)
+		}
+
 		return TEXTURE_NONE, RENDER_TARGET_NONE, false
 	}
 

--- a/render_backend_webgl.odin
+++ b/render_backend_webgl.odin
@@ -430,7 +430,25 @@ webgl_set_internal_state :: proc(state: rawptr) {
 	s = (^WebGL_State)(state)
 }
 
-create_texture :: proc(width: int, height: int, format: Pixel_Format, data: rawptr) -> WebGL_Texture {
+// WebGL hands out errors through a queue instead of return values, and nothing else in this backend
+// reads it, so it can hold something an earlier call left behind. Empty it, so that a check right
+// after a call only sees what that call did. The bound stops a lost context spinning here forever.
+GL_ERROR_QUEUE_DRAIN_LIMIT :: 32
+
+drain_gl_errors :: proc() {
+	for _ in 0..<GL_ERROR_QUEUE_DRAIN_LIMIT {
+		if gl.GetError() == gl.NO_ERROR {
+			return
+		}
+	}
+}
+
+create_texture :: proc(
+	width: int,
+	height: int,
+	format: Pixel_Format,
+	data: rawptr,
+) -> (WebGL_Texture, bool) {
 	id := gl.CreateTexture()
 	gl.BindTexture(gl.TEXTURE_2D, id)
 
@@ -441,13 +459,23 @@ create_texture :: proc(width: int, height: int, format: Pixel_Format, data: rawp
 
 	pf := gl_translate_pixel_format(format)
 
+	drain_gl_errors()
+
 	data_size := width*height*pixel_format_size(format)
 	gl.TexImage2D(gl.TEXTURE_2D, 0, pf, i32(width), i32(height), 0, gl.RGBA, gl.UNSIGNED_BYTE, data_size, data)
+
+	// This is where a texture that is too big for the GPU, or one the GPU has no memory left for,
+	// gets caught. Without the check it would become a texture that silently draws nothing.
+	if err := gl.GetError(); err != gl.NO_ERROR {
+		log.errorf("Failed creating %v x %v texture. GL error: %v", width, height, err)
+		gl.DeleteTexture(id)
+		return {}, false
+	}
 
 	return {
 		id = id,
 		format = format,
-	}
+	}, true
 }
 
 webgl_create_texture :: proc(
@@ -455,10 +483,17 @@ webgl_create_texture :: proc(
 	height: int,
 	format: Pixel_Format,
 ) -> (Texture_Handle, bool) {
-	texture_handle, texture_handle_err := hm.add(&s.textures, create_texture(width, height, format, nil))
+	texture, texture_ok := create_texture(width, height, format, nil)
+
+	if !texture_ok {
+		return TEXTURE_NONE, false
+	}
+
+	texture_handle, texture_handle_err := hm.add(&s.textures, texture)
 
 	if texture_handle_err != nil {
 		log.errorf("Failed adding texture to handle map: %v", texture_handle_err)
+		gl.DeleteTexture(texture.id)
 		return TEXTURE_NONE, false
 	}
 
@@ -471,10 +506,17 @@ webgl_load_texture :: proc(
 	height: int,
 	format: Pixel_Format,
 ) -> (Texture_Handle, bool) {
-	texture_handle, texture_handle_err := hm.add(&s.textures, create_texture(width, height, format, raw_data(data)))
+	texture, texture_ok := create_texture(width, height, format, raw_data(data))
+
+	if !texture_ok {
+		return TEXTURE_NONE, false
+	}
+
+	texture_handle, texture_handle_err := hm.add(&s.textures, texture)
 
 	if texture_handle_err != nil {
 		log.errorf("Failed adding texture to handle map: %v", texture_handle_err)
+		gl.DeleteTexture(texture.id)
 		return TEXTURE_NONE, false
 	}
 
@@ -518,7 +560,12 @@ webgl_create_render_texture :: proc(
 	width: int,
 	height: int,
 ) -> (Texture_Handle, Render_Target_Handle, bool) {
-	texture := create_texture(width, height, .RGBA_32_Float, nil)
+	texture, texture_ok := create_texture(width, height, .RGBA_32_Float, nil)
+
+	if !texture_ok {
+		return TEXTURE_NONE, RENDER_TARGET_NONE, false
+	}
+
 	texture.needs_vertical_flip = true
 	
 	framebuffer := gl.CreateFramebuffer()

--- a/render_backend_webgl.odin
+++ b/render_backend_webgl.odin
@@ -450,26 +450,35 @@ create_texture :: proc(width: int, height: int, format: Pixel_Format, data: rawp
 	}
 }
 
-webgl_create_texture :: proc(width: int, height: int, format: Pixel_Format) -> Texture_Handle {
+webgl_create_texture :: proc(
+	width: int,
+	height: int,
+	format: Pixel_Format,
+) -> (Texture_Handle, bool) {
 	texture_handle, texture_handle_err := hm.add(&s.textures, create_texture(width, height, format, nil))
 
 	if texture_handle_err != nil {
 		log.errorf("Failed adding texture to handle map: %v", texture_handle_err)
-		return TEXTURE_NONE
+		return TEXTURE_NONE, false
 	}
 
-	return texture_handle
+	return texture_handle, true
 }
 
-webgl_load_texture :: proc(data: []u8, width: int, height: int, format: Pixel_Format) -> Texture_Handle {
+webgl_load_texture :: proc(
+	data: []u8,
+	width: int,
+	height: int,
+	format: Pixel_Format,
+) -> (Texture_Handle, bool) {
 	texture_handle, texture_handle_err := hm.add(&s.textures, create_texture(width, height, format, raw_data(data)))
 
 	if texture_handle_err != nil {
 		log.errorf("Failed adding texture to handle map: %v", texture_handle_err)
-		return TEXTURE_NONE
+		return TEXTURE_NONE, false
 	}
 
-	return texture_handle
+	return texture_handle, true
 }
 
 webgl_update_texture :: proc(th: Texture_Handle, data: []u8, rect: Rect) -> bool {
@@ -505,7 +514,10 @@ webgl_texture_needs_vertical_flip :: proc(th: Texture_Handle) -> bool {
 	return tex.needs_vertical_flip
 }
 
-webgl_create_render_texture :: proc(width: int, height: int) -> (Texture_Handle, Render_Target_Handle) {
+webgl_create_render_texture :: proc(
+	width: int,
+	height: int,
+) -> (Texture_Handle, Render_Target_Handle, bool) {
 	texture := create_texture(width, height, .RGBA_32_Float, nil)
 	texture.needs_vertical_flip = true
 	
@@ -529,7 +541,7 @@ webgl_create_render_texture :: proc(width: int, height: int) -> (Texture_Handle,
 
 	if gl.CheckFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE {
 		log.errorf("Failed creating frame buffer of size %v x %v", width, height)
-		return TEXTURE_NONE, RENDER_TARGET_NONE
+		return TEXTURE_NONE, RENDER_TARGET_NONE, false
 	}
 
 	gl.BindFramebuffer(gl.FRAMEBUFFER, 0)
@@ -548,7 +560,7 @@ webgl_create_render_texture :: proc(width: int, height: int) -> (Texture_Handle,
 		log.errorf("Failed adding texture to handle map: %v", texture_handle_err)
 		gl.DeleteTexture(texture.id)
 		gl.DeleteFramebuffer(framebuffer)
-		return TEXTURE_NONE, RENDER_TARGET_NONE
+		return TEXTURE_NONE, RENDER_TARGET_NONE, false
 	}
 
 	render_target_handle, render_target_handle_err := hm.add(&s.render_targets, rt)
@@ -557,10 +569,10 @@ webgl_create_render_texture :: proc(width: int, height: int) -> (Texture_Handle,
 		log.errorf("Failed adding render target to handle map: %v", render_target_handle_err)
 		gl.DeleteTexture(texture.id)
 		gl.DeleteFramebuffer(framebuffer)
-		return TEXTURE_NONE, RENDER_TARGET_NONE
+		return TEXTURE_NONE, RENDER_TARGET_NONE, false
 	}
 
-	return texture_handle, render_target_handle
+	return texture_handle, render_target_handle, true
 }
 
 webgl_destroy_render_target :: proc(render_target: Render_Target_Handle) {
@@ -637,28 +649,33 @@ link_shader :: proc(vs_shader: gl.Shader, fs_shader: gl.Shader, err_buf: []u8, e
 	return program_id, true
 }
 
-webgl_load_shader :: proc(vs_source: []byte, fs_source: []byte, desc_allocator := frame_allocator, layout_formats: []Pixel_Format = {}) -> (handle: Shader_Handle, desc: Shader_Desc) {
+webgl_load_shader :: proc(
+	vs_source: []byte,
+	fs_source: []byte,
+	desc_allocator := frame_allocator,
+	layout_formats: []Pixel_Format = {},
+) -> (handle: Shader_Handle, desc: Shader_Desc, ok: bool) {
 	@static err: [1024]u8
 	err_msg: string
 	vs_shader, vs_shader_ok := compile_shader_from_source(vs_source, gl.VERTEX_SHADER, err[:], &err_msg)
 
 	if !vs_shader_ok  {
 		log.error(err_msg)
-		return {}, {}
+		return {}, {}, false
 	}
 	
 	fs_shader, fs_shader_ok := compile_shader_from_source(fs_source, gl.FRAGMENT_SHADER, err[:], &err_msg)
 
 	if !fs_shader_ok {
 		log.error(err_msg)
-		return {}, {}
+		return {}, {}, false
 	}
 
 	program, program_ok := link_shader(vs_shader, fs_shader, err[:], &err_msg)
 
 	if !program_ok {
 		log.error(err_msg)
-		return {}, {}
+		return {}, {}, false
 	}
 
 	stride: int
@@ -841,10 +858,10 @@ webgl_load_shader :: proc(vs_source: []byte, fs_source: []byte, desc_allocator :
 		gl.DeleteProgram(program)
 		gl.DeleteShader(vs_shader)
 		gl.DeleteShader(fs_shader)
-		return SHADER_NONE, {}
+		return SHADER_NONE, {}, false
 	}
 
-	return shader_handle, desc
+	return shader_handle, desc, true
 }
 
 // I might have missed something. But it doesn't seem like GL gives you this information.

--- a/render_backend_webgl.odin
+++ b/render_backend_webgl.odin
@@ -721,28 +721,37 @@ webgl_load_shader :: proc(
 	fs_source: []byte,
 	desc_allocator := frame_allocator,
 	layout_formats: []Pixel_Format = {},
-) -> (handle: Shader_Handle, desc: Shader_Desc, ok: bool) {
+) -> (
+	_handle: Shader_Handle,
+	_desc: Shader_Desc,
+	_ok: bool,
+) {
+	// Built up as the shaders are reflected over, and only handed back once everything worked.
+	// Filling in a named return value instead would mean the naked returns below hand out a
+	// half-built description alongside their `false`.
+	desc: Shader_Desc
+
 	@static err: [1024]u8
 	err_msg: string
 	vs_shader, vs_shader_ok := compile_shader_from_source(vs_source, gl.VERTEX_SHADER, err[:], &err_msg)
 
 	if !vs_shader_ok  {
 		log.error(err_msg)
-		return {}, {}, false
+		return
 	}
 	
 	fs_shader, fs_shader_ok := compile_shader_from_source(fs_source, gl.FRAGMENT_SHADER, err[:], &err_msg)
 
 	if !fs_shader_ok {
 		log.error(err_msg)
-		return {}, {}, false
+		return
 	}
 
 	program, program_ok := link_shader(vs_shader, fs_shader, err[:], &err_msg)
 
 	if !program_ok {
 		log.error(err_msg)
-		return {}, {}, false
+		return
 	}
 
 	stride: int
@@ -925,7 +934,7 @@ webgl_load_shader :: proc(
 		gl.DeleteProgram(program)
 		gl.DeleteShader(vs_shader)
 		gl.DeleteShader(fs_shader)
-		return SHADER_NONE, {}, false
+		return
 	}
 
 	return shader_handle, desc, true

--- a/tests/coordinate_system/render_texture_flip_test.odin
+++ b/tests/coordinate_system/render_texture_flip_test.odin
@@ -13,7 +13,6 @@
 package karl2d_coordinate_system_test
 
 import k2 "../.."
-import "core:sync"
 import "core:testing"
 
 RT_W :: 64

--- a/tools/api_doc_builder/api_doc_builder.odin
+++ b/tools/api_doc_builder/api_doc_builder.odin
@@ -10,6 +10,50 @@ import "core:odin/parser"
 import "core:odin/ast"
 import "core:strings"
 
+// Writes a procedure type the way the doc file should show it, which is not quite what the source
+// says.
+//
+// Return values lose their names. A name like `_ok` is there to stop the implementation assigning
+// to it, so it says nothing to somebody reading the API, and it would make two procedures that
+// return the same thing look like they differ.
+//
+// Tags such as `#optional_ok` have to be written back out. The parser keeps them in a bit set
+// rather than in the source range of the procedure type.
+proc_type_text :: proc(f: ^ast.File, type: ^ast.Proc_Type) -> string {
+	tag := ""
+
+	if .Optional_Ok in type.tags {
+		tag = " #optional_ok"
+	}
+
+	if type.results == nil || len(type.results.list) == 0 {
+		return fmt.tprintf("%v%v", f.src[type.pos.offset:type.end.offset], tag)
+	}
+
+	results := make([dynamic]string, context.temp_allocator)
+
+	for field in type.results.list {
+		// A field is one type plus the names that share it, so `(a, b: int)` is a single field
+		// standing for two return values. Dropping the names has to leave two entries behind.
+		// A return value with no name at all reports one name that is the type itself, so the
+		// count is right either way and the type is what we want in both cases.
+		for _ in 0..<max(len(field.names), 1) {
+			append(&results, f.src[field.type.pos.offset:field.type.end.offset])
+		}
+	}
+
+	// The parameters are used exactly as they are written, so a signature that splits them over
+	// several lines keeps them that way. `params.end` sits on the closing parenthesis.
+	params := f.src[type.pos.offset:type.params.end.offset + 1]
+
+	if len(results) == 1 {
+		return fmt.tprintf("%v -> %v%v", params, results[0], tag)
+	}
+
+	joined := strings.join(results[:], ", ", context.temp_allocator)
+	return fmt.tprintf("%v -> (%v)%v", params, joined, tag)
+}
+
 main :: proc() {
 	context.logger = log.create_console_logger()
 
@@ -55,15 +99,7 @@ main :: proc() {
 					#partial switch vd in v.derived {
 					case ^ast.Proc_Lit:
 						name := f.src[dd.names[vi].pos.offset:dd.names[vi].end.offset]
-						type := f.src[vd.type.pos.offset:vd.type.end.offset]
-
-						// The parser puts tags such as `#optional_ok` in a bit set, so they are
-						// not part of the source range of the procedure type. Write them back out.
-						if .Optional_Ok in vd.type.tags {
-							type = fmt.tprintf("%v #optional_ok", type)
-						}
-
-						val = fmt.tprintf("%v :: %v", name, type)
+						val = fmt.tprintf("%v :: %v", name, proc_type_text(f, vd.type))
 					}
 				}
 

--- a/tools/api_doc_builder/api_doc_builder.odin
+++ b/tools/api_doc_builder/api_doc_builder.odin
@@ -10,12 +10,19 @@ import "core:odin/parser"
 import "core:odin/ast"
 import "core:strings"
 
+// A return value with no name at all still reports one name, and that name is the type itself.
+// Comparing the positions is what tells a real name apart from that.
+result_is_named :: proc(f: ^ast.File, field: ^ast.Field) -> bool {
+	return len(field.names) > 0 && field.names[0].pos.offset != field.type.pos.offset
+}
+
 // Writes a procedure type the way the doc file should show it, which is not quite what the source
 // says.
 //
-// Return values lose their names. A name like `_ok` is there to stop the implementation assigning
-// to it, so it says nothing to somebody reading the API, and it would make two procedures that
-// return the same thing look like they differ.
+// Return values whose name starts with an underscore lose it. That name is there to stop the
+// implementation assigning to the return value, so it says nothing to somebody reading the API, and
+// it would make two procedures that return the same thing look like they differ. A return value
+// named anything else was named to describe itself, so that name is kept.
 //
 // Tags such as `#optional_ok` have to be written back out. The parser keeps them in a bit set
 // rather than in the source range of the procedure type.
@@ -30,15 +37,42 @@ proc_type_text :: proc(f: ^ast.File, type: ^ast.Proc_Type) -> string {
 		return fmt.tprintf("%v%v", f.src[type.pos.offset:type.end.offset], tag)
 	}
 
-	results := make([dynamic]string, context.temp_allocator)
+	// The underscore only counts when it is on every name. Odin does not let a procedure mix named
+	// and unnamed return values, so dropping some of the names and keeping the rest would write out
+	// a signature that does not parse.
+	strip_names := true
 
 	for field in type.results.list {
-		// A field is one type plus the names that share it, so `(a, b: int)` is a single field
-		// standing for two return values. Dropping the names has to leave two entries behind.
-		// A return value with no name at all reports one name that is the type itself, so the
-		// count is right either way and the type is what we want in both cases.
-		for _ in 0..<max(len(field.names), 1) {
-			append(&results, f.src[field.type.pos.offset:field.type.end.offset])
+		if !result_is_named(f, field) {
+			continue
+		}
+
+		for n in field.names {
+			if !strings.has_prefix(f.src[n.pos.offset:n.end.offset], "_") {
+				strip_names = false
+			}
+		}
+	}
+
+	results := make([dynamic]string, context.temp_allocator)
+	kept_a_name := false
+
+	for field in type.results.list {
+		type_src := f.src[field.type.pos.offset:field.type.end.offset]
+
+		if strip_names || !result_is_named(f, field) {
+			// A field is one type plus the names that share it, so `(a, b: int)` is a single field
+			// standing for two return values, and has to leave two entries behind.
+			for _ in 0..<max(len(field.names), 1) {
+				append(&results, type_src)
+			}
+
+			continue
+		}
+
+		for n in field.names {
+			append(&results, fmt.tprintf("%v: %v", f.src[n.pos.offset:n.end.offset], type_src))
+			kept_a_name = true
 		}
 	}
 
@@ -46,7 +80,9 @@ proc_type_text :: proc(f: ^ast.File, type: ^ast.Proc_Type) -> string {
 	// several lines keeps them that way. `params.end` sits on the closing parenthesis.
 	params := f.src[type.pos.offset:type.params.end.offset + 1]
 
-	if len(results) == 1 {
+	// A lone return value only needs the parentheses back if it kept a name, since `-> name: T` is
+	// not something you can write.
+	if len(results) == 1 && !kept_a_name {
 		return fmt.tprintf("%v -> %v%v", params, results[0], tag)
 	}
 

--- a/tools/api_doc_builder/api_doc_builder.odin
+++ b/tools/api_doc_builder/api_doc_builder.odin
@@ -56,6 +56,13 @@ main :: proc() {
 					case ^ast.Proc_Lit:
 						name := f.src[dd.names[vi].pos.offset:dd.names[vi].end.offset]
 						type := f.src[vd.type.pos.offset:vd.type.end.offset]
+
+						// The parser puts tags such as `#optional_ok` in a bit set, so they are
+						// not part of the source range of the procedure type. Write them back out.
+						if .Optional_Ok in vd.type.tags {
+							type = fmt.tprintf("%v #optional_ok", type)
+						}
+
 						val = fmt.tprintf("%v :: %v", name, type)
 					}
 				}


### PR DESCRIPTION
Every procedure that loads or creates a resource now returns a second `bool`, marked `#optional_ok`,
so there is one way to find out that something failed instead of checking a handle in some cases and
a struct field in others. Fixes #231.

### API changes

These twenty now return a second `bool`, marked `#optional_ok`:

`create_texture`, `load_texture_from_file`, `load_texture_from_bytes`, `load_texture_from_bytes_raw`,
`load_texture_from_image`, `load_image_from_file`, `load_image_from_bytes`,
`load_audio_clip_from_file`, `load_audio_clip_from_bytes`, `load_audio_clip_from_bytes_raw`,
`load_audio_stream_from_file`, `load_audio_stream_from_bytes`, `create_render_texture`,
`load_static_font_from_file`, `load_static_font_from_bytes`, `load_dynamic_font_from_file`,
`load_dynamic_font_from_bytes`, `create_custom_cursor`, `load_shader_from_file`,
`load_shader_from_bytes`.

Each says in its doc comment what the returned value does if you use it anyway, which differs by
type. A failed `Texture` draws nothing, a failed `Font` draws with the default font, a failed
`Shader` does nothing when you set it.

`load_image` is now `load_image_from_file`. It was the only loader without a `_from_file` suffix.

`create_audio_bus`, `play_audio_clip` and `play_audio_stream` are unchanged. The first only fails
when an allocation fails, and the other two start playback of a resource that already exists rather
than creating one.

All of this is backwards compatible. `#optional_ok` means the second value can be ignored, so
`tex := k2.load_texture_from_file("cat.png")` still compiles unchanged, and so does passing a call
straight into another procedure or into a struct literal. `load_image` stays as an `@(deprecated)`
forwarder.

### Other changes

- The render and platform backends return their own failure information now, instead of
  `karl2d.odin` guessing from a `*_NONE` handle. `create_texture`, `load_texture`,
  `create_render_texture`, `load_shader` and `create_custom_cursor` all gained a `bool`.
- The D3D11 backend was throwing away the `HRESULT` of most of its calls, so a shader that failed to
  compile could crash on a nil blob and a texture the GPU refused became a texture that silently
  drew nothing. Those are checked now, and the failure paths release what they had already created.
- The GL and WebGL backends check `glGetError` after uploading a texture, which is what catches a
  texture that is too large or that the GPU has no memory for.
- `load_dynamic_font_from_bytes` never validated its TTF data or checked its atlas texture, so a
  broken font silently drew nothing.
- The shader loaders in all three backends build their `Shader_Desc` in a local instead of filling
  in a named return value, so a failure hands back an empty one rather than a half-built one.
- `tools/api_doc_builder` writes `#optional_ok` into `karl2d.doc.odin`, since the parser keeps it in
  a bit set and it was getting dropped. It also leaves out return value names that start with an
  underscore, which are an implementation detail.
- `agent.md` describes when to use named return values, why they start with an underscore, and how
  to split a signature over several lines.
- `tests/coordinate_system/render_texture_flip_test.odin` had a dead `import "core:sync"` that made
  the suite fail under `-vet`.

Created with the help of Claude Code