### PR TITLE
Balance law for stereo sounds

### DIFF
--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -562,6 +562,11 @@ sound_is_valid :: proc(sound: Sound) -> bool
 set_sound_volume :: proc(sound: Sound, volume: f32)
 
 // Set the pan of a sound. Range: -1 to 1, where -1 is full left, 0 is center and 1 is full right.
+//
+// What pan does depends on the audio clip. A mono clip is moved between the left and right
+// speakers while keeping its overall loudness the same. A stereo clip is already a finished stereo
+// mix, so instead of moving it, pan turns the opposite side down. Either way, a sound at pan 0
+// plays at the level it was authored at.
 set_sound_pan :: proc(sound: Sound, pan: f32)
 
 // Set the pitch of a sound. Range: 0.01 and up, where 1 is the default. Pitch 2 makes the sound
@@ -713,10 +718,10 @@ set_audio_bus_volume :: proc(bus: Audio_Bus, volume: f32)
 // Set the pan of an audio bus. Range: -1 to 1, where -1 is full left, 0 is center and 1 is full
 // right.
 //
-// This is a balance control: It turns the opposite side down. The pan of a sound works
-// differently: It moves the sound between the left and right speakers while keeping the overall
-// loudness the same. A bus is already a finished stereo mix, and a bus at pan 0 has to leave it
-// exactly as it is.
+// This is a balance control: It turns the opposite side down. A bus is already a finished stereo
+// mix, and a bus at pan 0 has to leave it exactly as it is. A sound that plays a mono clip works
+// differently: It moves between the left and right speakers while keeping the overall loudness the
+// same. See `set_sound_pan`.
 set_audio_bus_pan :: proc(bus: Audio_Bus, pan: f32)
 
 // Set an effect to run on everything that is mixed into the bus. This is how you apply your own

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -2046,6 +2046,11 @@ set_sound_volume :: proc(sound: Sound, volume: f32) {
 }
 
 // Set the pan of a sound. Range: -1 to 1, where -1 is full left, 0 is center and 1 is full right.
+//
+// What pan does depends on the audio clip. A mono clip is moved between the left and right
+// speakers while keeping its overall loudness the same. A stereo clip is already a finished stereo
+// mix, so instead of moving it, pan turns the opposite side down. Either way, a sound at pan 0
+// plays at the level it was authored at.
 set_sound_pan :: proc(sound: Sound, pan: f32) {
 	sound_object := hm.get(&s.sounds, sound)
 
@@ -3198,10 +3203,10 @@ set_audio_bus_volume :: proc(bus: Audio_Bus, volume: f32) {
 // Set the pan of an audio bus. Range: -1 to 1, where -1 is full left, 0 is center and 1 is full
 // right.
 //
-// This is a balance control: It turns the opposite side down. The pan of a sound works
-// differently: It moves the sound between the left and right speakers while keeping the overall
-// loudness the same. A bus is already a finished stereo mix, and a bus at pan 0 has to leave it
-// exactly as it is.
+// This is a balance control: It turns the opposite side down. A bus is already a finished stereo
+// mix, and a bus at pan 0 has to leave it exactly as it is. A sound that plays a mono clip works
+// differently: It moves between the left and right speakers while keeping the overall loudness the
+// same. See `set_sound_pan`.
 set_audio_bus_pan :: proc(bus: Audio_Bus, pan: f32) {
 	bus_object := bus == AUDIO_BUS_MASTER ? &s.master_bus : hm.get(&s.audio_buses, bus)
 
@@ -3505,16 +3510,35 @@ update_audio_mixer :: proc() {
 		pan_end := clamp(move_towards(settings.pan, target_settings.pan, adjust_parameter_delta), -1, 1)
 		settings.pan = pan_end
 		
-		// Use cos/sine to get a constant-power audio curve. This means that the sound won't get
-		// quieter in the middle, but will instead just pan.
-		pan_stereo_start := [2]f32 {
-			math.cos((pan_start + 1) * math.PI / 4),
-			math.sin((pan_start + 1) * math.PI / 4),
-		}
+		// The pan law follows the signal, not the object. A mono clip is a single signal that
+		// gets placed somewhere between the speakers, so it uses a constant-power curve: The
+		// sound keeps its loudness as it moves, instead of dipping in the middle. A stereo clip
+		// is already a finished stereo mix, so it uses a balance instead: Pan turns the opposite
+		// side down, and a centered stereo clip comes out at the level it was authored at. The
+		// buses use the balance law too, for the same reason.
+		pan_stereo_start: [2]f32
+		pan_stereo_end: [2]f32
 
-		pan_stereo_end := [2]f32 {
-			math.cos((pan_end + 1) * math.PI / 4),
-			math.sin((pan_end + 1) * math.PI / 4),
+		if data.channels == .Stereo {
+			pan_stereo_start = {
+				min(1, 1 - pan_start),
+				min(1, 1 + pan_start),
+			}
+
+			pan_stereo_end = {
+				min(1, 1 - pan_end),
+				min(1, 1 + pan_end),
+			}
+		} else {
+			pan_stereo_start = {
+				math.cos((pan_start + 1) * math.PI / 4),
+				math.sin((pan_start + 1) * math.PI / 4),
+			}
+
+			pan_stereo_end = {
+				math.cos((pan_end + 1) * math.PI / 4),
+				math.sin((pan_end + 1) * math.PI / 4),
+			}
 		}
 
 		interpolate := data.sample_rate != AUDIO_MIX_SAMPLE_RATE || pitch != 1
@@ -3638,9 +3662,9 @@ update_audio_mixer :: proc() {
 			continue
 		}
 
-		// The pan of a bus is a balance: It turns the opposite side down. The playing sounds use a
-		// constant-power curve instead, but that curve scales both channels by 0.707 in the middle.
-		// A bus that has not been touched has to leave the mix exactly as it is.
+		// The pan of a bus is a balance: It turns the opposite side down. A bus that has not been
+		// touched has to leave the mix exactly as it is. Sounds that play a mono clip use a
+		// constant-power curve instead, since those are placed rather than balanced.
 		gain_start := [2]f32 {
 			volume_start * min(1, 1 - pan_start),
 			volume_start * min(1, 1 + pan_start),


### PR DESCRIPTION
Sounds that play a stereo clip now use the balance pan law instead of the constant-power one, so a stereo clip at pan 0 comes out at the level it was authored at rather than 3 dB below it. Mono clips keep the constant-power curve.

Fixes #225.

API changes:

- `set_sound_pan`: doc comment now says what pan does for a mono clip versus a stereo clip.
- `set_audio_bus_pan`: doc comment updated, since the sentence about how sound pan differs from bus pan only applies to mono clips now.

No signature changed, so this is backwards compatible: nothing that compiles today stops compiling. The audible behaviour of stereo clips does change, which is the point of the fix.

Measured with a clip whose samples are all 0.5, before and after:

```
                  before                  after
pan      mono L    mono R    stereo L  stereo R    stereo L  stereo R
-1.0     0.5000    0.0000    0.5000    0.0000      0.5000    0.0000
-0.5     0.4619    0.1913    0.4619    0.1913      0.5000    0.2500
 0.0     0.3536    0.3536    0.3536    0.3536      0.5000    0.5000
 0.5     0.1913    0.4619    0.1913    0.4619      0.2500    0.5000
 1.0    -0.0000    0.5000   -0.0000    0.5000      0.0000    0.5000
```

The mono column is unchanged, and the two laws still agree at the extremes.

What other libraries do, checked against their sources:

- miniaudio: `ma_pan_mode_balance` is the default and is exactly `min(1, 1 - pan)` / `min(1, 1 + pan)`, with a fast path that copies the frames untouched at pan 0.
- SDL2_mixer: `Mix_SetPanning` applies linear per-channel gains and unregisters the effect entirely when both are 255, so the centre is a true no-op.
- Web Audio `StereoPannerNode`: splits on channel count the same way this change does. Mono gets `cos`/`sin` of `(pan + 1) / 2`, which is the same curve Karl2D already used, and stereo passes through untouched at pan 0.

One correction to the issue: raylib is not transparent at the centre. It does not use miniaudio's panner, it has its own law in `MixAudioFrames`, `y = 0.5 * x * (3 - x * x)`, applied to the already-converted stereo frames. At pan 0 that is 0.6875 per channel, so raylib attenuates mono and stereo alike, slightly more than Karl2D did. The rest of the case for the fix stands.
