### PR TITLE
Count queued samples in the CoreAudio backend

### DIFF
--- a/audio_backend_core_audio.odin
+++ b/audio_backend_core_audio.odin
@@ -31,7 +31,7 @@ Core_Audio_State :: struct {
 	semaphore:      sync.Sema,
 	buffers:        [3]Audio.QueueBufferRef,
 	buffer:         int,
-	posted_samples: int,
+	queued_samples: int,
 }
 
 core_audio_state_size :: proc() -> int {
@@ -77,8 +77,13 @@ core_audio_init :: proc(state: rawptr, allocator: runtime.Allocator) {
 	}
 	sync.sema_post(&s.semaphore, len(s.buffers))
 
+	// The queue hands a buffer back once it has been played. That is the moment its samples stop
+	// counting towards what is left to play.
 	_core_audio_callback :: proc "c" (inUserData: rawptr, inAQ: Audio.QueueRef, inBuffer: Audio.QueueBufferRef) {
-		sync.sema_post(&s.semaphore)
+		state := (^Core_Audio_State)(inUserData)
+		played := int(inBuffer.mAudioDataByteSize) / size_of([2]Audio_Sample)
+		intrinsics.atomic_sub(&state.queued_samples, played)
+		sync.sema_post(&state.semaphore)
 	}
 }
 
@@ -105,23 +110,26 @@ core_audio_feed :: proc(samples: [][2]Audio_Sample) {
 		buffer.mAudioDataByteSize = u32(to_write_bytes)
 		remaining = remaining[to_write_samples:]
 
+		// Count the samples before handing the buffer over. The queue may play it and call the
+		// callback right away, and the callback takes them off again.
+		intrinsics.atomic_add(&s.queued_samples, to_write_samples)
+
 		if !ch(Audio.QueueEnqueueBuffer(s.queue, buffer, 0, nil)) {
+			intrinsics.atomic_sub(&s.queued_samples, to_write_samples)
 			return
 		}
-
-		s.posted_samples += to_write_samples
 	}
 }
 
+// How many samples the queue still has left to play. This counts what is in the buffers that have
+// been enqueued and not handed back yet.
+//
+// It is deliberately not the queue's own playback position. The mixer uses this number to decide
+// when to feed, and `feed` blocks until the queue hands a buffer back, so the two have to agree.
+// The playback position says nothing about which buffers are free, so it can send the mixer into
+// `feed` while all of them are still in flight. The frame then stalls until one is played.
 core_audio_remaining_samples :: proc() -> int {
-	if s.posted_samples == 0 {
-		return 0
-	}
-
-	time: CA.TimeStamp
-	ch(Audio.QueueGetCurrentTime(s.queue, nil, &time, nil))
-
-	return s.posted_samples - int(time.mSampleTime)
+	return intrinsics.atomic_load(&s.queued_samples)
 }
 
 ch :: proc(status: Audio.CFOSStatus, loc := #caller_location) -> bool {


### PR DESCRIPTION
`core_audio_remaining_samples` now returns the samples sitting in buffers that have been enqueued and not handed back yet, instead of deriving them from the queue's playback position.

Fixes #230.

No API changes. Backwards compatible.

`feed` blocks on a semaphore until the queue hands a buffer back, and there are only three buffers of one mix chunk each, so one wait is up to about 32 ms. That is the >20 ms `update_audio_mixer` spikes in the profile. The mixer decides whether to call `feed` from `remaining_samples`, so the two numbers have to agree about when a buffer is free, and the playback position does not know about buffers at all. `QueueStart` runs in `init` while the first samples are not posted until the first mixer call, so everything the game loads in between widens the gap between the queue clock and `posted_samples`. That fits the report: loading textures makes it worse, loading only audio does not.

Counting the buffers directly makes the two agree by construction. While `remaining_samples` is at or below one buffer, at least one buffer is free, so `feed` does not block.

Draft because I have no Mac to run it on. It builds for `darwin_arm64` and `darwin_amd64` with `-vet -strict-style -vet-tabs`, but it needs someone to actually run the repro from the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
