### PR TITLE
Keep window alive on close request

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -23,6 +23,17 @@ Conventions for writing code, writing documentation, and collaborating on this p
 
 Write them like a tweet, max 180 characters. Only simple sentences. Only allowed punctuation is the period. If possible, keep them to 3-4 words. Use more words if really needed.
 
+## Pull request descriptions
+
+Keep them short. They contain only these things, in this order:
+
+- A short description of what was done. A few sentences at most.
+- The things that changed in the API. Say so explicitly if nothing did.
+- Bullet points of the changes that are not in the API.
+- The line "Created with the help of Claude Code" at the bottom.
+
+Nothing else. No narrative of how the work was done, no verification logs, no rationale that belongs in the issue.
+
 ## Verifying Your Work
 - Build and test through the examples in `examples/`. Prefer the existing VS Code build tasks; they already include `-vet -strict-style -vet-tabs` and come in three variants: default (D3D11 on Windows), `(GL)`, and `(web)`. Use the same `-vet -strict-style -vet-tabs` flags when running `odin` directly.
 - After edits, run the most relevant build task(s) for what you touched. After a large change, run `odin run tools/test_examples`, the CI script that builds every example (some are excluded from web builds, e.g. `minimal_hello_world`, `custom_frame_update`).

--- a/platform_mac.odin
+++ b/platform_mac.odin
@@ -243,7 +243,11 @@ mac_init :: proc(
 
 			windowShouldClose = proc(_: ^NS.Window) -> bool {
 				append(&s.events, Event_Close_Window_Requested{})
-				return true
+
+				// Returning true closes the window, which also releases it. It's up to the
+				// application to decide what a close request means, it may want to show a
+				// confirmation dialogue. The window is closed in `mac_shutdown`.
+				return false
 			},
 
 			// Focus and unfocus events

--- a/platform_windows.odin
+++ b/platform_windows.odin
@@ -741,6 +741,11 @@ _windows_window_proc :: proc "stdcall" (hwnd: win32.HWND, msg: win32.UINT, wpara
 	case win32.WM_CLOSE:
 		append(&s.events, Event_Close_Window_Requested{})
 
+		// The default handler destroys the window. We don't want that: it's up to the application
+		// to decide what a close request means, it may want to show a confirmation dialogue. The
+		// window is destroyed in `windows_shutdown`.
+		return 0
+
 	case win32.WM_SYSKEYDOWN, win32.WM_KEYDOWN:
 		repeat := bool(lparam & (1 << 30))
 		key := key_from_event_params(wparam, lparam)


### PR DESCRIPTION
Fixes #220. On Windows, `WM_CLOSE` fell through to `DefWindowProcW`, which destroys the window. Anything asking the window for something afterwards got nothing, so `get_window_position` returned `{0, 0}`. macOS had the same problem: `windowShouldClose` returned true, which closes and releases the window. Now the window survives a close request and is only destroyed by `shutdown`, so the application can decide what to do with the request.

No API changes.

- `platform_windows.odin`: `WM_CLOSE` returns 0 instead of letting the default handler destroy the window.
- `platform_mac.odin`: `windowShouldClose` returns false.
- `agent.md`: added the rules for pull request descriptions.

Created with the help of Claude Code
