### PR TITLE
Replace vsync with frame callbacks on wayland

### DIFF
--- a/platform_bindings/linux/wayland/wayland_core.odin
+++ b/platform_bindings/linux/wayland/wayland_core.odin
@@ -16,6 +16,20 @@ display_flush: proc "c" (display: ^Display) -> c.int
 
 display_dispatch_pending: proc "c" (display: ^Display) -> c.int
 
+display_get_fd: proc "c" (display: ^Display) -> c.int
+
+display_create_queue: proc "c" (display: ^Display) -> ^Event_Queue
+
+event_queue_destroy: proc "c" (queue: ^Event_Queue)
+
+display_dispatch_queue_pending: proc "c" (display: ^Display, queue: ^Event_Queue) -> c.int
+
+display_prepare_read_queue: proc "c" (display: ^Display, queue: ^Event_Queue) -> c.int
+
+display_read_events: proc "c" (display: ^Display) -> c.int
+
+display_cancel_read: proc "c" (display: ^Display)
+
 proxy_marshal_flags: proc "c" (
 	proxy:     ^Proxy,
 	opcode:    u32,
@@ -32,6 +46,12 @@ display_roundtrip: proc "c" (display: ^Display) -> c.int
 proxy_add_listener: proc "c" (proxy: ^Proxy, implementation: rawptr, userdata: rawptr) -> c.int
 
 proxy_destroy: proc "c" (proxy: ^Proxy)
+
+proxy_create_wrapper: proc "c" (proxy: ^Proxy) -> ^Proxy
+
+proxy_wrapper_destroy: proc "c" (proxy_wrapper: ^Proxy)
+
+proxy_set_queue: proc "c" (proxy: ^Proxy, queue: ^Event_Queue)
 
 egl_window_create: proc "c" (surface: ^Surface, width: c.int, height: c.int) -> ^EGL_Window
 
@@ -71,6 +91,8 @@ Interface :: struct {
 }
 
 Proxy :: struct {}
+
+Event_Queue :: struct {}
 
 Display :: struct {
 	using proxy: Proxy,
@@ -133,11 +155,21 @@ load :: proc() -> (missing: string, ok: bool) {
 		{"wl_display_dispatch", &display_dispatch},
 		{"wl_display_flush", &display_flush},
 		{"wl_display_dispatch_pending", &display_dispatch_pending},
+		{"wl_display_get_fd", &display_get_fd},
+		{"wl_display_create_queue", &display_create_queue},
+		{"wl_event_queue_destroy", &event_queue_destroy},
+		{"wl_display_dispatch_queue_pending", &display_dispatch_queue_pending},
+		{"wl_display_prepare_read_queue", &display_prepare_read_queue},
+		{"wl_display_read_events", &display_read_events},
+		{"wl_display_cancel_read", &display_cancel_read},
 		{"wl_proxy_marshal_flags", &proxy_marshal_flags},
 		{"wl_proxy_get_version", &proxy_get_version},
 		{"wl_display_roundtrip", &display_roundtrip},
 		{"wl_proxy_add_listener", &proxy_add_listener},
 		{"wl_proxy_destroy", &proxy_destroy},
+		{"wl_proxy_create_wrapper", &proxy_create_wrapper},
+		{"wl_proxy_wrapper_destroy", &proxy_wrapper_destroy},
+		{"wl_proxy_set_queue", &proxy_set_queue},
 	}
 
 	lib_client, missing, ok = load_symbols(LIB_WAYLAND_CLIENT, client_symbols)

--- a/platform_linux_glue_gl_wayland.odin
+++ b/platform_linux_glue_gl_wayland.odin
@@ -1,5 +1,5 @@
-// Glues together OpenGL with a Wayland window. This is done by making an EGL context and using it to
-// SwapBuffers etc.
+// Glues together OpenGL with a Wayland window. This is done by making an EGL context and using
+// it to SwapBuffers etc.
 #+build linux
 
 package karl2d
@@ -9,8 +9,10 @@ import "log"
 import egl "platform_bindings/linux/egl"
 import wl "platform_bindings/linux/wayland"
 import "base:runtime"
+import "core:c"
 import "core:slice"
 import "core:sys/posix"
+import "core:time"
 
 @(private="package")
 make_linux_gl_wayland_glue :: proc(
@@ -22,9 +24,18 @@ make_linux_gl_wayland_glue :: proc(
 ) -> Window_Render_Glue {
 	state := new(Linux_GL_Wayland_Glue_State, allocator, loc)
 	state.display = display
-	state.surface = surface
 	state.window = window
 	state.allocator = allocator
+
+	// The frame callback gets an event queue of its own. It is requested on a proxy wrapper of
+	// the surface, which is what makes its `done` event land in that queue instead of in the
+	// default one. Waiting for a frame in `linux_gl_wayland_glue_present` then dispatches only
+	// frame callbacks. Input and `xdg_toplevel.configure` stay queued and are dispatched at the
+	// top of the next frame, where the rest of the code expects them.
+	state.frame_queue = wl.display_create_queue(display)
+	state.frame_surface = (^wl.Surface)(wl.proxy_create_wrapper(surface))
+	wl.proxy_set_queue(state.frame_surface, state.frame_queue)
+
 	return {
 		state = (^Window_Render_Glue_State)(state),
 
@@ -38,7 +49,8 @@ make_linux_gl_wayland_glue :: proc(
 
 Linux_GL_Wayland_Glue_State :: struct {
 	display: ^wl.Display,
-	surface: ^wl.Surface,
+	frame_queue: ^wl.Event_Queue,
+	frame_surface: ^wl.Surface,
 	frame_callback: ^wl.Callback,
 	window: ^wl.EGL_Window,
 	egl_context: egl.Context,
@@ -144,28 +156,23 @@ linux_gl_wayland_glue_make_context :: proc(s: ^Linux_GL_Wayland_Glue_State, opti
 	return false
 }
 
+// How long `linux_gl_wayland_glue_present` waits for the compositor to signal that it wants a new
+// frame. The wait needs a timeout because a compositor sends no frame callbacks at all for a window
+// it doesn't show, and the game would hang. It also must not fire while the window is visible: a
+// whole frame is at stake, so anything shorter than the display's frame time times out every frame
+// and the game free runs. 50 ms leaves room down to 20 Hz.
+FRAME_CALLBACK_TIMEOUT :: 50*time.Millisecond
+
 linux_gl_wayland_glue_present :: proc(s: ^Linux_GL_Wayland_Glue_State) {
-
-	wl.display_dispatch_pending(s.display)
-	wl.display_flush(s.display)
-
 	if s.frame_callback != nil {
-		// Wait for the frame callback done event
-		fd := posix.FD(wl.display_get_fd(s.display))
-
-		for s.frame_callback != nil {
-			pfd := posix.pollfd{
-				fd     = fd,
-				events = {posix.Poll_Event_Bits.IN},
-			}
-			if posix.poll(&pfd, nfds=1, timeout=20) == 0 {
-				break // Timeout
-			}
-			// Drain events until frame_callback get's called
-			wl.display_dispatch(s.display)
-		}
+		// Hand the frame to the GPU before going to sleep, so it has something to work on
+		// during the wait.
+		gl.Flush()
+		wayland_wait_for_frame(s)
 	}
 
+	// Nothing to request while the previous callback is still pending, which is the case when
+	// the wait above timed out. That one is waited for again next frame.
 	if s.frame_callback == nil {
 		@static listener := wl.Callback_Listener {
 			proc "c" (data: rawptr, callback: ^wl.Callback, callback_data: u32) {
@@ -173,18 +180,92 @@ linux_gl_wayland_glue_present :: proc(s: ^Linux_GL_Wayland_Glue_State) {
 				(^^wl.Callback)(data)^ = nil // Clear callback to exit the loop
 			},
 		}
-		s.frame_callback = wl.surface_frame(s.surface)
+		s.frame_callback = wl.surface_frame(s.frame_surface)
 		wl.add_listener(s.frame_callback, &listener, &s.frame_callback)
 	}
 
-	// Non-blocking swap (egl.SwapInterval is 0)
+	// Non-blocking swap (egl.SwapInterval is 0). It commits the surface, which is what carries
+	// the frame request above to the compositor.
 	egl.SwapBuffers(s.egl_display, s.egl_surface)
+}
+
+// Waits for the frame callback the previous `linux_gl_wayland_glue_present` requested. This is what
+// throttles the frame rate now that EGL's own vsync is off. Returns when the callback arrives, when
+// `FRAME_CALLBACK_TIMEOUT` runs out or when the connection to the compositor breaks. The timeout is
+// a budget for the whole wait, not for each poll, so unrelated events arriving in a stream cannot
+// stretch it indefinitely.
+@(private="file")
+wayland_wait_for_frame :: proc(s: ^Linux_GL_Wayland_Glue_State) {
+	fd := posix.FD(wl.display_get_fd(s.display))
+	deadline := time.tick_add(time.tick_now(), FRAME_CALLBACK_TIMEOUT)
+
+	for s.frame_callback != nil {
+		// Reading the socket has to be announced first. That fails while the frame queue still
+		// holds events, and dispatching those may be all that is needed.
+		for wl.display_prepare_read_queue(s.display, s.frame_queue) != 0 {
+			if wl.display_dispatch_queue_pending(s.display, s.frame_queue) < 0 {
+				return
+			}
+		}
+
+		if s.frame_callback == nil {
+			wl.display_cancel_read(s.display)
+			return
+		}
+
+		// Sends the frame request off. EAGAIN only means the socket buffer is full, and the
+		// poll below gives the compositor time to drain it.
+		if wl.display_flush(s.display) < 0 && posix.errno() != .EAGAIN {
+			wl.display_cancel_read(s.display)
+			return
+		}
+
+		remaining := time.tick_diff(time.tick_now(), deadline)
+
+		if remaining <= 0 {
+			wl.display_cancel_read(s.display)
+			return
+		}
+
+		pfd := posix.pollfd {
+			fd     = fd,
+			events = {.IN},
+		}
+
+		// Rounded up so that a sliver of remaining time doesn't turn into a zero timeout, which
+		// would spin.
+		timeout_ms := c.int((remaining + time.Millisecond - 1)/time.Millisecond)
+		poll_res := posix.poll(&pfd, nfds=1, timeout=timeout_ms)
+
+		if poll_res <= 0 {
+			wl.display_cancel_read(s.display)
+
+			// Zero is the timeout. -1 with EINTR or EAGAIN is just a signal arriving, so try
+			// again until the deadline runs out. Anything else is a real error.
+			if poll_res < 0 && (posix.errno() == .EINTR || posix.errno() == .EAGAIN) {
+				continue
+			}
+
+			return
+		}
+
+		if wl.display_read_events(s.display) < 0 {
+			return
+		}
+
+		if wl.display_dispatch_queue_pending(s.display, s.frame_queue) < 0 {
+			return
+		}
+	}
 }
 
 linux_gl_wayland_glue_destroy :: proc(s: ^Linux_GL_Wayland_Glue_State) {
 	if s.frame_callback != nil {
 		wl.destroy(s.frame_callback)
 	}
+
+	wl.proxy_wrapper_destroy(s.frame_surface)
+	wl.event_queue_destroy(s.frame_queue)
 	egl.DestroyContext(s.egl_display, s.egl_context)
 	a := s.allocator
 	free(s, a)

--- a/platform_linux_glue_gl_wayland.odin
+++ b/platform_linux_glue_gl_wayland.odin
@@ -1,4 +1,4 @@
-// Glues together OpenGL with an X11 window. This is done by making a glX context and using it to
+// Glues together OpenGL with a Wayland window. This is done by making an EGL context and using it to
 // SwapBuffers etc.
 #+build linux
 
@@ -10,16 +10,19 @@ import egl "platform_bindings/linux/egl"
 import wl "platform_bindings/linux/wayland"
 import "base:runtime"
 import "core:slice"
+import "core:sys/posix"
 
 @(private="package")
 make_linux_gl_wayland_glue :: proc(
 	display: ^wl.Display,
+	surface: ^wl.Surface,
 	window: ^wl.EGL_Window,
 	allocator: runtime.Allocator,
 	loc := #caller_location
 ) -> Window_Render_Glue {
 	state := new(Linux_GL_Wayland_Glue_State, allocator, loc)
 	state.display = display
+	state.surface = surface
 	state.window = window
 	state.allocator = allocator
 	return {
@@ -35,6 +38,8 @@ make_linux_gl_wayland_glue :: proc(
 
 Linux_GL_Wayland_Glue_State :: struct {
 	display: ^wl.Display,
+	surface: ^wl.Surface,
+	frame_callback: ^wl.Callback,
 	window: ^wl.EGL_Window,
 	egl_context: egl.Context,
 	egl_display: egl.Display,
@@ -125,11 +130,13 @@ linux_gl_wayland_glue_make_context :: proc(s: ^Linux_GL_Wayland_Glue_State, opti
 	}
 
 	if egl.MakeCurrent(s.egl_display, s.egl_surface, s.egl_surface, s.egl_context) {
-		egl.SwapInterval(s.egl_display, 1)
 		gl.load_up_to(3, 3, egl.gl_set_proc_address)
 
-		// vsync
-		egl.SwapInterval(s.egl_display, 1)
+		// Disable EGL vsync (swap interval = 0)
+		// Otherwise egl.SwapBuffers would block indefinitely for unfocused windows.
+		// Frame timing is managed in linux_gl_wayland_glue_present using frame callbacks,
+		// which ensures that the event loop stays responsive.
+		egl.SwapInterval(s.egl_display, interval=0)
 
 		return true
 	}
@@ -138,10 +145,46 @@ linux_gl_wayland_glue_make_context :: proc(s: ^Linux_GL_Wayland_Glue_State, opti
 }
 
 linux_gl_wayland_glue_present :: proc(s: ^Linux_GL_Wayland_Glue_State) {
+
+	wl.display_dispatch_pending(s.display)
+	wl.display_flush(s.display)
+
+	if s.frame_callback != nil {
+		// Wait for the frame callback done event
+		fd := posix.FD(wl.display_get_fd(s.display))
+
+		for s.frame_callback != nil {
+			pfd := posix.pollfd{
+				fd     = fd,
+				events = {posix.Poll_Event_Bits.IN},
+			}
+			if posix.poll(&pfd, nfds=1, timeout=20) == 0 {
+				break // Timeout
+			}
+			// Drain events until frame_callback get's called
+			wl.display_dispatch(s.display)
+		}
+	}
+
+	if s.frame_callback == nil {
+		@static listener := wl.Callback_Listener {
+			proc "c" (data: rawptr, callback: ^wl.Callback, callback_data: u32) {
+				wl.destroy(callback)
+				(^^wl.Callback)(data)^ = nil // Clear callback to exit the loop
+			},
+		}
+		s.frame_callback = wl.surface_frame(s.surface)
+		wl.add_listener(s.frame_callback, &listener, &s.frame_callback)
+	}
+
+	// Non-blocking swap (egl.SwapInterval is 0)
 	egl.SwapBuffers(s.egl_display, s.egl_surface)
 }
 
 linux_gl_wayland_glue_destroy :: proc(s: ^Linux_GL_Wayland_Glue_State) {
+	if s.frame_callback != nil {
+		wl.destroy(s.frame_callback)
+	}
 	egl.DestroyContext(s.egl_display, s.egl_context)
 	a := s.allocator
 	free(s, a)

--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -186,11 +186,11 @@ wl_init :: proc(
 	log.ensure(s.window != nil, "Wayland compositor never sent an initial configure")
 
 	when RENDER_BACKEND_NAME == "gl" {
-		s.window_render_glue = make_linux_gl_wayland_glue(s.display, s.window, s.allocator)
+		s.window_render_glue = make_linux_gl_wayland_glue(s.display, s.surface, s.window, s.allocator)
 	} else when RENDER_BACKEND_NAME == "nil" {
 		s.window_render_glue = {}
 	} else {
-		#panic("Unsupported combo of Linux + X11 and render backend '" + RENDER_BACKEND_NAME + "'")
+		#panic("Unsupported combo of Linux + Wayland and render backend '" + RENDER_BACKEND_NAME + "'")
 	}
 
 	if options.disable_auto_scale_hint {


### PR DESCRIPTION
I had an issue with running karl2d apps where I would get "this app is unresponsive, should I KILL it?" warnings after switching window focus.
Turns out this is due to vsync which caused `egl.SwapBuffers` to block until the window is refocused.

I discovered this when working on clipboard integration, where wayland requires the writer to handle read requests. So when you copy then alt-tab to switch windows to paste, karl2d app would be frozen and the read-request wouldn't be handed until refocused again.

This PR disables vsync on wayland and "reimplements" blocking by polling until a frame callback is called to tell when the surface is ready or until a timeout is exceeded. Which is what glfw does as well: https://github.com/glfw/glfw/blob/92dcf4ce74f2e2554a98fea09be7c705c17daa5a/src/wl_window.c#L2342

It works on my end but I don't know what I'm doing so I would appreciate someone else looking at this.