### PR TITLE
fix DPI change when dragging across monitors (Windows)

### DIFF
--- a/platform_windows.odin
+++ b/platform_windows.odin
@@ -885,11 +885,27 @@ _windows_window_proc :: proc "stdcall" (hwnd: win32.HWND, msg: win32.UINT, wpara
 		new_dpi := win32.LOWORD(wparam)
 		s.window_scale = f32(new_dpi) / 96.0
 
+		// Windows supplies the outer window rectangle that preserves the window's logical size at
+		// the new DPI. Applying it here is important for apps like AltSnap, where unlike the native
+		// title-bar drag loop, they do not necessarily perform this adjustment on our behalf.
+		suggested_rect := (^win32.RECT)(uintptr(lparam))
+		win32.SetWindowPos(
+			hwnd,
+			{},
+			suggested_rect.left,
+			suggested_rect.top,
+			suggested_rect.right - suggested_rect.left,
+			suggested_rect.bottom - suggested_rect.top,
+			win32.SWP_NOACTIVATE | win32.SWP_NOZORDER,
+		)
+
 		append(&s.events, Event_Window_Scale_Changed {
 			scale = s.window_scale,
 			screen_width = s.screen_width,
 			screen_height = s.screen_height,
 		})
+
+		return 0
 
 	case win32.WM_ENTERSIZEMOVE:
 		s.in_resize_move_state = true


### PR DESCRIPTION
I tend to drag my windows around a lot using [AltSnap](https://github.com/RamonUnch/AltSnap), and I realised the window in karl2d wasn't behaving totally as expected, like others were. After talking to Codex, it pointed to [here in MSDN](https://learn.microsoft.com/en-gb/windows/win32/hidpi/wm-dpichanged#:~:text=The%20expectation%20is%20that%20apps%20will%20reposition%20and%20resize%20windows%20based%20on%20the%20suggestions%20provided%20by%20lParam%20when%20handling%20this%20message.)

Some videos:

BEFORE

https://github.com/user-attachments/assets/7f5c60da-057f-47ea-a35c-de4492291ee5



AFTER

https://github.com/user-attachments/assets/b5a950d4-4490-4d82-adf0-610a75b8e195


---

## Rules Checklist

You can always submit a draft pull request. But when you make your Pull Request "ready for review", then please make sure these rules are followed (put an x between each [ ]):
- [x] Make sure that the code you submit is working and tested.
- [x] Do not submit "basic" or "rudimentary" code that needs further work to actually be finished. Finish the code to the best of your abilities.
- [x] Do not modify any code that is unrelated to your changes. That just makes reviewing your code harder: I'll have a hard time seeing what you actually did. Do not use auto formatters such as odinfmt.
- [x] If you used an LLM to generate any code, then make that you understand every single line. In other words: No form of "vibe coded" PRs are allowed.
- [x] If you commit changes that were unintended, just do additional commits that undo them. Don't worry about polluting the commit history: I will do a "squash merge" of your Pull Request. Just make sure that the diff in the "Files changed" tab looks tidy.
- [x] If the GitHub testing action complain about the `karl2d.doc.odin` file being out-of-date, then please regenerate it by running `odin run tools/api_doc_builder`. This way you'll have an easier time seeing if you've made changes to the user-facing API.
- [x] Make sure that the code follows the same style as in `karl2d.odin`:
	- Please look through that file and pay attention to how characters such as `:` `=`, `(` `{` etc are placed.
	- Use tabs, not spaces.
	- Lines cannot be longer than 100 characters. See the `init` proc in `karl2d.odin` for an example of how to split up procedure signatures that are too long. That proc also shows how to write API comments. Use a ruler in your editor to make it easy to spot long lines.
