### PR TITLE
Split init into four procs

### DIFF
--- a/examples/monitors/monitors.odin
+++ b/examples/monitors/monitors.odin
@@ -1,0 +1,96 @@
+// Demonstrates the split of `k2.init` into `init_platform`, `open_window`, `init_rendering` and
+// `init_sound`. Queries the connected monitors right after `init_platform`, before a window
+// exists, and uses that to pick a window size based on the primary monitor.
+package karl2d_monitors_example
+
+import k2 "../.."
+import "core:fmt"
+
+init :: proc() {
+	k2.init_platform()
+
+	monitor_count := k2.get_monitor_count()
+	fmt.printfln("Monitor count: %v", monitor_count)
+
+	for i in 0..<monitor_count {
+		fmt.printfln(
+			"Monitor %v: size %v, position %v, scale %v",
+			i,
+			k2.get_monitor_size(i),
+			k2.get_monitor_position(i),
+			k2.get_monitor_scale(i),
+		)
+	}
+
+	// Half the primary monitor's size, so the window comfortably fits on screen. Not every platform
+	// can report monitors: Wayland reports none at all right now, see
+	// `platform_linux_window_wayland.odin`. So check the count before asking, and keep a fixed size
+	// to fall back on.
+	window_width := 640
+	window_height := 480
+
+	if monitor_count > 0 {
+		primary_size := k2.get_monitor_size(0)
+
+		if primary_size.x > 0 && primary_size.y > 0 {
+			window_width = primary_size.x/2
+			window_height = primary_size.y/2
+		}
+	}
+
+	k2.open_window(
+		window_width,
+		window_height,
+		"Karl2D Monitors",
+		options = { window_mode = .Windowed_Resizable },
+	)
+
+	k2.init_rendering()
+	k2.init_sound()
+}
+
+step :: proc() -> bool {
+	if !k2.update() {
+		return false
+	}
+
+	k2.clear(k2.DARK_GRAY)
+
+	monitor_count := k2.get_monitor_count()
+	y: f32 = 20
+
+	k2.draw_text(fmt.tprintfln("Monitor count: %v", monitor_count), {20, y}, 28, k2.WHITE)
+	y += 40
+
+	for i in 0..<monitor_count {
+		line := fmt.tprintfln(
+			"Monitor %v: size %v, position %v, scale %v",
+			i,
+			k2.get_monitor_size(i),
+			k2.get_monitor_position(i),
+			k2.get_monitor_scale(i),
+		)
+
+		k2.draw_text(line, {20, y}, 28, k2.LIGHT_GREEN)
+		y += 34
+	}
+
+	k2.present()
+
+	// `fmt.tprintfln` above allocates using `context.temp_allocator`. Those allocations are not
+	// needed for more than a frame, so they can be thrown away now.
+	free_all(context.temp_allocator)
+
+	return true
+}
+
+shutdown :: proc() {
+	k2.shutdown()
+}
+
+// This is not run by the web version, but it makes this program also work on non-web!
+main :: proc() {
+	init()
+	for step() {}
+	shutdown()
+}

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -9,11 +9,12 @@ package karl2d
 
 // Allocates Karl2D's internal state and sets up the platform layer. Does not open a window.
 //
-// This is the first procedure to call, and the only one that has to run before a window exists:
-// `windows_init`/`linux_init` etc allocate from the package-global frame allocator, which is set up
-// here. Call `get_monitor_count`, `get_monitor_size`, `get_monitor_position` and
-// `get_monitor_scale` after this and before `open_window` if you want to pick a window size based
-// on the display.
+// This is the first procedure to call. It sets up the package-global frame allocator that the
+// platform backends allocate from, and it does the process-level work that has to happen before
+// any window exists, such as making the process DPI aware on Windows.
+//
+// Call `get_monitor_count`, `get_monitor_size`, `get_monitor_position` and `get_monitor_scale`
+// after this and before `open_window` if you want to pick a window size based on the display.
 //
 // The internal state will use `allocator` for all dynamically allocated memory. The return value is
 // a pointer to it, see `init` for what you can do with that pointer.

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -7,6 +7,47 @@ package karl2d
 // SETUP, WINDOW MANAGEMENT AND FRAME MANAGEMENT //
 //-----------------------------------------------//
 
+// Allocates Karl2D's internal state and sets up the platform layer. Does not open a window.
+//
+// This is the first procedure to call, and the only one that has to run before a window exists:
+// `windows_init`/`linux_init` etc allocate from the package-global frame allocator, which is set up
+// here. Call `get_monitor_count`, `get_monitor_size`, `get_monitor_position` and
+// `get_monitor_scale` after this and before `open_window` if you want to pick a window size based
+// on the display.
+//
+// The internal state will use `allocator` for all dynamically allocated memory. The return value is
+// a pointer to it, see `init` for what you can do with that pointer.
+init_platform :: proc(
+	allocator := context.allocator,
+	loc := #caller_location,
+) -> ^State
+
+// Opens the window. Call `init_platform` first.
+//
+// `screen_width` and `screen_height` refer to the resolution of the drawable area of the window.
+// The window might be slightly larger due to borders and headers. The true width and height will be
+// scaled up by the scaling setting in the operating system.
+open_window :: proc(
+	screen_width: int,
+	screen_height: int,
+	window_title: string,
+	options := Window_Options {},
+	loc := #caller_location,
+)
+
+// Boots the rendering backend. Call `open_window` first.
+//
+// Sets up the projection, the vertex buffer, the batching system, the shape-drawing texture, the
+// default shader and the default font.
+init_rendering :: proc(
+	options := Rendering_Options {},
+	loc := #caller_location,
+)
+
+// Boots the audio backend and sets up the mixer's handle maps. Call `init_platform` first. Does not
+// depend on a window, so it can run before or after `open_window`/`init_rendering`.
+init_sound :: proc(loc := #caller_location)
+
 // Opens a window and initializes some internal state. The internal state will use `allocator` for
 // all dynamically allocated memory.
 //
@@ -22,6 +63,17 @@ package karl2d
 // `set_internal_state()`. This is useful for example when doing game code reload, as the state may
 // get reset when the library is reloaded. You can safely ignore the return value if you have no
 // such needs.
+//
+// `init` is a wrapper over four procedures, called in this order:
+//
+//// k2.init_platform()
+//// k2.open_window()
+//// k2.init_rendering()
+//// k2.init_sound()
+//
+// Call them directly instead of `init` if you need to do work between the steps, such as querying
+// monitors with `get_monitor_size` before deciding how big a window to open, or if you want to skip
+// audio or rendering entirely.
 init :: proc(
 	screen_width: int,
 	screen_height: int,
@@ -66,7 +118,41 @@ update :: proc() -> bool
 close_window_requested :: proc() -> bool
 
 // Closes the window and cleans up Karl2D's internal state.
+//
+// `shutdown` is a wrapper over four procedures, called in reverse order of `init`:
+//
+//// k2.shutdown_sound()
+//// k2.shutdown_rendering()
+//// k2.close_window()
+//// k2.shutdown_platform()
+//
+// Call them directly instead of `shutdown` if you only want to tear down some of what `init` set
+// up.
 shutdown :: proc()
+
+// Destroys everything `init_sound` set up. Does nothing if `init_sound` was never called (or if
+// `shutdown_sound` has already run).
+//
+// Called by `shutdown`, but can be called manually if you need more control.
+shutdown_sound :: proc()
+
+// Destroys everything `init_rendering` set up. Does nothing if `init_rendering` was never called
+// (or if `shutdown_rendering` has already run).
+//
+// Called by `shutdown`, but can be called manually if you need more control.
+shutdown_rendering :: proc()
+
+// Closes the window `open_window` opened. Does nothing if `open_window` was never called (or if
+// `close_window` has already run).
+//
+// Called by `shutdown`, but can be called manually if you need more control.
+close_window :: proc()
+
+// Frees Karl2D's internal state. Call this last, after `shutdown_sound`, `shutdown_rendering` and
+// `close_window`.
+//
+// Called by `shutdown`, but can be called manually if you need more control.
+shutdown_platform :: proc()
 
 // Clear the "screen" with the supplied color. By default this will clear your window. But if you
 // have set a Render Texture using the `set_render_texture` procedure, then that Render Texture will
@@ -165,6 +251,23 @@ get_window_scale :: proc() -> f32
 
 // Use to change between windowed mode, resizable windowed mode and fullscreen
 set_window_mode :: proc(window_mode: Window_Mode)
+
+// Returns how many monitors are connected. Works after `init_platform`, before `open_window`, so
+// you can decide how big a window to open based on the display it will end up on.
+get_monitor_count :: proc() -> int
+
+// Returns the size of `monitor`, in physical pixels, matching what `set_screen_size` takes. Monitor
+// 0 is the primary monitor. Works after `init_platform`, before `open_window`.
+get_monitor_size :: proc(monitor := 0) -> [2]int
+
+// Returns the position of `monitor`, in physical pixels. Monitor 0 is the primary monitor. Works
+// after `init_platform`, before `open_window`.
+get_monitor_position :: proc(monitor := 0) -> [2]int
+
+// Returns the scale of `monitor`. This usually comes from some DPI scaling setting in the OS. 1
+// means 100% scale, 1.5 means 150% etc. Monitor 0 is the primary monitor. Works after
+// `init_platform`, before `open_window`.
+get_monitor_scale :: proc(monitor := 0) -> f32
 
 // Flushes the current batch. A batch consists of a number of draw calls and a vertex buffer. This
 // procedure sends all that off to the rendering backend for drawing. Normally, you do not need to
@@ -1326,11 +1429,8 @@ Window_Mode :: enum {
 	Borderless_Fullscreen,
 }
 
-Init_Options :: struct {
+Window_Options :: struct {
 	window_mode: Window_Mode,
-
-	// Enable to request anti-alias. On most systems this means 4x Multi Sample Anti Alias
-	anti_alias: bool,
 
 	// This hint may disable scaling of the window when created. Scaling here refers to the scaling
 	// that is set for the monitor in the OS settings (the same number returned by
@@ -1340,6 +1440,11 @@ Init_Options :: struct {
 	// platforms, such as Linux+Wayland, it does not work, because Wayland always auto scales all
 	// windows.
 	disable_auto_scale_hint: bool,
+}
+
+Rendering_Options :: struct {
+	// Enable to request anti-alias. On most systems this means 4x Multi Sample Anti Alias
+	anti_alias: bool,
 
 	// Enable depth testing. Draws are then sorted by the z value set with `set_z`: higher z ends up
 	// in front. Things drawn at the same z use the drawing order, like when depth testing is off.
@@ -1350,6 +1455,13 @@ Init_Options :: struct {
 	// coordinates. Only used when `depth_test` is on.
 	depth_range_min: f32,
 	depth_range_max: f32,
+}
+
+// The combination of `Window_Options` and `Rendering_Options`, used by `init`. The granular
+// procedures `open_window` and `init_rendering` take the individual halves instead.
+Init_Options :: struct {
+	using window: Window_Options,
+	using rendering: Rendering_Options,
 }
 
 DEPTH_RANGE_DEFAULT_MIN :: -1
@@ -1772,6 +1884,13 @@ State :: struct {
 	platform_state: rawptr,
 	render_backend: Render_Backend_Interface,
 	render_backend_state: rawptr,
+
+	// Rendering and audio are initialised by separate procedures from the platform and the window,
+	// so a program can skip either or query monitors before opening a window. These track how far
+	// along that setup is.
+	window_open: bool,
+	rendering_initialized: bool,
+	audio_initialized: bool,
 
 	fs: fs.FontContext,
 	

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -30,30 +30,21 @@ import hm "core:container/handle_map"
 // SETUP, WINDOW MANAGEMENT AND FRAME MANAGEMENT //
 //-----------------------------------------------//
 
-// Opens a window and initializes some internal state. The internal state will use `allocator` for
-// all dynamically allocated memory.
+// Allocates Karl2D's internal state and sets up the platform layer. Does not open a window.
 //
-// `screen_width` and `screen_height` refer to the resolution of the drawable area of the window.
-// The window might be slightly larger due to borders and headers. The true width and height will be
-// scaled up by the scaling setting in the operating system.
+// This is the first procedure to call, and the only one that has to run before a window exists:
+// `windows_init`/`linux_init` etc allocate from the package-global frame allocator, which is set up
+// here. Call `get_monitor_count`, `get_monitor_size`, `get_monitor_position` and
+// `get_monitor_scale` after this and before `open_window` if you want to pick a window size based
+// on the display.
 //
-// Call `init` before using Karl2D procedures that depend on runtime state, such as window,
-// drawing, input, audio, texture, font and shader procedures. Pure helper procedures, types and
-// constants can be used before `init`.
-//
-// The return value is a pointer to Karl2D's internal state. You can restore this state later using
-// `set_internal_state()`. This is useful for example when doing game code reload, as the state may
-// get reset when the library is reloaded. You can safely ignore the return value if you have no
-// such needs.
-init :: proc(
-	screen_width: int,
-	screen_height: int,
-	window_title: string,
-	options := Init_Options {},
+// The internal state will use `allocator` for all dynamically allocated memory. The return value is
+// a pointer to it, see `init` for what you can do with that pointer.
+init_platform :: proc(
 	allocator := context.allocator,
-	loc := #caller_location
+	loc := #caller_location,
 ) -> ^State {
-	assert(s == nil, "Don't call 'init' twice.")
+	assert(s == nil, "Don't call 'init_platform' twice.")
 	s = new(State, allocator, loc)
 	s.allocator = allocator
 
@@ -79,7 +70,7 @@ init :: proc(
 
 	// We allocate memory for the windowing backend and pass the blob of memory to it.
 	platform_state_alloc_error: runtime.Allocator_Error
-	
+
 	s.platform_state, platform_state_alloc_error = mem.alloc(
 		pf.state_size(),
 		allocator = s.allocator,
@@ -91,7 +82,48 @@ init :: proc(
 		platform_state_alloc_error,
 	)
 
-	pf.init(s.platform_state, screen_width, screen_height, window_title, options, s.allocator)
+	// Process-level setup that has to happen before any window exists. On Windows this is what
+	// makes the process DPI aware, without which the monitor queries below would report
+	// virtualized sizes.
+	pf.init_process(s.platform_state, s.allocator)
+
+	return s
+}
+
+// Opens the window. Call `init_platform` first.
+//
+// `screen_width` and `screen_height` refer to the resolution of the drawable area of the window.
+// The window might be slightly larger due to borders and headers. The true width and height will be
+// scaled up by the scaling setting in the operating system.
+open_window :: proc(
+	screen_width: int,
+	screen_height: int,
+	window_title: string,
+	options := Window_Options {},
+	loc := #caller_location,
+) {
+	assert(s != nil, "Call k2.init_platform before k2.open_window")
+	assert(!s.window_open, "Don't call 'open_window' twice.")
+
+	pf.init(screen_width, screen_height, window_title, options)
+	s.window_open = true
+
+	s.events = make([dynamic]Event, s.allocator)
+	s.typed_runes = make([dynamic]rune, s.allocator)
+	s.touch_events_from_mouse = true
+}
+
+// Boots the rendering backend. Call `open_window` first.
+//
+// Sets up the projection, the vertex buffer, the batching system, the shape-drawing texture, the
+// default shader and the default font.
+init_rendering :: proc(
+	options := Rendering_Options {},
+	loc := #caller_location,
+) {
+	assert(s != nil, "Call k2.init_platform before k2.init_rendering")
+	assert(s.window_open, "Call k2.open_window before k2.init_rendering")
+	assert(!s.rendering_initialized, "Don't call 'init_rendering' twice.")
 
 	// This is an OS-independent handle that we can pass to any rendering backend.
 	window_render_glue := pf.get_window_render_glue()
@@ -137,10 +169,15 @@ init :: proc(
 		s.render_backend_state,
 		window_render_glue,
 		pf.get_screen_width(),
-		pf.get_screen_height(), 
+		pf.get_screen_height(),
 		options,
 		s.allocator,
 	)
+
+	// The render backend is up from here on, so the rest of this procedure can freely call the
+	// public procedures (`load_shader_from_bytes`, `load_dynamic_font_from_bytes`, ...) that assert
+	// rendering is initialized.
+	s.rendering_initialized = true
 
 	// The vertex buffer is created in a render backend-independent way. It is passed to the
 	// render backend each frame as part of `draw_current_batch()`.
@@ -185,28 +222,73 @@ init :: proc(
 	default_font := load_dynamic_font_from_bytes(DEFAULT_FONT_DATA)
 	log.assertf(default_font == FONT_DEFAULT, "Default font must be at index %i", FONT_DEFAULT)
 	_set_font(FONT_DEFAULT)
+}
 
-	s.events = make([dynamic]Event, s.allocator)
-	s.typed_runes = make([dynamic]rune, s.allocator)
-	s.touch_events_from_mouse = true
+// Boots the audio backend and sets up the mixer's handle maps. Call `init_platform` first. Does not
+// depend on a window, so it can run before or after `open_window`/`init_rendering`.
+init_sound :: proc(loc := #caller_location) {
+	assert(s != nil, "Call k2.init_platform before k2.init_sound")
+	assert(!s.audio_initialized, "Don't call 'init_sound' twice.")
 
-	// Audio
-	{
-		s.audio_backend = AUDIO_BACKEND
-		ab = s.audio_backend
+	s.audio_backend = AUDIO_BACKEND
+	ab = s.audio_backend
 
-		audio_alloc_error: runtime.Allocator_Error
-		s.audio_backend_state, audio_alloc_error = mem.alloc(ab.state_size(), allocator = s.allocator)
-		log.assertf(audio_alloc_error == nil, "Failed allocating memory for audio backend: %v", audio_alloc_error)
-		ab.init(s.audio_backend_state, s.allocator)
-		hm.dynamic_init(&s.sounds, s.allocator)
-		hm.dynamic_init(&s.audio_clips, s.allocator)
-		hm.dynamic_init(&s.audio_streams, s.allocator)
-		hm.dynamic_init(&s.audio_buses, s.allocator)
-		s.master_bus.target_settings = DEFAULT_AUDIO_BUS_SETTINGS
-		s.master_bus.current_settings = DEFAULT_AUDIO_BUS_SETTINGS
-	}
+	audio_alloc_error: runtime.Allocator_Error
+	s.audio_backend_state, audio_alloc_error = mem.alloc(ab.state_size(), allocator = s.allocator)
+	log.assertf(
+		audio_alloc_error == nil,
+		"Failed allocating memory for audio backend: %v",
+		audio_alloc_error,
+	)
+	ab.init(s.audio_backend_state, s.allocator)
+	hm.dynamic_init(&s.sounds, s.allocator)
+	hm.dynamic_init(&s.audio_clips, s.allocator)
+	hm.dynamic_init(&s.audio_streams, s.allocator)
+	hm.dynamic_init(&s.audio_buses, s.allocator)
+	s.master_bus.target_settings = DEFAULT_AUDIO_BUS_SETTINGS
+	s.master_bus.current_settings = DEFAULT_AUDIO_BUS_SETTINGS
 
+	s.audio_initialized = true
+}
+
+// Opens a window and initializes some internal state. The internal state will use `allocator` for
+// all dynamically allocated memory.
+//
+// `screen_width` and `screen_height` refer to the resolution of the drawable area of the window.
+// The window might be slightly larger due to borders and headers. The true width and height will be
+// scaled up by the scaling setting in the operating system.
+//
+// Call `init` before using Karl2D procedures that depend on runtime state, such as window,
+// drawing, input, audio, texture, font and shader procedures. Pure helper procedures, types and
+// constants can be used before `init`.
+//
+// The return value is a pointer to Karl2D's internal state. You can restore this state later using
+// `set_internal_state()`. This is useful for example when doing game code reload, as the state may
+// get reset when the library is reloaded. You can safely ignore the return value if you have no
+// such needs.
+//
+// `init` is a wrapper over four procedures, called in this order:
+//
+//// k2.init_platform()
+//// k2.open_window()
+//// k2.init_rendering()
+//// k2.init_sound()
+//
+// Call them directly instead of `init` if you need to do work between the steps, such as querying
+// monitors with `get_monitor_size` before deciding how big a window to open, or if you want to skip
+// audio or rendering entirely.
+init :: proc(
+	screen_width: int,
+	screen_height: int,
+	window_title: string,
+	options := Init_Options {},
+	allocator := context.allocator,
+	loc := #caller_location
+) -> ^State {
+	init_platform(allocator, loc)
+	open_window(screen_width, screen_height, window_title, options.window, loc)
+	init_rendering(options.rendering, loc)
+	init_sound(loc)
 	return s
 }
 
@@ -236,10 +318,14 @@ init :: proc(
 ////     }
 //// }
 update :: proc() -> bool {
-	assert_initialized()
+	assert_window_open()
 	reset_frame_allocator()
 	calculate_frame_time()
-	update_audio_mixer()
+
+	if s.audio_initialized {
+		update_audio_mixer()
+	}
+
 	process_events()
 	return !close_window_requested()
 }
@@ -250,25 +336,61 @@ update :: proc() -> bool {
 //
 // Called by `update`, but can be called manually if you need more control.
 close_window_requested :: proc() -> bool {
-	assert_initialized()
+	assert_window_open()
 	return s.close_window_requested
 }
 
 // Closes the window and cleans up Karl2D's internal state.
+//
+// `shutdown` is a wrapper over four procedures, called in reverse order of `init`:
+//
+//// k2.shutdown_sound()
+//// k2.shutdown_rendering()
+//// k2.close_window()
+//// k2.shutdown_platform()
+//
+// Call them directly instead of `shutdown` if you only want to tear down some of what `init` set
+// up.
 shutdown :: proc() {
 	assert(s != nil, "You've called 'shutdown' without calling 'init' first")
+	shutdown_sound()
+	shutdown_rendering()
+	close_window()
+	shutdown_platform()
+}
 
-	// Audio
-	{
-		hm.dynamic_destroy(&s.audio_streams)
-		ab.shutdown()
-		hm.dynamic_destroy(&s.sounds)
-		hm.dynamic_destroy(&s.audio_clips)
-		hm.dynamic_destroy(&s.audio_buses)
-		free(s.audio_backend_state, s.allocator)
+// Destroys everything `init_sound` set up. Does nothing if `init_sound` was never called (or if
+// `shutdown_sound` has already run).
+//
+// Called by `shutdown`, but can be called manually if you need more control.
+shutdown_sound :: proc() {
+	assert(s != nil, "You've called 'shutdown_sound' without calling 'init_platform' first")
+
+	if !s.audio_initialized {
+		return
 	}
 
-	delete(s.events)
+	hm.dynamic_destroy(&s.audio_streams)
+	ab.shutdown()
+	hm.dynamic_destroy(&s.sounds)
+	hm.dynamic_destroy(&s.audio_clips)
+	hm.dynamic_destroy(&s.audio_buses)
+	free(s.audio_backend_state, s.allocator)
+
+	s.audio_initialized = false
+}
+
+// Destroys everything `init_rendering` set up. Does nothing if `init_rendering` was never called
+// (or if `shutdown_rendering` has already run).
+//
+// Called by `shutdown`, but can be called manually if you need more control.
+shutdown_rendering :: proc() {
+	assert(s != nil, "You've called 'shutdown_rendering' without calling 'init_platform' first")
+
+	if !s.rendering_initialized {
+		return
+	}
+
 	destroy_font(FONT_DEFAULT)
 	rb.destroy_texture(s.shape_drawing_texture)
 	destroy_shader(s.default_shader)
@@ -277,17 +399,42 @@ shutdown :: proc() {
 	delete(s.batch_draw_calls)
 	runtime.arena_destroy(&s.batch_arena)
 
-	pf.shutdown()
-
 	fs.Destroy(&s.fs)
 	delete(s.fonts)
 
+	free(s.render_backend_state, s.allocator)
+
+	s.rendering_initialized = false
+}
+
+// Closes the window `open_window` opened. Does nothing if `open_window` was never called (or if
+// `close_window` has already run).
+//
+// Called by `shutdown`, but can be called manually if you need more control.
+close_window :: proc() {
+	assert(s != nil, "You've called 'close_window' without calling 'init_platform' first")
+
+	if !s.window_open {
+		return
+	}
+
+	pf.shutdown()
+	delete(s.events)
 	delete(s.typed_runes)
 
-	a := s.allocator
-	free(s.platform_state, a)
-	free(s.render_backend_state, a)
-	free(s, a)
+	s.window_open = false
+}
+
+// Frees Karl2D's internal state. Call this last, after `shutdown_sound`, `shutdown_rendering` and
+// `close_window`.
+//
+// Called by `shutdown`, but can be called manually if you need more control.
+shutdown_platform :: proc() {
+	assert(s != nil, "You've called 'shutdown_platform' without calling 'init_platform' first")
+
+	pf.shutdown_process()
+	free(s.platform_state, s.allocator)
+	free(s, s.allocator)
 	s = nil
 }
 
@@ -295,7 +442,7 @@ shutdown :: proc() {
 // have set a Render Texture using the `set_render_texture` procedure, then that Render Texture will
 // be cleared instead.
 clear :: proc(color: Color) {
-	assert_initialized()
+	assert_rendering_initialized()
 	draw_current_batch()
 	rb.clear(s.current_render_target, color)
 }
@@ -305,7 +452,7 @@ clear :: proc(color: Color) {
 //
 // Called as part of `update`, but can be called manually if you need more control.
 reset_frame_allocator :: proc() {
-	assert_initialized()
+	assert_platform_initialized()
 	free_all(s.frame_allocator)
 }
 
@@ -314,7 +461,7 @@ reset_frame_allocator :: proc() {
 //
 // Called as part of `update`, but can be called manually if you need more control.
 calculate_frame_time :: proc() {
-	assert_initialized()
+	assert_platform_initialized()
 	now := time.now()
 
 	if s.prev_frame_time != {} {
@@ -341,7 +488,7 @@ calculate_frame_time :: proc() {
 // WebGL note: WebGL does the backbuffer flipping automatically. But you should still call this to
 // make sure that all rendering has been sent off to the GPU (as it calls `draw_current_batch()`).
 present :: proc() {
-	assert_initialized()
+	assert_rendering_initialized()
 	draw_current_batch()
 	rb.present()
 }
@@ -352,7 +499,7 @@ present :: proc() {
 //
 // Called by `update`, but can be called manually if you need more control.
 process_events :: proc() {
-	assert_initialized()
+	assert_window_open()
 	s.key_went_up = {}
 	s.key_went_down = {}
 	s.key_repeat = {}
@@ -467,11 +614,13 @@ process_events :: proc() {
 			}
 
 		case Event_Screen_Resize:
-			// Recorded draw calls were meant for the old swapchain size.
-			draw_current_batch()
-			rb.resize_swapchain(e.width, e.height)
-			s.proj_matrix = make_default_projection(e.width, e.height, _camera_flip_y())
-			_update_view_projection()
+			if s.rendering_initialized {
+				// Recorded draw calls were meant for the old swapchain size.
+				draw_current_batch()
+				rb.resize_swapchain(e.width, e.height)
+				s.proj_matrix = make_default_projection(e.width, e.height, _camera_flip_y())
+				_update_view_projection()
+			}
 
 		case Event_Window_Focused:			
 
@@ -507,8 +656,10 @@ process_events :: proc() {
 			}
 
 		case Event_Window_Scale_Changed:
-			draw_current_batch()
-			rb.resize_swapchain(e.screen_width, e.screen_height)
+			if s.rendering_initialized {
+				draw_current_batch()
+				rb.resize_swapchain(e.screen_width, e.screen_height)
+			}
 		}
 	}
 
@@ -559,7 +710,7 @@ process_events :: proc() {
 // Warning: The returned slice is only valid during the current frame! You can make a clone of it
 // using the `slice.clone` procedure (import `core:slice`).
 get_events :: proc() -> []Event {
-	assert_initialized()
+	assert_window_open()
 	return s.events[:]
 }
 
@@ -567,7 +718,7 @@ get_events :: proc() -> []Event {
 //
 // This value is updated when `calculate_frame_time()` runs (which is also called by `update()`).
 get_frame_time :: proc() -> f32 {
-	assert_initialized()
+	assert_platform_initialized()
 	return s.frame_time
 }
 
@@ -576,42 +727,48 @@ get_frame_time :: proc() -> f32 {
 //
 // This value is updated when `calculate_frame_time()` runs (which is also called by `update()`).
 get_time :: proc() -> f64 {
-	assert_initialized()
+	assert_platform_initialized()
 	return s.time
 }
 
 // Resize the drawing area of the window (the screen) to a new size. While the user cannot resize
 // windows with `window_mode == .Windowed_Resizable`, this procedure is able to resize such windows.
 set_screen_size :: proc(width: int, height: int) {
-	assert_initialized()
+	assert_window_open()
 
-	// Recorded draw calls were meant for the old screen size.
-	draw_current_batch()
+	if s.rendering_initialized {
+		// Recorded draw calls were meant for the old screen size.
+		draw_current_batch()
+	}
+
 	pf.set_screen_size(width, height)
-	rb.resize_swapchain(pf.get_screen_width(), pf.get_screen_height())
+
+	if s.rendering_initialized {
+		rb.resize_swapchain(pf.get_screen_width(), pf.get_screen_height())
+	}
 }
 
 // Gets the width of the drawing area within the window.
 get_screen_width :: proc() -> int {
-	assert_initialized()
+	assert_window_open()
 	return pf.get_screen_width()
 }
 
 // Gets the height of the drawing area within the window.
 get_screen_height :: proc() -> int  {
-	assert_initialized()
+	assert_window_open()
 	return pf.get_screen_height()
 }
 
 // Gets the screen width and height as a 2D vector.
 get_screen_size :: proc() -> Vec2 {
-	assert_initialized()
+	assert_window_open()
 	return { f32(pf.get_screen_width()), f32(pf.get_screen_height()) }
 }
 
 // Change the window title.
 set_window_title :: proc(title: string) {
-	assert_initialized()
+	assert_window_open()
 	pf.set_window_title(title)
 }
 
@@ -619,7 +776,7 @@ set_window_title :: proc(title: string) {
 //
 // This does nothing for web builds.
 set_window_position :: proc(x: int, y: int) {
-	assert_initialized()
+	assert_window_open()
 	pf.set_window_position(x, y)
 }
 
@@ -627,7 +784,7 @@ set_window_position :: proc(x: int, y: int) {
 //
 // This returns {} for web and Wayland builds.
 get_window_position :: proc() -> Vec2 {
-	assert_initialized()
+	assert_window_open()
 	return pf.get_window_position()
 }
 
@@ -638,14 +795,61 @@ get_window_position :: proc() -> Vec2 {
 // wanted resolution by the scale and send it into `set_screen_size`. You can use a camera and set
 // the zoom to the window scale in order to make things the same percieved size.
 get_window_scale :: proc() -> f32 {
-	assert_initialized()
+	assert_window_open()
 	return pf.get_window_scale()
 }
 
 // Use to change between windowed mode, resizable windowed mode and fullscreen
 set_window_mode :: proc(window_mode: Window_Mode) {
-	assert_initialized()
+	assert_window_open()
 	pf.set_window_mode(window_mode)
+}
+
+// Returns how many monitors are connected. Works after `init_platform`, before `open_window`, so
+// you can decide how big a window to open based on the display it will end up on.
+get_monitor_count :: proc() -> int {
+	assert_platform_initialized()
+	return pf.get_monitor_count()
+}
+
+// Returns the size of `monitor`, in physical pixels, matching what `set_screen_size` takes. Monitor
+// 0 is the primary monitor. Works after `init_platform`, before `open_window`.
+get_monitor_size :: proc(monitor := 0) -> [2]int {
+	assert_platform_initialized()
+
+	if monitor < 0 || monitor >= pf.get_monitor_count() {
+		log.errorf("Cannot get monitor size, monitor %v does not exist.", monitor)
+		return {}
+	}
+
+	return pf.get_monitor_size(monitor)
+}
+
+// Returns the position of `monitor`, in physical pixels. Monitor 0 is the primary monitor. Works
+// after `init_platform`, before `open_window`.
+get_monitor_position :: proc(monitor := 0) -> [2]int {
+	assert_platform_initialized()
+
+	if monitor < 0 || monitor >= pf.get_monitor_count() {
+		log.errorf("Cannot get monitor position, monitor %v does not exist.", monitor)
+		return {}
+	}
+
+	return pf.get_monitor_position(monitor)
+}
+
+// Returns the scale of `monitor`. This usually comes from some DPI scaling setting in the OS. 1
+// means 100% scale, 1.5 means 150% etc. Monitor 0 is the primary monitor. Works after
+// `init_platform`, before `open_window`.
+get_monitor_scale :: proc(monitor := 0) -> f32 {
+	assert_platform_initialized()
+
+	if monitor < 0 || monitor >= pf.get_monitor_count() {
+		log.errorf("Cannot get monitor scale, monitor %v does not exist.", monitor)
+		return {}
+	}
+
+	return pf.get_monitor_scale(monitor)
 }
 
 // Flushes the current batch. A batch consists of a number of draw calls and a vertex buffer. This
@@ -661,6 +865,7 @@ set_window_mode :: proc(window_mode: Window_Mode) {
 // dictates how big a vertex is. The maximum number of vertices in a batch is therefore
 // `VERTEX_BUFFER_MAX / shader.vertex_size`. Running out of room flushes the batch automatically.
 draw_current_batch :: proc() {
+	assert_rendering_initialized()
 	_finish_draw_call()
 
 	if len(s.batch_draw_calls) > 0 {
@@ -733,7 +938,7 @@ get_typed_runes :: proc() -> []rune {
 //
 // Warning: The returned slice is only valid during the current frame!
 get_touches :: proc() -> []Touch {
-	assert_initialized()
+	assert_window_open()
 	return s.touches[:]
 }
 
@@ -744,7 +949,7 @@ get_touches :: proc() -> []Touch {
 // The touch is built from the mouse state, so it never shows up in `get_events`, only in
 // `get_touches`.
 set_touch_events_from_mouse :: proc(enabled: bool) {
-	assert_initialized()
+	assert_window_open()
 
 	// Turning this off mid-press must not leave a phantom touch stuck in `get_touches`.
 	if !enabled {
@@ -1186,6 +1391,8 @@ draw_texture_fit :: proc(
 	rotation: f32 = 0,
 	tint := WHITE,
 ) {
+	assert_rendering_initialized()
+
 	if texture.handle == TEXTURE_NONE || texture.width == 0 || texture.height == 0 {
 		return
 	}
@@ -1737,6 +1944,7 @@ create_texture :: proc(
 	height: int,
 	format: Pixel_Format,
 ) -> (Texture, bool) #optional_ok {
+	assert_rendering_initialized()
 	h, h_ok := rb.create_texture(width, height, format)
 
 	if !h_ok {
@@ -1837,6 +2045,7 @@ load_texture_from_bytes_raw :: proc(
 	height: int,
 	format: Pixel_Format,
 ) -> (Texture, bool) #optional_ok {
+	assert_rendering_initialized()
 	backend_tex, backend_tex_ok := rb.load_texture(bytes[:], width, height, format)
 
 	if !backend_tex_ok {
@@ -1864,6 +2073,8 @@ load_texture_from_bytes_raw :: proc(
 // this error, it will also be logged. In case of failure, the returned `Texture` will still be
 // possible to use, but it won't draw anything.
 load_texture_from_image :: proc(image: Image) -> (Texture, bool) #optional_ok {
+	assert_rendering_initialized()
+
 	if image.width == 0 || image.height == 0 {
 		log.error("Invalid image: Height or width is zero")
 		return {}, false
@@ -1976,6 +2187,8 @@ get_texture_rect :: proc(t: Texture) -> Rect {
 // Update a texture with new pixels. `bytes` is the new pixel data. `rect` is the rectangle in
 // `tex` where the new pixels should end up.
 update_texture :: proc(tex: Texture, bytes: []u8, rect: Rect) -> bool {
+	assert_rendering_initialized()
+
 	// Recorded draw calls may still be waiting to use the old pixels.
 	_flush_if_batch_uses_texture(tex.handle)
 	return rb.update_texture(tex.handle, bytes, rect)
@@ -1983,6 +2196,7 @@ update_texture :: proc(tex: Texture, bytes: []u8, rect: Rect) -> bool {
 
 // Destroy a texture, freeing up any memory it has used on the GPU.
 destroy_texture :: proc(tex: Texture) {
+	assert_rendering_initialized()
 	_flush_if_batch_uses_texture(tex.handle)
 	rb.destroy_texture(tex.handle)
 }
@@ -2005,6 +2219,8 @@ set_texture_filter_ex :: proc(
 	scale_up_filter: Texture_Filter,
 	mip_filter: Texture_Filter,
 ) {
+	assert_rendering_initialized()
+
 	// Recorded draw calls may still be waiting to sample this texture with the old filter.
 	_flush_if_batch_uses_texture(t.handle)
 	rb.set_texture_filter(t.handle, scale_down_filter, scale_up_filter, mip_filter)
@@ -2034,6 +2250,7 @@ play_audio_clip :: proc(
 	loop := false,
 	bus: Audio_Bus = AUDIO_BUS_MASTER,
 ) -> Sound {
+	assert_audio_initialized()
 	audio_clip_object := hm.get(&s.audio_clips, clip)
 
 	if audio_clip_object == nil {
@@ -2074,6 +2291,7 @@ play_audio_clip :: proc(
 // `play_audio_stream`, this also rewinds the stream to the start. Use `set_sound_paused` to pause
 // the Sound instead, which won't lose the current playback position and settings.
 stop_sound :: proc(sound: Sound) {
+	assert_audio_initialized()
 	sound_object := hm.get(&s.sounds, sound)
 
 	if sound_object == nil {
@@ -2091,6 +2309,7 @@ stop_sound :: proc(sound: Sound) {
 // Pause or unpause a sound. A paused sound keeps its position and stays valid until it is unpaused
 // or stopped.
 set_sound_paused :: proc(sound: Sound, paused: bool) {
+	assert_audio_initialized()
 	sound_object := hm.get(&s.sounds, sound)
 
 	if sound_object == nil {
@@ -2102,6 +2321,7 @@ set_sound_paused :: proc(sound: Sound, paused: bool) {
 
 // Returns true if the sound exists and is not paused.
 sound_is_playing :: proc(sound: Sound) -> bool {
+	assert_audio_initialized()
 	sound_object := hm.get(&s.sounds, sound)
 	return sound_object != nil && !sound_object.paused
 }
@@ -2109,11 +2329,13 @@ sound_is_playing :: proc(sound: Sound) -> bool {
 // Returns true if the sound still exists. Both playing and paused sounds are valid. A finished or
 // stopped sound is not.
 sound_is_valid :: proc(sound: Sound) -> bool {
+	assert_audio_initialized()
 	return hm.is_valid(&s.sounds, sound)
 }
 
 // Set the volume of a sound. Range: 0 to 1.
 set_sound_volume :: proc(sound: Sound, volume: f32) {
+	assert_audio_initialized()
 	sound_object := hm.get(&s.sounds, sound)
 
 	if sound_object == nil {
@@ -2125,6 +2347,7 @@ set_sound_volume :: proc(sound: Sound, volume: f32) {
 
 // Set the pan of a sound. Range: -1 to 1, where -1 is full left, 0 is center and 1 is full right.
 set_sound_pan :: proc(sound: Sound, pan: f32) {
+	assert_audio_initialized()
 	sound_object := hm.get(&s.sounds, sound)
 
 	if sound_object == nil {
@@ -2137,6 +2360,7 @@ set_sound_pan :: proc(sound: Sound, pan: f32) {
 // Set the pitch of a sound. Range: 0.01 and up, where 1 is the default. Pitch 2 makes the sound
 // play twice as fast, which also makes it sound higher pitched.
 set_sound_pitch :: proc(sound: Sound, pitch: f32) {
+	assert_audio_initialized()
 	sound_object := hm.get(&s.sounds, sound)
 
 	if sound_object == nil {
@@ -2153,6 +2377,7 @@ set_sound_pitch :: proc(sound: Sound, pitch: f32) {
 // audio has to be decoded before it can play. Don't do it every frame while dragging a scrub bar,
 // do it when the player lets go.
 set_sound_time :: proc(sound: Sound, seconds: f32) {
+	assert_audio_initialized()
 	sound_object := hm.get(&s.sounds, sound)
 
 	if sound_object == nil {
@@ -2185,6 +2410,7 @@ set_sound_time :: proc(sound: Sound, seconds: f32) {
 // Get how far into its audio the sound currently is, in seconds. A looping sound goes back to 0
 // each time it starts over. Returns 0 if the sound doesn't exist.
 get_sound_time :: proc(sound: Sound) -> f32 {
+	assert_audio_initialized()
 	sound_object := hm.get(&s.sounds, sound)
 
 	if sound_object == nil {
@@ -2258,6 +2484,7 @@ get_sound_time :: proc(sound: Sound) -> f32 {
 // Get the length of the sound's audio, in seconds. Use it together with `get_sound_time` to show
 // how far into a song you are. Returns 0 if the sound doesn't exist or if the length is unknown.
 get_sound_length :: proc(sound: Sound) -> f32 {
+	assert_audio_initialized()
 	sound_object := hm.get(&s.sounds, sound)
 
 	if sound_object == nil {
@@ -2305,6 +2532,7 @@ get_sound_length :: proc(sound: Sound) -> f32 {
 // reaches into the streaming decoder and tells that one to loop. A `Sound` started from a stream
 // plays a short buffer that the decoder keeps filling, so that sound always loops.
 set_sound_loop :: proc(sound: Sound, loop: bool) {
+	assert_audio_initialized()
 	sound_object := hm.get(&s.sounds, sound)
 
 	if sound_object == nil {
@@ -2326,6 +2554,7 @@ set_sound_loop :: proc(sound: Sound, loop: bool) {
 
 // Route a sound into an audio bus. Pass `AUDIO_BUS_MASTER` for the master bus.
 set_sound_bus :: proc(sound: Sound, bus: Audio_Bus) {
+	assert_audio_initialized()
 	sound_object := hm.get(&s.sounds, sound)
 
 	if sound_object == nil {
@@ -2343,6 +2572,7 @@ set_sound_bus :: proc(sound: Sound, bus: Audio_Bus) {
 // How many sounds currently play this clip. Useful for limiting how many overlapping sounds you
 // start from the same clip.
 get_num_sounds_playing_clip :: proc(clip: Audio_Clip) -> int {
+	assert_audio_initialized()
 	count: int
 
 	for it := hm.dynamic_iterator_make(&s.sounds); sound_object, _ in hm.dynamic_iterate(&it) {
@@ -2571,6 +2801,7 @@ load_audio_clip_from_bytes_raw :: proc(
 	sample_rate: int,
 	channels: Audio_Channels,
 ) -> (Audio_Clip, bool) #optional_ok {
+	assert_audio_initialized()
 	samples: []Audio_Sample
 
 	switch format{
@@ -2641,6 +2872,7 @@ load_audio_clip_from_bytes_raw :: proc(
 // Destroy an audio clip previously loaded using `load_audio_clip_from_xxx`. Also stops sounds
 // playing this clip.
 destroy_audio_clip :: proc(clip: Audio_Clip)  {
+	assert_audio_initialized()
 	audio_clip_object := hm.get(&s.audio_clips, clip)
 
 	if audio_clip_object == nil {
@@ -2676,6 +2908,7 @@ load_audio_stream_from_file :: proc(
 	_stream: Audio_Stream,
 	_ok: bool,
 ) #optional_ok {
+	assert_audio_initialized()
 	f, f_err := file_open(filename)
 
 	if f_err != nil {
@@ -2856,6 +3089,7 @@ load_audio_stream_from_bytes :: proc(
 	_stream: Audio_Stream,
 	_ok: bool,
 ) #optional_ok {
+	assert_audio_initialized()
 	vorbis_err: stbv.Error
 
 	vorbis_buffer := stbv.vorbis_alloc {
@@ -2934,6 +3168,7 @@ load_audio_stream_from_bytes :: proc(
 // If you created the stream using `load_audio_stream_from_bytes`, then this procedure will NOT
 // deallocate the bytes that you sent into that procedure.
 destroy_audio_stream :: proc(stream: Audio_Stream) {
+	assert_audio_initialized()
 	sd := hm.get(&s.audio_streams, stream)
 
 	if sd == nil {
@@ -2965,6 +3200,7 @@ destroy_audio_stream :: proc(stream: Audio_Stream) {
 // Streams in new audio data from the audio stream. You need to call this once per frame in order
 // for the streaming to actually happen. 
 update_audio_stream :: proc(stream: Audio_Stream) {
+	assert_audio_initialized()
 	sd := hm.get(&s.audio_streams, stream)
 
 	if sd == nil {
@@ -3178,6 +3414,7 @@ play_audio_stream :: proc(
 	loop := false,
 	bus: Audio_Bus = AUDIO_BUS_MASTER,
 ) -> Sound {
+	assert_audio_initialized()
 	sd := hm.get(&s.audio_streams, stream)
 
 	if sd == nil {
@@ -3246,6 +3483,7 @@ play_audio_stream :: proc(
 // A new bus has volume 1, pan 0 and no effect. That makes it a passthrough: Playing a sound on a
 // fresh bus sounds exactly like playing it on the master bus, until you change something.
 create_audio_bus :: proc() -> Audio_Bus {
+	assert_audio_initialized()
 	bus_object := Audio_Bus_Object {
 		target_settings = DEFAULT_AUDIO_BUS_SETTINGS,
 		current_settings = DEFAULT_AUDIO_BUS_SETTINGS,
@@ -3266,6 +3504,8 @@ create_audio_bus :: proc() -> Audio_Bus {
 // Destroy an audio bus. Everything routed to it goes back to the master bus, including sounds that
 // are playing right now.
 destroy_audio_bus :: proc(bus: Audio_Bus) {
+	assert_audio_initialized()
+
 	if bus == AUDIO_BUS_MASTER {
 		log.error("Cannot destroy audio bus, the master bus cannot be destroyed.")
 		return
@@ -3293,6 +3533,7 @@ destroy_audio_bus :: proc(bus: Audio_Bus) {
 //
 // This works on `AUDIO_BUS_MASTER` as well, which is how you set the master volume of your game.
 set_audio_bus_volume :: proc(bus: Audio_Bus, volume: f32) {
+	assert_audio_initialized()
 	bus_object := bus == AUDIO_BUS_MASTER ? &s.master_bus : hm.get(&s.audio_buses, bus)
 
 	if bus_object == nil {
@@ -3311,6 +3552,7 @@ set_audio_bus_volume :: proc(bus: Audio_Bus, volume: f32) {
 // loudness the same. A bus is already a finished stereo mix, and a bus at pan 0 has to leave it
 // exactly as it is.
 set_audio_bus_pan :: proc(bus: Audio_Bus, pan: f32) {
+	assert_audio_initialized()
 	bus_object := bus == AUDIO_BUS_MASTER ? &s.master_bus : hm.get(&s.audio_buses, bus)
 
 	if bus_object == nil {
@@ -3330,6 +3572,7 @@ set_audio_bus_pan :: proc(bus: Audio_Bus, pan: f32) {
 //
 // See `Audio_Effect_Proc` for what the effect is given and what it is allowed to do.
 set_audio_bus_effect :: proc(bus: Audio_Bus, effect: Audio_Effect_Proc, user_data: rawptr = nil) {
+	assert_audio_initialized()
 	bus_object := bus == AUDIO_BUS_MASTER ? &s.master_bus : hm.get(&s.audio_buses, bus)
 
 	if bus_object == nil {
@@ -3350,6 +3593,8 @@ set_audio_bus_effect :: proc(bus: Audio_Bus, effect: Audio_Effect_Proc, user_dat
 //
 // Will only run if the audio backend is running low on audio data.
 update_audio_mixer :: proc() {
+	assert_audio_initialized()
+
 	// If the sample rate of the backend is 44100 samples/second and AUDIO_MIX_CHUNK_SIZE is 1400
 	// samples, then this procedure will only run roughly 44100/1400 = 31 times per second. This
 	// gives a latency of up to (1.5 * (44100/1400)) = 47 milliseconds. Is it too big, or too small?
@@ -3816,6 +4061,7 @@ update_audio_mixer :: proc() {
 // handle this error, it will also be logged. In case of failure, the returned `Render_Texture`
 // will still be possible to use, but setting it does nothing, so drawing stays where it was.
 create_render_texture :: proc(width: int, height: int) -> (Render_Texture, bool) #optional_ok {
+	assert_rendering_initialized()
 	texture, render_target, render_texture_ok := rb.create_render_texture(width, height)
 
 	if !render_texture_ok {
@@ -3835,6 +4081,8 @@ create_render_texture :: proc(width: int, height: int) -> (Render_Texture, bool)
 
 // Destroy a Render_Texture previously created using `create_render_texture`.
 destroy_render_texture :: proc(render_texture: Render_Texture) {
+	assert_rendering_initialized()
+
 	// Recorded draw calls may still be waiting to draw into this render target, or sample it.
 	_flush_if_batch_uses_render_target(render_texture.render_target)
 	_flush_if_batch_uses_texture(render_texture.texture.handle)
@@ -3845,6 +4093,8 @@ destroy_render_texture :: proc(render_texture: Render_Texture) {
 // Make all rendering go into a texture instead of onto the screen. Create the render texture using
 // `create_render_texture`. Pass `nil` to resume drawing onto the screen.
 set_render_texture :: proc(render_texture: Maybe(Render_Texture)) {
+	assert_rendering_initialized()
+
 	if rt, rt_ok := render_texture.?; rt_ok {
 		if rt.render_target == RENDER_TARGET_NONE {
 			log.errorf("Invalid render texture: %v", rt)
@@ -4372,6 +4622,7 @@ load_dynamic_font_from_bytes :: proc(
 	data: []u8,
 	options: Font_Options = {},
 ) -> (Font, bool) #optional_ok {
+	assert_rendering_initialized()
 	font_info: stbtt.fontinfo
 	font_offset := stbtt.GetFontOffsetForIndex(raw_data(data), 0)
 	init_ok := stbtt.InitFont(&font_info, raw_data(data), font_offset)
@@ -4425,6 +4676,8 @@ load_font_from_bytes :: proc(data: []u8, options: Font_Options = {}) -> (Font, b
 
 // Destroy a font previously loaded using `load_font_from_file` or `load_font_from_bytes`.
 destroy_font :: proc(font: Font) {
+	assert_rendering_initialized()
+
 	if int(font) >= len(s.fonts) {
 		return
 	}
@@ -4570,6 +4823,7 @@ load_shader_from_bytes :: proc(
 	fragment_shader_bytes: []byte,
 	layout_formats: []Pixel_Format = {},
 ) -> (Shader, bool) #optional_ok {
+	assert_rendering_initialized()
 	handle, desc, shader_ok := rb.load_shader(
 		vertex_shader_bytes,
 		fragment_shader_bytes,
@@ -4655,6 +4909,8 @@ load_shader_from_bytes :: proc(
 
 // Destroy a shader previously loaded using `load_shader_from_file` or `load_shader_from_bytes`
 destroy_shader :: proc(shader: Shader) {
+	assert_rendering_initialized()
+
 	// Recorded draw calls may still be waiting to draw with this shader.
 	_flush_if_batch_uses_shader(shader.handle)
 	rb.destroy_shader(shader.handle)
@@ -4795,6 +5051,8 @@ pixel_format_size :: proc(f: Pixel_Format) -> int {
 // Make Karl2D use a camera. Return to the "default camera" by passing `nil`. All drawing operations
 // will use this camera until you again change it.
 set_camera :: proc(camera: Maybe(Camera)) {
+	assert_rendering_initialized()
+
 	if camera == s.current_camera {
 		return
 	}
@@ -4965,11 +5223,19 @@ set_internal_state :: proc(state: ^State) {
 	s = state
 	frame_allocator = s.frame_allocator
 	pf = s.platform
-	rb = s.render_backend
-	ab = s.audio_backend
+
+	// The platform state exists from `init_platform` onwards, not just once a window is open.
 	pf.set_internal_state(s.platform_state)
-	rb.set_internal_state(s.render_backend_state)
-	ab.set_internal_state(s.audio_backend_state)
+
+	if s.rendering_initialized {
+		rb = s.render_backend
+		rb.set_internal_state(s.render_backend_state)
+	}
+
+	if s.audio_initialized {
+		ab = s.audio_backend
+		ab.set_internal_state(s.audio_backend_state)
+	}
 }
 
 Open_URL_Error :: enum {
@@ -5263,11 +5529,8 @@ Window_Mode :: enum {
 	Borderless_Fullscreen,
 }
 
-Init_Options :: struct {
+Window_Options :: struct {
 	window_mode: Window_Mode,
-
-	// Enable to request anti-alias. On most systems this means 4x Multi Sample Anti Alias
-	anti_alias: bool,
 
 	// This hint may disable scaling of the window when created. Scaling here refers to the scaling
 	// that is set for the monitor in the OS settings (the same number returned by
@@ -5277,6 +5540,11 @@ Init_Options :: struct {
 	// platforms, such as Linux+Wayland, it does not work, because Wayland always auto scales all
 	// windows.
 	disable_auto_scale_hint: bool,
+}
+
+Rendering_Options :: struct {
+	// Enable to request anti-alias. On most systems this means 4x Multi Sample Anti Alias
+	anti_alias: bool,
 
 	// Enable depth testing. Draws are then sorted by the z value set with `set_z`: higher z ends up
 	// in front. Things drawn at the same z use the drawing order, like when depth testing is off.
@@ -5287,6 +5555,13 @@ Init_Options :: struct {
 	// coordinates. Only used when `depth_test` is on.
 	depth_range_min: f32,
 	depth_range_max: f32,
+}
+
+// The combination of `Window_Options` and `Rendering_Options`, used by `init`. The granular
+// procedures `open_window` and `init_rendering` take the individual halves instead.
+Init_Options :: struct {
+	using window: Window_Options,
+	using rendering: Rendering_Options,
 }
 
 DEPTH_RANGE_DEFAULT_MIN :: -1
@@ -5708,6 +5983,13 @@ State :: struct {
 	platform_state: rawptr,
 	render_backend: Render_Backend_Interface,
 	render_backend_state: rawptr,
+
+	// Rendering and audio are initialised by separate procedures from the platform and the window,
+	// so a program can skip either or query monitors before opening a window. These track how far
+	// along that setup is.
+	window_open: bool,
+	rendering_initialized: bool,
+	audio_initialized: bool,
 
 	fs: fs.FontContext,
 	
@@ -6172,8 +6454,23 @@ count_text_lines :: proc "contextless" (text: string) -> int {
 	return lines
 }
 
-assert_initialized :: proc(loc := #caller_location) {
-	assert(s != nil, "Call k2.init before using this Karl2D procedure", loc)
+assert_platform_initialized :: proc(loc := #caller_location) {
+	assert(s != nil, "Call k2.init_platform before using this Karl2D procedure", loc)
+}
+
+assert_window_open :: proc(loc := #caller_location) {
+	assert(s != nil, "Call k2.open_window before using this Karl2D procedure", loc)
+	assert(s.window_open, "Call k2.open_window before using this Karl2D procedure", loc)
+}
+
+assert_rendering_initialized :: proc(loc := #caller_location) {
+	assert(s != nil, "Call k2.init_rendering before using this Karl2D procedure", loc)
+	assert(s.rendering_initialized, "Call k2.init_rendering before using this Karl2D procedure", loc)
+}
+
+assert_audio_initialized :: proc(loc := #caller_location) {
+	assert(s != nil, "Call k2.init_sound before using this Karl2D procedure", loc)
+	assert(s.audio_initialized, "Call k2.init_sound before using this Karl2D procedure", loc)
 }
 
 // Finds a currently tracked touch by id. Returns nil if the touch isn't tracked, which happens for

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -32,11 +32,12 @@ import hm "core:container/handle_map"
 
 // Allocates Karl2D's internal state and sets up the platform layer. Does not open a window.
 //
-// This is the first procedure to call, and the only one that has to run before a window exists:
-// `windows_init`/`linux_init` etc allocate from the package-global frame allocator, which is set up
-// here. Call `get_monitor_count`, `get_monitor_size`, `get_monitor_position` and
-// `get_monitor_scale` after this and before `open_window` if you want to pick a window size based
-// on the display.
+// This is the first procedure to call. It sets up the package-global frame allocator that the
+// platform backends allocate from, and it does the process-level work that has to happen before
+// any window exists, such as making the process DPI aware on Windows.
+//
+// Call `get_monitor_count`, `get_monitor_size`, `get_monitor_position` and `get_monitor_scale`
+// after this and before `open_window` if you want to pick a window size based on the display.
 //
 // The internal state will use `allocator` for all dynamically allocated memory. The return value is
 // a pointer to it, see `init` for what you can do with that pointer.
@@ -85,7 +86,7 @@ init_platform :: proc(
 	// Process-level setup that has to happen before any window exists. On Windows this is what
 	// makes the process DPI aware, without which the monitor queries below would report
 	// virtualized sizes.
-	pf.init_process(s.platform_state, s.allocator)
+	pf.init(s.platform_state, s.allocator)
 
 	return s
 }
@@ -105,7 +106,7 @@ open_window :: proc(
 	assert(s != nil, "Call k2.init_platform before k2.open_window")
 	assert(!s.window_open, "Don't call 'open_window' twice.")
 
-	pf.init(screen_width, screen_height, window_title, options)
+	pf.open_window(screen_width, screen_height, window_title, options)
 	s.window_open = true
 
 	s.events = make([dynamic]Event, s.allocator)
@@ -418,7 +419,7 @@ close_window :: proc() {
 		return
 	}
 
-	pf.shutdown()
+	pf.close_window()
 	delete(s.events)
 	delete(s.typed_runes)
 
@@ -432,7 +433,7 @@ close_window :: proc() {
 shutdown_platform :: proc() {
 	assert(s != nil, "You've called 'shutdown_platform' without calling 'init_platform' first")
 
-	pf.shutdown_process()
+	pf.shutdown()
 	free(s.platform_state, s.allocator)
 	free(s, s.allocator)
 	s = nil

--- a/platform_interface.odin
+++ b/platform_interface.odin
@@ -11,21 +11,21 @@ Platform_Interface :: struct #all_or_none {
 	//
 	// This is also where the platform state pointer is handed over, so everything after this can
 	// use it.
-	init_process: proc(
+	init: proc(
 		platform_state: rawptr,
 		allocator: runtime.Allocator,
 	),
 
-	shutdown_process: proc(),
+	shutdown: proc(),
 
-	init: proc(
+	open_window: proc(
 		window_width: int,
 		window_height: int,
 		window_title: string,
 		init_options: Window_Options,
 	),
 
-	shutdown: proc(),
+	close_window: proc(),
 	get_window_render_glue: proc() -> Window_Render_Glue,
 	get_events: proc(events: ^[dynamic]Event),
 	set_window_title: proc(title: string),

--- a/platform_interface.odin
+++ b/platform_interface.odin
@@ -5,13 +5,24 @@ import "base:runtime"
 Platform_Interface :: struct #all_or_none {
 	state_size: proc() -> int,
 
-	init: proc(
+	// Process-level setup that has to happen before any window exists: making the process DPI
+	// aware, registering a window class, creating the application object and so on. Called by
+	// `init_platform`, which is what makes the monitor queries below work before `open_window`.
+	//
+	// This is also where the platform state pointer is handed over, so everything after this can
+	// use it.
+	init_process: proc(
 		platform_state: rawptr,
+		allocator: runtime.Allocator,
+	),
+
+	shutdown_process: proc(),
+
+	init: proc(
 		window_width: int,
 		window_height: int,
 		window_title: string,
-		init_options: Init_Options,
-		allocator: runtime.Allocator,
+		init_options: Window_Options,
 	),
 
 	shutdown: proc(),
@@ -25,6 +36,11 @@ Platform_Interface :: struct #all_or_none {
 	get_screen_height: proc() -> int,
 	get_window_scale: proc() -> f32,
 	set_window_mode: proc(window_mode: Window_Mode),
+
+	get_monitor_count: proc() -> int,
+	get_monitor_size: proc(monitor: int) -> [2]int,
+	get_monitor_position: proc(monitor: int) -> [2]int,
+	get_monitor_scale: proc(monitor: int) -> f32,
 
 	set_cursor_hidden: proc(hidden: bool),
 	is_cursor_hidden: proc() -> bool,
@@ -55,7 +71,7 @@ Window_Render_Glue :: struct {
 	using state: ^Window_Render_Glue_State,
 	make_context: proc(
 		state: ^Window_Render_Glue_State,
-		init_options: Init_Options,
+		init_options: Rendering_Options,
 	) -> bool,
 	present: proc(state: ^Window_Render_Glue_State),
 	destroy: proc(state: ^Window_Render_Glue_State),

--- a/platform_linux.odin
+++ b/platform_linux.odin
@@ -18,10 +18,10 @@ import "core:time"
 @(private="package")
 PLATFORM_LINUX :: Platform_Interface {
 	state_size = linux_state_size,
-	init_process = linux_init_process,
-	shutdown_process = linux_shutdown_process,
 	init = linux_init,
 	shutdown = linux_shutdown,
+	open_window = linux_open_window,
+	close_window = linux_close_window,
 	get_window_render_glue = linux_get_window_render_glue,
 	get_events = linux_get_events,
 	set_window_title = linux_set_window_title,
@@ -58,7 +58,7 @@ linux_state_size :: proc() -> int {
 
 // Picks the windowing backend and sets up the gamepads. None of this needs a window, and doing it
 // here means `s.win` is already resolved when the monitor queries run before `open_window`.
-linux_init_process :: proc(platform_state: rawptr, allocator: runtime.Allocator) {
+linux_init :: proc(platform_state: rawptr, allocator: runtime.Allocator) {
 	assert(platform_state != nil)
 	s = (^Linux_State)(platform_state)
 	s.allocator = allocator
@@ -81,7 +81,7 @@ linux_init_process :: proc(platform_state: rawptr, allocator: runtime.Allocator)
 		win_state_alloc_error,
 	)
 
-	s.win.init_process(s.win_state, allocator)
+	s.win.init(s.win_state, allocator)
 
 	linux_create_connected_gamepads()
 
@@ -95,13 +95,13 @@ linux_init_process :: proc(platform_state: rawptr, allocator: runtime.Allocator)
 	}
 }
 
-linux_init :: proc(
+linux_open_window :: proc(
 	screen_width: int,
 	screen_height: int,
 	window_title: string,
 	options: Window_Options,
 ) {
-	s.win.init(
+	s.win.open_window(
 		screen_width,
 		screen_height,
 		window_title,
@@ -109,11 +109,11 @@ linux_init :: proc(
 	)
 }
 
-linux_shutdown :: proc() {
-	s.win.shutdown()
+linux_close_window :: proc() {
+	s.win.close_window()
 }
 
-linux_shutdown_process :: proc() {
+linux_shutdown :: proc() {
 	for &g in s.gamepads {
 		linux_destroy_gamepad(&g)
 	}
@@ -121,7 +121,7 @@ linux_shutdown_process :: proc() {
 	udev.monitor_unref(s.udev_mon)
 	udev.unref(s.udev_ptr)
 
-	s.win.shutdown_process()
+	s.win.shutdown()
 	a := s.allocator
 	free(s.win_state, a)
 }
@@ -202,7 +202,7 @@ linux_get_window_scale :: proc() -> f32 {
 	return s.win.get_window_scale()
 }
 
-// `s.win` is resolved in `linux_init_process`, so these work before `open_window` has run.
+// `s.win` is resolved in `linux_init`, so these work before `open_window` has run.
 linux_get_monitor_count :: proc() -> int {
 	return s.win.get_monitor_count()
 }
@@ -711,23 +711,23 @@ Linux_State :: struct {
 Linux_Window_Interface :: struct #all_or_none {
 	state_size: proc() -> int,
 
-	// Connects to the display server. Runs from `linux_init_process`, before any window exists, so
+	// Connects to the display server. Runs from `linux_init`, before any window exists, so
 	// the monitor queries have something to ask.
-	init_process: proc(
+	init: proc(
 		window_state: rawptr,
 		allocator: runtime.Allocator,
 	),
 
-	shutdown_process: proc(),
+	shutdown: proc(),
 
-	init: proc(
+	open_window: proc(
 		screen_width: int,
 		screen_height: int,
 		window_title: string,
 		init_options: Window_Options,
 	),
 
-	shutdown: proc(),
+	close_window: proc(),
 	get_window_render_glue: proc() -> Window_Render_Glue,
 	get_events: proc(events: ^[dynamic]Event),
 	set_title: proc(title: string),

--- a/platform_linux.odin
+++ b/platform_linux.odin
@@ -18,6 +18,8 @@ import "core:time"
 @(private="package")
 PLATFORM_LINUX :: Platform_Interface {
 	state_size = linux_state_size,
+	init_process = linux_init_process,
+	shutdown_process = linux_shutdown_process,
 	init = linux_init,
 	shutdown = linux_shutdown,
 	get_window_render_glue = linux_get_window_render_glue,
@@ -30,6 +32,10 @@ PLATFORM_LINUX :: Platform_Interface {
 	get_window_position = linux_get_window_position,
 	get_window_scale = linux_get_window_scale,
 	set_window_mode = linux_set_window_mode,
+	get_monitor_count = linux_get_monitor_count,
+	get_monitor_size = linux_get_monitor_size,
+	get_monitor_position = linux_get_monitor_position,
+	get_monitor_scale = linux_get_monitor_scale,
 	set_cursor_hidden = linux_set_cursor_hidden,
 	is_cursor_hidden = linux_is_cursor_hidden,
 	set_mouse_locked = linux_set_mouse_locked,
@@ -50,19 +56,14 @@ linux_state_size :: proc() -> int {
 	return size_of(Linux_State)
 }
 
-linux_init :: proc(
-	platform_state: rawptr,
-	screen_width: int,
-	screen_height: int,
-	window_title: string,
-	options: Init_Options,
-	allocator: runtime.Allocator,
-) {
+// Picks the windowing backend and sets up the gamepads. None of this needs a window, and doing it
+// here means `s.win` is already resolved when the monitor queries run before `open_window`.
+linux_init_process :: proc(platform_state: rawptr, allocator: runtime.Allocator) {
 	assert(platform_state != nil)
 	s = (^Linux_State)(platform_state)
 	s.allocator = allocator
 	xdg_session_type := os.get_env("XDG_SESSION_TYPE", frame_allocator)
-	
+
 	if xdg_session_type == "wayland" {
 		s.win = LINUX_WINDOW_WAYLAND
 	} else {
@@ -80,14 +81,7 @@ linux_init :: proc(
 		win_state_alloc_error,
 	)
 
-	s.win.init(
-		s.win_state,
-		screen_width,
-		screen_height,
-		window_title,
-		options,
-		allocator,
-	)
+	s.win.init_process(s.win_state, allocator)
 
 	linux_create_connected_gamepads()
 
@@ -101,7 +95,25 @@ linux_init :: proc(
 	}
 }
 
+linux_init :: proc(
+	screen_width: int,
+	screen_height: int,
+	window_title: string,
+	options: Window_Options,
+) {
+	s.win.init(
+		screen_width,
+		screen_height,
+		window_title,
+		options,
+	)
+}
+
 linux_shutdown :: proc() {
+	s.win.shutdown()
+}
+
+linux_shutdown_process :: proc() {
 	for &g in s.gamepads {
 		linux_destroy_gamepad(&g)
 	}
@@ -109,7 +121,7 @@ linux_shutdown :: proc() {
 	udev.monitor_unref(s.udev_mon)
 	udev.unref(s.udev_ptr)
 
-	s.win.shutdown()
+	s.win.shutdown_process()
 	a := s.allocator
 	free(s.win_state, a)
 }
@@ -188,6 +200,23 @@ set_screen_size :: proc(w, h: int) {
 
 linux_get_window_scale :: proc() -> f32 {
 	return s.win.get_window_scale()
+}
+
+// `s.win` is resolved in `linux_init_process`, so these work before `open_window` has run.
+linux_get_monitor_count :: proc() -> int {
+	return s.win.get_monitor_count()
+}
+
+linux_get_monitor_size :: proc(monitor: int) -> [2]int {
+	return s.win.get_monitor_size(monitor)
+}
+
+linux_get_monitor_position :: proc(monitor: int) -> [2]int {
+	return s.win.get_monitor_position(monitor)
+}
+
+linux_get_monitor_scale :: proc(monitor: int) -> f32 {
+	return s.win.get_monitor_scale(monitor)
 }
 
 linux_create_connected_gamepads :: proc() {
@@ -682,13 +711,20 @@ Linux_State :: struct {
 Linux_Window_Interface :: struct #all_or_none {
 	state_size: proc() -> int,
 
-	init: proc(
+	// Connects to the display server. Runs from `linux_init_process`, before any window exists, so
+	// the monitor queries have something to ask.
+	init_process: proc(
 		window_state: rawptr,
+		allocator: runtime.Allocator,
+	),
+
+	shutdown_process: proc(),
+
+	init: proc(
 		screen_width: int,
 		screen_height: int,
 		window_title: string,
-		init_options: Init_Options,
-		allocator: runtime.Allocator,
+		init_options: Window_Options,
 	),
 
 	shutdown: proc(),
@@ -702,6 +738,12 @@ Linux_Window_Interface :: struct #all_or_none {
 	get_screen_height: proc() -> int,
 	get_window_scale: proc() -> f32,
 	set_window_mode: proc(window_mode: Window_Mode),
+
+	get_monitor_count: proc() -> int,
+	get_monitor_size: proc(monitor: int) -> [2]int,
+	get_monitor_position: proc(monitor: int) -> [2]int,
+	get_monitor_scale: proc(monitor: int) -> f32,
+
 	set_cursor_hidden: proc(hidden: bool),
 	is_cursor_hidden: proc() -> bool,
 	set_mouse_locked: proc(locked: bool),

--- a/platform_linux_glue_gl_wayland.odin
+++ b/platform_linux_glue_gl_wayland.odin
@@ -26,7 +26,10 @@ make_linux_gl_wayland_glue :: proc(
 		state = (^Window_Render_Glue_State)(state),
 
 		// these casts just make the proc take a Windows_GL_Glue_State instead of a Window_Render_Glue_State
-		make_context = cast(proc(state: ^Window_Render_Glue_State, options: Init_Options) -> bool)(linux_gl_wayland_glue_make_context),
+		make_context = cast(proc(
+			state: ^Window_Render_Glue_State,
+			options: Rendering_Options,
+		) -> bool)(linux_gl_wayland_glue_make_context),
 		present = cast(proc(state: ^Window_Render_Glue_State))(linux_gl_wayland_glue_present),
 		destroy = cast(proc(state: ^Window_Render_Glue_State))(linux_gl_wayland_glue_destroy),
 		viewport_resized = cast(proc(state: ^Window_Render_Glue_State))(linux_gl_wayland_glue_viewport_resized),
@@ -42,7 +45,10 @@ Linux_GL_Wayland_Glue_State :: struct {
 	allocator: runtime.Allocator,
 }
 
-linux_gl_wayland_glue_make_context :: proc(s: ^Linux_GL_Wayland_Glue_State, options: Init_Options) -> bool {
+linux_gl_wayland_glue_make_context :: proc(
+	s: ^Linux_GL_Wayland_Glue_State,
+	options: Rendering_Options,
+) -> bool {
 	// Get a valid EGL configuration based on some attribute guidelines
 	// Create a context based on a "chosen" configuration
 	EGL_CONTEXT_FLAGS_KHR :: 0x30FC

--- a/platform_linux_glue_gl_x11.odin
+++ b/platform_linux_glue_gl_x11.odin
@@ -26,7 +26,10 @@ make_linux_gl_x11_glue :: proc(
 		state = (^Window_Render_Glue_State)(state),
 
 		// these casts just make the proc take a Windows_GL_Glue_State instead of a Window_Render_Glue_State
-		make_context = cast(proc(state: ^Window_Render_Glue_State, options: Init_Options) -> bool)(linux_gl_x11_glue_make_context),
+		make_context = cast(proc(
+			state: ^Window_Render_Glue_State,
+			options: Rendering_Options,
+		) -> bool)(linux_gl_x11_glue_make_context),
 		present = cast(proc(state: ^Window_Render_Glue_State))(linux_gl_x11_glue_present),
 		destroy = cast(proc(state: ^Window_Render_Glue_State))(linux_gl_x11_glue_destroy),
 		viewport_resized = cast(proc(state: ^Window_Render_Glue_State))(linux_gl_x11_glue_viewport_resized),
@@ -40,7 +43,10 @@ Linux_GL_X11_Glue_State :: struct {
 	allocator: runtime.Allocator,
 }
 
-linux_gl_x11_glue_make_context :: proc(s: ^Linux_GL_X11_Glue_State, options: Init_Options) -> bool {
+linux_gl_x11_glue_make_context :: proc(
+	s: ^Linux_GL_X11_Glue_State,
+	options: Rendering_Options,
+) -> bool {
 	visual_attribs := slice.to_dynamic(
 		[]i32 {
 			glx.RENDER_TYPE, glx.RGBA_BIT,

--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -4,6 +4,8 @@ package karl2d
 @(private="package")
 LINUX_WINDOW_WAYLAND :: Linux_Window_Interface {
 	state_size = wl_state_size,
+	init_process = wl_init_process,
+	shutdown_process = wl_shutdown_process,
 	init = wl_init,
 	shutdown = wl_shutdown,
 	get_window_render_glue = wl_get_window_render_glue,
@@ -16,6 +18,10 @@ LINUX_WINDOW_WAYLAND :: Linux_Window_Interface {
 	set_screen_size = wl_set_screen_size,
 	get_window_scale = wl_get_window_scale,
 	set_window_mode = wl_set_window_mode,
+	get_monitor_count = wl_get_monitor_count,
+	get_monitor_size = wl_get_monitor_size,
+	get_monitor_position = wl_get_monitor_position,
+	get_monitor_scale = wl_get_monitor_scale,
 	set_cursor_hidden = wl_set_cursor_hidden,
 	is_cursor_hidden = wl_is_cursor_hidden,
 	set_mouse_locked = wl_set_mouse_locked,
@@ -52,14 +58,9 @@ wl_state_size :: proc() -> int {
 	return size_of(WL_State)
 }
 
-wl_init :: proc(
-	window_state: rawptr,
-	screen_width: int,
-	screen_height: int,
-	window_title: string,
-	options: Init_Options,
-	allocator: runtime.Allocator,
-) {
+// Connects to the compositor and collects the globals. None of this needs a surface, so it runs
+// before `open_window`.
+wl_init_process :: proc(window_state: rawptr, allocator: runtime.Allocator) {
 	s = (^WL_State)(window_state)
 	s.allocator = allocator
 	s.scale = 1
@@ -80,7 +81,14 @@ wl_init :: proc(
 
 	// Initializes pointer and keyboard based on seat capabilities.
 	wl.display_roundtrip(s.display)
+}
 
+wl_init :: proc(
+	screen_width: int,
+	screen_height: int,
+	window_title: string,
+	options: Window_Options,
+) {
 	// Sets default size that gets used if the compositor doesn't suggest a size.
 	s.last_configure_width = screen_width
 	s.last_configure_height = screen_height
@@ -696,7 +704,21 @@ fractional_scale_listener := wl.WP_Fractional_Scale_V1_Listener {
 	},
 }
 
+// Destroys the surface and toplevel `wl_init` created. Everything else Wayland-related belongs to
+// the connection, and is torn down in `wl_shutdown_process`.
 wl_shutdown :: proc() {
+	if s.toplevel != nil {
+		wl.xdg_toplevel_destroy(s.toplevel)
+		s.toplevel = nil
+	}
+
+	if s.surface != nil {
+		wl.surface_destroy(s.surface)
+		s.surface = nil
+	}
+}
+
+wl_shutdown_process :: proc() {
 	for it := hm.dynamic_iterator_make(&s.custom_cursors); cd, _ in hm.dynamic_iterate(&it) {
 		wl.wp_viewport_destroy(cd.viewport)
 		wl.surface_destroy(cd.surface)
@@ -828,6 +850,33 @@ wl_set_screen_size :: proc(w, h: int) {
 
 wl_get_window_scale :: proc() -> f32 {
 	return s.scale
+}
+
+// Binding `wl_output` and listening for `geometry`/`mode`/`scale` would be the correct
+// implementation (the bindings exist in `platform_bindings/linux/wayland`), but it needs a new
+// registry global, a listener that accumulates per-output events, and an extra
+// `wl.display_roundtrip` to collect them before the values are usable. That's substantial protocol
+// plumbing on top of the existing registry handler, and it hasn't been done.
+//
+// So this reports zero monitors rather than one monitor of unknown size: a program that asks can
+// tell that Karl2D has nothing to say and fall back to a size of its own, which is what
+// `examples/monitors` does. Claiming one monitor and then reporting it as 0x0 would look like a
+// real answer. Scale can't reuse `wl_get_window_scale`/`s.scale` either, since that is only known
+// once a surface exists and has received a `wp_fractional_scale` event, i.e. after `open_window`.
+wl_get_monitor_count :: proc() -> int {
+	return 0
+}
+
+wl_get_monitor_size :: proc(monitor: int) -> [2]int {
+	return {}
+}
+
+wl_get_monitor_position :: proc(monitor: int) -> [2]int {
+	return {}
+}
+
+wl_get_monitor_scale :: proc(monitor: int) -> f32 {
+	return 0
 }
 
 wl_set_window_mode :: proc(window_mode: Window_Mode) {

--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -4,10 +4,10 @@ package karl2d
 @(private="package")
 LINUX_WINDOW_WAYLAND :: Linux_Window_Interface {
 	state_size = wl_state_size,
-	init_process = wl_init_process,
-	shutdown_process = wl_shutdown_process,
 	init = wl_init,
 	shutdown = wl_shutdown,
+	open_window = wl_open_window,
+	close_window = wl_close_window,
 	get_window_render_glue = wl_get_window_render_glue,
 	get_events = wl_get_events,
 	set_title = wl_set_title,
@@ -60,7 +60,7 @@ wl_state_size :: proc() -> int {
 
 // Connects to the compositor and collects the globals. None of this needs a surface, so it runs
 // before `open_window`.
-wl_init_process :: proc(window_state: rawptr, allocator: runtime.Allocator) {
+wl_init :: proc(window_state: rawptr, allocator: runtime.Allocator) {
 	s = (^WL_State)(window_state)
 	s.allocator = allocator
 	s.scale = 1
@@ -83,7 +83,7 @@ wl_init_process :: proc(window_state: rawptr, allocator: runtime.Allocator) {
 	wl.display_roundtrip(s.display)
 }
 
-wl_init :: proc(
+wl_open_window :: proc(
 	screen_width: int,
 	screen_height: int,
 	window_title: string,
@@ -704,9 +704,9 @@ fractional_scale_listener := wl.WP_Fractional_Scale_V1_Listener {
 	},
 }
 
-// Destroys the surface and toplevel `wl_init` created. Everything else Wayland-related belongs to
-// the connection, and is torn down in `wl_shutdown_process`.
-wl_shutdown :: proc() {
+// Destroys the surface and toplevel `wl_open_window` created. Everything else Wayland-related
+// belongs to the connection, and is torn down in `wl_shutdown`.
+wl_close_window :: proc() {
 	if s.toplevel != nil {
 		wl.xdg_toplevel_destroy(s.toplevel)
 		s.toplevel = nil
@@ -718,7 +718,7 @@ wl_shutdown :: proc() {
 	}
 }
 
-wl_shutdown_process :: proc() {
+wl_shutdown :: proc() {
 	for it := hm.dynamic_iterator_make(&s.custom_cursors); cd, _ in hm.dynamic_iterate(&it) {
 		wl.wp_viewport_destroy(cd.viewport)
 		wl.surface_destroy(cd.surface)
@@ -995,7 +995,7 @@ wl_load_cursor_theme :: proc() {
 // cursor, so every entry point goes through this instead of setting it independently. The pointer
 // re-entering the window does too, since the compositor forgets the cursor when it leaves.
 wl_apply_cursor :: proc() {
-	// The fractional scale listener can fire during wl_init, before the pointer and the cursor
+	// The fractional scale listener can fire during wl_open_window, before the pointer and the cursor
 	// surface exist. Passing a nil surface to the compositor would mean "hide the cursor", and
 	// attaching a buffer to one would dereference a nil proxy inside libwayland.
 	if s.pointer == nil || s.cursor_surface == nil {
@@ -1053,9 +1053,9 @@ wl_apply_cursor :: proc() {
 	image := theme_cursor.images[0]
 	buf := wl.cursor_image_get_buffer(image)
 
-	// The theme image is THEME_CURSOR_SIZE*scale physical pixels but the viewport set up in wl_init
-	// maps it down to THEME_CURSOR_SIZE logical pixels, so the hotspot (in the image's own pixels)
-	// has to be scaled down to match.
+	// The theme image is THEME_CURSOR_SIZE*scale physical pixels but the viewport set up in
+	// wl_open_window maps it down to THEME_CURSOR_SIZE logical pixels, so the hotspot (in the
+	// image's own pixels) has to be scaled down to match.
 	wl.pointer_set_cursor(
 		s.pointer,
 		s.pointer_enter_serial,

--- a/platform_linux_window_x11.odin
+++ b/platform_linux_window_x11.odin
@@ -6,10 +6,10 @@ package karl2d
 @(private="package")
 LINUX_WINDOW_X11 :: Linux_Window_Interface {
 	state_size = x11_state_size,
-	init_process = x11_init_process,
-	shutdown_process = x11_shutdown_process,
 	init = x11_init,
 	shutdown = x11_shutdown,
+	open_window = x11_open_window,
+	close_window = x11_close_window,
 	get_window_render_glue = x11_get_window_render_glue,
 	get_events = x11_get_events,
 	set_title = x11_set_title,
@@ -62,7 +62,7 @@ x11_state_size :: proc() -> int {
 
 // Opens the connection to the X server. Runs before any window exists so the monitor queries have
 // a display to ask.
-x11_init_process :: proc(window_state: rawptr, allocator: runtime.Allocator) {
+x11_init :: proc(window_state: rawptr, allocator: runtime.Allocator) {
 	s = (^X11_State)(window_state)
 	s.allocator = allocator
 	s.display = X.OpenDisplay(nil)
@@ -70,7 +70,7 @@ x11_init_process :: proc(window_state: rawptr, allocator: runtime.Allocator) {
 	hm.dynamic_init(&s.custom_cursors, allocator)
 }
 
-x11_shutdown_process :: proc() {
+x11_shutdown :: proc() {
 	delete(s.events)
 	hm.dynamic_destroy(&s.custom_cursors)
 
@@ -80,7 +80,7 @@ x11_shutdown_process :: proc() {
 	}
 }
 
-x11_init :: proc(
+x11_open_window :: proc(
 	screen_width: int,
 	screen_height: int,
 	window_title: string,
@@ -173,7 +173,7 @@ x11_init :: proc(
 	}
 }
 
-x11_shutdown :: proc() {
+x11_close_window :: proc() {
 	if s.xic != nil {
 		XDestroyIC(s.xic)
 	}
@@ -463,7 +463,7 @@ x11_get_window_scale :: proc() -> f32 {
 // setup that means one oversized monitor spanning them all. Proper per-monitor enumeration needs
 // XRandR bindings, which aren't written.
 //
-// `s.display` is opened by `x11_init_process`, so these work before `open_window` is called.
+// `s.display` is opened by `x11_init`, so these work before `open_window` is called.
 x11_get_monitor_count :: proc() -> int {
 	return 1
 }

--- a/platform_linux_window_x11.odin
+++ b/platform_linux_window_x11.odin
@@ -6,6 +6,8 @@ package karl2d
 @(private="package")
 LINUX_WINDOW_X11 :: Linux_Window_Interface {
 	state_size = x11_state_size,
+	init_process = x11_init_process,
+	shutdown_process = x11_shutdown_process,
 	init = x11_init,
 	shutdown = x11_shutdown,
 	get_window_render_glue = x11_get_window_render_glue,
@@ -18,6 +20,10 @@ LINUX_WINDOW_X11 :: Linux_Window_Interface {
 	set_screen_size = x11_set_screen_size,
 	get_window_scale = x11_get_window_scale,
 	set_window_mode = x11_set_window_mode,
+	get_monitor_count = x11_get_monitor_count,
+	get_monitor_size = x11_get_monitor_size,
+	get_monitor_position = x11_get_monitor_position,
+	get_monitor_scale = x11_get_monitor_scale,
 	set_cursor_hidden = x11_set_cursor_hidden,
 	is_cursor_hidden = x11_is_cursor_hidden,
 	set_mouse_locked = x11_set_mouse_locked,
@@ -54,21 +60,34 @@ x11_state_size :: proc() -> int {
 	return size_of(X11_State)
 }
 
-x11_init :: proc(
-	window_state: rawptr,
-	screen_width: int,
-	screen_height: int,
-	window_title: string,
-	init_options: Init_Options,
-	allocator: runtime.Allocator,
-) {
+// Opens the connection to the X server. Runs before any window exists so the monitor queries have
+// a display to ask.
+x11_init_process :: proc(window_state: rawptr, allocator: runtime.Allocator) {
 	s = (^X11_State)(window_state)
 	s.allocator = allocator
-	s.screen_width = screen_width
-	s.screen_height = screen_height
 	s.display = X.OpenDisplay(nil)
 	s.events = make([dynamic]Event, allocator)
 	hm.dynamic_init(&s.custom_cursors, allocator)
+}
+
+x11_shutdown_process :: proc() {
+	delete(s.events)
+	hm.dynamic_destroy(&s.custom_cursors)
+
+	if s.display != nil {
+		X.CloseDisplay(s.display)
+		s.display = nil
+	}
+}
+
+x11_init :: proc(
+	screen_width: int,
+	screen_height: int,
+	window_title: string,
+	init_options: Window_Options,
+) {
+	s.screen_width = screen_width
+	s.screen_height = screen_height
 
 	s.window = X.CreateSimpleWindow(
 		s.display,
@@ -155,8 +174,6 @@ x11_init :: proc(
 }
 
 x11_shutdown :: proc() {
-	delete(s.events)
-
 	if s.xic != nil {
 		XDestroyIC(s.xic)
 	}
@@ -174,10 +191,10 @@ x11_shutdown :: proc() {
 	for it := hm.dynamic_iterator_make(&s.custom_cursors); cd, _ in hm.dynamic_iterate(&it) {
 		X.FreeCursor(s.display, cd.cursor)
 	}
-	hm.dynamic_destroy(&s.custom_cursors)
 
 	X.FreeCursor(s.display, s.blank_cursor)
 	X.DestroyWindow(s.display, s.window)
+	s.window = 0
 }
 
 x11_get_window_render_glue :: proc() -> Window_Render_Glue {
@@ -439,6 +456,33 @@ x11_set_screen_size :: proc(w, h: int) {
 
 x11_get_window_scale :: proc() -> f32 {
 	return 1
+}
+
+// There are no XRandR or Xinerama bindings in `platform_bindings/linux/` yet, so this reports the
+// whole X screen as a single monitor rather than the actual physical monitors. On a multi-monitor
+// setup that means one oversized monitor spanning them all. Proper per-monitor enumeration needs
+// XRandR bindings, which aren't written.
+//
+// `s.display` is opened by `x11_init_process`, so these work before `open_window` is called.
+x11_get_monitor_count :: proc() -> int {
+	return 1
+}
+
+x11_get_monitor_size :: proc(monitor: int) -> [2]int {
+	if s.display == nil {
+		return {}
+	}
+
+	screen := X.DefaultScreen(s.display)
+	return { int(X.DisplayWidth(s.display, screen)), int(X.DisplayHeight(s.display, screen)) }
+}
+
+x11_get_monitor_position :: proc(monitor: int) -> [2]int {
+	return {}
+}
+
+x11_get_monitor_scale :: proc(monitor: int) -> f32 {
+	return x11_get_window_scale()
 }
 
 enter_borderless_fullscreen :: proc() {

--- a/platform_mac.odin
+++ b/platform_mac.odin
@@ -19,6 +19,8 @@ import "log"
 @(private="package")
 PLATFORM_MAC :: Platform_Interface {
 	state_size = mac_state_size,
+	init_process = mac_init_process,
+	shutdown_process = mac_shutdown_process,
 	init = mac_init,
 	shutdown = mac_shutdown,
 	get_window_render_glue = mac_get_window_render_glue,
@@ -31,6 +33,11 @@ PLATFORM_MAC :: Platform_Interface {
 	get_window_position = mac_get_window_position,
 	get_window_scale = mac_get_window_scale,
 	set_window_mode = mac_set_window_mode,
+
+	get_monitor_count = mac_get_monitor_count,
+	get_monitor_size = mac_get_monitor_size,
+	get_monitor_position = mac_get_monitor_position,
+	get_monitor_scale = mac_get_monitor_scale,
 
 	set_cursor_hidden = mac_set_cursor_hidden,
 	is_cursor_hidden = mac_is_cursor_hidden,
@@ -125,14 +132,10 @@ mac_state_size :: proc() -> int {
 	return size_of(Mac_State)
 }
 
-mac_init :: proc(
-	platform_state: rawptr,
-	screen_width: int,
-	screen_height: int,
-	window_title: string,
-	init_options: Init_Options,
-	allocator: runtime.Allocator,
-) {
+// Creates the NSApplication and its menu bar. This has to happen before anything asks AppKit about
+// screens, which is why it runs from `init_platform` rather than from `mac_init`: `NSScreen` is
+// only dependable once the shared application exists.
+mac_init_process :: proc(platform_state: rawptr, allocator: runtime.Allocator) {
 	assert(platform_state != nil)
 	s = (^Mac_State)(platform_state)
 	s.odin_ctx = context
@@ -155,6 +158,25 @@ mac_init :: proc(
 	app_menu->addItemWithTitle(NS.AT("Quit"), NS.sel_registerName(cstring("terminate:")), NS.AT("q"))
 	app_menu_item->setSubmenu(app_menu)
 	s.app->setAppleMenu(app_menu)
+}
+
+mac_shutdown_process :: proc() {
+	for it := hm.dynamic_iterator_make(&s.custom_cursors); cd, _ in hm.dynamic_iterate(&it) {
+		cd.cursor->release()
+		delete(cd.pixels, s.allocator)
+	}
+
+	hm.dynamic_destroy(&s.custom_cursors)
+	delete(s.events)
+}
+
+mac_init :: proc(
+	screen_width: int,
+	screen_height: int,
+	window_title: string,
+	init_options: Window_Options,
+) {
+	NS.scoped_autoreleasepool()
 
 	// Create the window
 	rect := NS.Rect {
@@ -308,16 +330,11 @@ mac_init :: proc(
 }
 
 mac_shutdown :: proc() {
-	for it := hm.dynamic_iterator_make(&s.custom_cursors); cd, _ in hm.dynamic_iterate(&it) {
-		cd.cursor->release()
-		delete(cd.pixels, s.allocator)
-	}
-	hm.dynamic_destroy(&s.custom_cursors)
-
 	if s.window != nil {
 		s.window->close()
+		s.window = nil
 	}
-	delete(s.events)
+
 	a := s.allocator
 	free(s.gc_connect_blk, a)
 	free(s.gc_disconnect_blk, a)
@@ -796,6 +813,59 @@ mac_set_window_mode :: proc(window_mode: Window_Mode) {
 		s.screen_width  = int(f32(content_rect.width) * scale)
 		s.screen_height = int(f32(content_rect.height) * scale)
 	}
+}
+
+// Returns the `NS.Screen` for `monitor`, or `nil` if it is out of range. `karl2d.odin` already
+// validates `monitor` against `get_monitor_count`, but this stays defensive since it's also used
+// internally.
+mac_get_screen :: proc(monitor: int) -> ^NS.Screen {
+	screens := NS.Screen_screens()
+
+	if monitor < 0 || NS.UInteger(monitor) >= screens->count() {
+		return nil
+	}
+
+	return NS.Array_objectAs(screens, NS.UInteger(monitor), ^NS.Screen)
+}
+
+mac_get_monitor_count :: proc() -> int {
+	return int(NS.Screen_screens()->count())
+}
+
+mac_get_monitor_size :: proc(monitor: int) -> [2]int {
+	screen := mac_get_screen(monitor)
+
+	if screen == nil {
+		return {}
+	}
+
+	scale := f32(screen->backingScaleFactor())
+	frame := screen->frame()
+	return { int(f32(frame.size.width) * scale), int(f32(frame.size.height) * scale) }
+}
+
+mac_get_monitor_position :: proc(monitor: int) -> [2]int {
+	screen := mac_get_screen(monitor)
+
+	if screen == nil {
+		return {}
+	}
+
+	// Scaled by `backingScaleFactor` so this is in physical pixels, the same unit
+	// `mac_get_monitor_size` reports in and the one `get_monitor_position` documents.
+	scale := f32(screen->backingScaleFactor())
+	origin := screen->frame().origin
+	return { int(f32(origin.x) * scale), int(f32(origin.y) * scale) }
+}
+
+mac_get_monitor_scale :: proc(monitor: int) -> f32 {
+	screen := mac_get_screen(monitor)
+
+	if screen == nil {
+		return 0
+	}
+
+	return f32(screen->backingScaleFactor())
 }
 
 mac_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> (Custom_Cursor, bool) {

--- a/platform_mac.odin
+++ b/platform_mac.odin
@@ -19,10 +19,10 @@ import "log"
 @(private="package")
 PLATFORM_MAC :: Platform_Interface {
 	state_size = mac_state_size,
-	init_process = mac_init_process,
-	shutdown_process = mac_shutdown_process,
 	init = mac_init,
 	shutdown = mac_shutdown,
+	open_window = mac_open_window,
+	close_window = mac_close_window,
 	get_window_render_glue = mac_get_window_render_glue,
 	get_events = mac_get_events,
 	set_window_title = mac_set_window_title,
@@ -133,9 +133,9 @@ mac_state_size :: proc() -> int {
 }
 
 // Creates the NSApplication and its menu bar. This has to happen before anything asks AppKit about
-// screens, which is why it runs from `init_platform` rather than from `mac_init`: `NSScreen` is
-// only dependable once the shared application exists.
-mac_init_process :: proc(platform_state: rawptr, allocator: runtime.Allocator) {
+// screens, which is why it runs from `init_platform` rather than from `mac_open_window`:
+// `NSScreen` is only dependable once the shared application exists.
+mac_init :: proc(platform_state: rawptr, allocator: runtime.Allocator) {
 	assert(platform_state != nil)
 	s = (^Mac_State)(platform_state)
 	s.odin_ctx = context
@@ -160,7 +160,7 @@ mac_init_process :: proc(platform_state: rawptr, allocator: runtime.Allocator) {
 	s.app->setAppleMenu(app_menu)
 }
 
-mac_shutdown_process :: proc() {
+mac_shutdown :: proc() {
 	for it := hm.dynamic_iterator_make(&s.custom_cursors); cd, _ in hm.dynamic_iterate(&it) {
 		cd.cursor->release()
 		delete(cd.pixels, s.allocator)
@@ -170,7 +170,7 @@ mac_shutdown_process :: proc() {
 	delete(s.events)
 }
 
-mac_init :: proc(
+mac_open_window :: proc(
 	screen_width: int,
 	screen_height: int,
 	window_title: string,
@@ -268,7 +268,7 @@ mac_init :: proc(
 
 				// Returning true closes the window, which also releases it. It's up to the
 				// application to decide what a close request means, it may want to show a
-				// confirmation dialogue. The window is closed in `mac_shutdown`.
+				// confirmation dialogue. The window is closed in `mac_close_window`.
 				return false
 			},
 
@@ -329,7 +329,7 @@ mac_init :: proc(
 	}
 }
 
-mac_shutdown :: proc() {
+mac_close_window :: proc() {
 	if s.window != nil {
 		s.window->close()
 		s.window = nil

--- a/platform_mac_glue_gl.odin
+++ b/platform_mac_glue_gl.odin
@@ -24,7 +24,10 @@ make_mac_gl_glue :: proc(
 		state = (^Window_Render_Glue_State)(state),
 
 		// these casts just make the proc take a Mac_GL_Glue_State instead of a Window_Render_Glue_State
-		make_context = cast(proc(state: ^Window_Render_Glue_State, options: Init_Options) -> bool)(mac_gl_glue_make_context),
+		make_context = cast(proc(
+			state: ^Window_Render_Glue_State,
+			options: Rendering_Options,
+		) -> bool)(mac_gl_glue_make_context),
 		present = cast(proc(state: ^Window_Render_Glue_State))(mac_gl_glue_present),
 		destroy = cast(proc(state: ^Window_Render_Glue_State))(mac_gl_glue_destroy),
 		viewport_resized = cast(proc(state: ^Window_Render_Glue_State))(mac_gl_glue_viewport_resized),
@@ -36,7 +39,7 @@ Mac_GL_Glue_State :: struct {
 	gl_ctx: ^nsgl.OpenGLContext,
 }
 
-mac_gl_glue_make_context :: proc(s: ^Mac_GL_Glue_State, options: Init_Options) -> bool {
+mac_gl_glue_make_context :: proc(s: ^Mac_GL_Glue_State, options: Rendering_Options) -> bool {
 	// Create pixel format attributes (null-terminated array)
 	attrs := slice.to_dynamic(
 		[]u32 {

--- a/platform_web.odin
+++ b/platform_web.odin
@@ -8,6 +8,8 @@ package karl2d
 @(private="package")
 PLATFORM_WEB :: Platform_Interface {
 	state_size = web_state_size,
+	init_process = web_init_process,
+	shutdown_process = web_shutdown_process,
 	init = web_init,
 	shutdown = web_shutdown,
 	get_window_render_glue = web_get_window_render_glue,
@@ -20,6 +22,11 @@ PLATFORM_WEB :: Platform_Interface {
 	get_window_position = web_get_position,
 	get_window_scale = web_get_window_scale,
 	set_window_mode = web_set_window_mode,
+
+	get_monitor_count = web_get_monitor_count,
+	get_monitor_size = web_get_monitor_size,
+	get_monitor_position = web_get_monitor_position,
+	get_monitor_scale = web_get_monitor_scale,
 
 	set_cursor_hidden = web_set_cursor_hidden,
 	is_cursor_hidden = web_is_cursor_hidden,
@@ -50,21 +57,35 @@ web_state_size :: proc() -> int {
 	return size_of(Web_State)
 }
 
-web_init :: proc(
-	window_state: rawptr,
-	window_width: int,
-	window_height: int,
-	window_title: string,
-	init_options: Init_Options,
-	allocator: runtime.Allocator,
-) {
+// The browser has nothing to set up at the process level, but the canvas id has to be known before
+// the monitor queries run, and they run before `open_window`.
+web_init_process :: proc(window_state: rawptr, allocator: runtime.Allocator) {
 	s = (^Web_State)(window_state)
 	s.allocator = allocator
 	s.events = make([dynamic]Event, allocator)
 	s.key_from_js_event_key_code = make(map[string]Keyboard_Key, allocator)
 	s.canvas_id = "webgl-canvas"
 	hm.dynamic_init(&s.custom_cursors, allocator)
+}
 
+web_shutdown_process :: proc() {
+	for it := hm.dynamic_iterator_make(&s.custom_cursors); cd, _ in hm.dynamic_iterate(&it) {
+		delete(cd.data_uri, s.allocator)
+		delete(cd.style_value, s.allocator)
+		delete(cd.style_value_scaled, s.allocator)
+	}
+
+	hm.dynamic_destroy(&s.custom_cursors)
+	delete(s.events)
+	delete(s.key_from_js_event_key_code)
+}
+
+web_init :: proc(
+	window_width: int,
+	window_height: int,
+	window_title: string,
+	init_options: Window_Options,
+) {
 	js.set_document_title(window_title)
 	s.prev_scale = f32(js.device_pixel_ratio())
 	// The browser window probably has some other size than what was sent in.
@@ -320,15 +341,6 @@ web_set_screen_size_to_window_size :: proc(canvas_id: HTML_Canvas_ID) {
 }
 
 web_shutdown :: proc() {
-	for it := hm.dynamic_iterator_make(&s.custom_cursors); cd, _ in hm.dynamic_iterate(&it) {
-		delete(cd.data_uri, s.allocator)
-		delete(cd.style_value, s.allocator)
-		delete(cd.style_value_scaled, s.allocator)
-	}
-	hm.dynamic_destroy(&s.custom_cursors)
-
-	delete(s.events)
-	delete(s.key_from_js_event_key_code)
 }
 
 web_get_window_render_glue :: proc() -> Window_Render_Glue {
@@ -467,6 +479,36 @@ web_set_window_mode :: proc(new_mode: Window_Mode) {
 	} else if new_mode == .Windowed && old_mode == .Windowed_Resizable {
 		web_set_screen_size(s.width, s.height)
 	}
+}
+
+// The web platform has no notion of multiple monitors, only the one screen the page runs on.
+web_get_monitor_count :: proc() -> int {
+	return 1
+}
+
+// `window.screen.width`/`window.screen.height` aren't exposed by the `core:sys/wasm/js` bindings,
+// so stash them onto an element and read them back, the same trick
+// `_web_event_pointer_lock_change` uses. The canvas is what that gets stashed on: Karl2D cannot run
+// without it, so it is the one element guaranteed to be there, whereas a page that was not built
+// from `index_template.html` may well have dropped the `id="body"` off its body tag.
+web_get_monitor_size :: proc(monitor: int) -> [2]int {
+	js.evaluate(
+		"document.getElementById('webgl-canvas')._k2_screen_width = window.screen.width; " +
+		"document.getElementById('webgl-canvas')._k2_screen_height = window.screen.height",
+	)
+
+	scale := f64(web_get_window_scale())
+	width := js.get_element_key_f64(s.canvas_id, "_k2_screen_width") * scale
+	height := js.get_element_key_f64(s.canvas_id, "_k2_screen_height") * scale
+	return { int(width), int(height) }
+}
+
+web_get_monitor_position :: proc(monitor: int) -> [2]int {
+	return {}
+}
+
+web_get_monitor_scale :: proc(monitor: int) -> f32 {
+	return web_get_window_scale()
 }
 
 web_set_cursor_hidden :: proc(hidden: bool) {

--- a/platform_web.odin
+++ b/platform_web.odin
@@ -8,10 +8,10 @@ package karl2d
 @(private="package")
 PLATFORM_WEB :: Platform_Interface {
 	state_size = web_state_size,
-	init_process = web_init_process,
-	shutdown_process = web_shutdown_process,
 	init = web_init,
 	shutdown = web_shutdown,
+	open_window = web_open_window,
+	close_window = web_close_window,
 	get_window_render_glue = web_get_window_render_glue,
 	get_events = web_get_events,
 	set_window_title = web_set_window_title,
@@ -59,7 +59,7 @@ web_state_size :: proc() -> int {
 
 // The browser has nothing to set up at the process level, but the canvas id has to be known before
 // the monitor queries run, and they run before `open_window`.
-web_init_process :: proc(window_state: rawptr, allocator: runtime.Allocator) {
+web_init :: proc(window_state: rawptr, allocator: runtime.Allocator) {
 	s = (^Web_State)(window_state)
 	s.allocator = allocator
 	s.events = make([dynamic]Event, allocator)
@@ -68,7 +68,7 @@ web_init_process :: proc(window_state: rawptr, allocator: runtime.Allocator) {
 	hm.dynamic_init(&s.custom_cursors, allocator)
 }
 
-web_shutdown_process :: proc() {
+web_shutdown :: proc() {
 	for it := hm.dynamic_iterator_make(&s.custom_cursors); cd, _ in hm.dynamic_iterate(&it) {
 		delete(cd.data_uri, s.allocator)
 		delete(cd.style_value, s.allocator)
@@ -80,7 +80,7 @@ web_shutdown_process :: proc() {
 	delete(s.key_from_js_event_key_code)
 }
 
-web_init :: proc(
+web_open_window :: proc(
 	window_width: int,
 	window_height: int,
 	window_title: string,
@@ -340,7 +340,7 @@ web_set_screen_size_to_window_size :: proc(canvas_id: HTML_Canvas_ID) {
 	})
 }
 
-web_shutdown :: proc() {
+web_close_window :: proc() {
 }
 
 web_get_window_render_glue :: proc() -> Window_Render_Glue {

--- a/platform_windows.odin
+++ b/platform_windows.odin
@@ -7,10 +7,10 @@ package karl2d
 @(private="package")
 PLATFORM_WINDOWS :: Platform_Interface {
 	state_size = windows_state_size,
-	init_process = windows_init_process,
-	shutdown_process = windows_shutdown_process,
 	init = windows_init,
 	shutdown = windows_shutdown,
+	open_window = windows_open_window,
+	close_window = windows_close_window,
 	get_window_render_glue = windows_get_window_render_glue,
 	get_events = windows_get_events,
 	set_window_title = windows_set_window_title,
@@ -57,7 +57,7 @@ windows_state_size :: proc() -> int {
 
 CLASS_NAME :: "karl2d"
 
-windows_init_process :: proc(platform_state: rawptr, allocator: runtime.Allocator) {
+windows_init :: proc(platform_state: rawptr, allocator: runtime.Allocator) {
 	assert(platform_state != nil)
 	s = (^Windows_State)(platform_state)
 	s.allocator = allocator
@@ -68,8 +68,8 @@ windows_init_process :: proc(platform_state: rawptr, allocator: runtime.Allocato
 	// This has to run before anything asks Windows about monitors or window sizes. Until it does,
 	// the process is DPI unaware and Windows hands back virtualized coordinates: on a 3840x2160
 	// display at 150% scaling, `GetMonitorInfoW` reports 2560x1440 and `GetDpiForMonitor` reports
-	// 96. That is why it lives here and not in `windows_init`, which only runs once a window is
-	// being opened.
+	// 96. That is why it lives here and not in `windows_open_window`, which only runs once a
+	// window is being opened.
 	win32.SetProcessDpiAwarenessContext(win32.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)
 	win32.SetProcessDPIAware()
 
@@ -91,7 +91,7 @@ windows_init_process :: proc(platform_state: rawptr, allocator: runtime.Allocato
 	windows_refresh_monitors()
 }
 
-windows_shutdown_process :: proc() {
+windows_shutdown :: proc() {
 	for it := hm.dynamic_iterator_make(&s.custom_cursors); cd, _ in hm.dynamic_iterate(&it) {
 		win32.DestroyCursor(cd.hcursor)
 	}
@@ -100,7 +100,7 @@ windows_shutdown_process :: proc() {
 	delete(s.events)
 }
 
-windows_init :: proc(
+windows_open_window :: proc(
 	screen_width: int,
 	screen_height: int,
 	window_title: string,
@@ -160,7 +160,7 @@ windows_init :: proc(
 	}
 }
 
-windows_shutdown :: proc() {
+windows_close_window :: proc() {
 	win32.DestroyWindow(s.hwnd)
 	s.hwnd = nil
 }
@@ -497,7 +497,7 @@ Windows_State :: struct {
 	// Multilingual Plane (BMP). Emojis are examples of such characters.
 	char_high_surrogate: rune,
 
-	// Filled in by `windows_refresh_monitors`, which runs during `windows_init_process` and again
+	// Filled in by `windows_refresh_monitors`, which runs during `windows_init` and again
 	// whenever WM_DISPLAYCHANGE says the display setup changed.
 	monitors: Windows_Monitor_List,
 }
@@ -574,7 +574,7 @@ Windows_Monitor_List :: struct {
 }
 
 // Enumerates connected monitors into `s.monitors`, primary first. Called by
-// `windows_init_process`, so the monitor queries work before a window exists, and again on
+// `windows_init`, so the monitor queries work before a window exists, and again on
 // WM_DISPLAYCHANGE so the list doesn't go stale when a display is plugged in or unplugged.
 //
 // The process must already be DPI aware when this runs, otherwise the rects come back virtualized.
@@ -859,7 +859,7 @@ _windows_window_proc :: proc "stdcall" (hwnd: win32.HWND, msg: win32.UINT, wpara
 
 		// The default handler destroys the window. We don't want that: it's up to the application
 		// to decide what a close request means, it may want to show a confirmation dialogue. The
-		// window is destroyed in `windows_shutdown`.
+		// window is destroyed in `windows_close_window`.
 		return 0
 
 	case win32.WM_SYSKEYDOWN, win32.WM_KEYDOWN:

--- a/platform_windows.odin
+++ b/platform_windows.odin
@@ -7,6 +7,8 @@ package karl2d
 @(private="package")
 PLATFORM_WINDOWS :: Platform_Interface {
 	state_size = windows_state_size,
+	init_process = windows_init_process,
+	shutdown_process = windows_shutdown_process,
 	init = windows_init,
 	shutdown = windows_shutdown,
 	get_window_render_glue = windows_get_window_render_glue,
@@ -19,6 +21,11 @@ PLATFORM_WINDOWS :: Platform_Interface {
 	set_screen_size = windows_set_screen_size,
 	get_window_scale = windows_get_window_scale,
 	set_window_mode = windows_set_window_mode,
+
+	get_monitor_count = windows_get_monitor_count,
+	get_monitor_size = windows_get_monitor_size,
+	get_monitor_position = windows_get_monitor_position,
+	get_monitor_scale = windows_get_monitor_scale,
 
 	set_cursor_hidden = windows_set_cursor_hidden,
 	is_cursor_hidden = windows_is_cursor_hidden,
@@ -48,14 +55,9 @@ windows_state_size :: proc() -> int {
 	return size_of(Windows_State)
 }
 
-windows_init :: proc(
-	platform_state: rawptr,
-	screen_width: int,
-	screen_height: int,
-	window_title: string,
-	options: Init_Options,
-	allocator: runtime.Allocator,
-) {
+CLASS_NAME :: "karl2d"
+
+windows_init_process :: proc(platform_state: rawptr, allocator: runtime.Allocator) {
 	assert(platform_state != nil)
 	s = (^Windows_State)(platform_state)
 	s.allocator = allocator
@@ -63,9 +65,14 @@ windows_init :: proc(
 	s.custom_context = context
 	hm.dynamic_init(&s.custom_cursors, allocator)
 
+	// This has to run before anything asks Windows about monitors or window sizes. Until it does,
+	// the process is DPI unaware and Windows hands back virtualized coordinates: on a 3840x2160
+	// display at 150% scaling, `GetMonitorInfoW` reports 2560x1440 and `GetDpiForMonitor` reports
+	// 96. That is why it lives here and not in `windows_init`, which only runs once a window is
+	// being opened.
 	win32.SetProcessDpiAwarenessContext(win32.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)
 	win32.SetProcessDPIAware()
-	CLASS_NAME :: "karl2d"
+
 	instance := win32.HINSTANCE(win32.GetModuleHandleW(nil))
 
 	cls := win32.WNDCLASSW {
@@ -77,6 +84,29 @@ windows_init :: proc(
 	}
 
 	win32.RegisterClassW(&cls)
+
+	win32.XInputEnable(true)
+
+	// The process is DPI aware now, so this reports real pixels. Refreshed on WM_DISPLAYCHANGE.
+	windows_refresh_monitors()
+}
+
+windows_shutdown_process :: proc() {
+	for it := hm.dynamic_iterator_make(&s.custom_cursors); cd, _ in hm.dynamic_iterate(&it) {
+		win32.DestroyCursor(cd.hcursor)
+	}
+
+	hm.dynamic_destroy(&s.custom_cursors)
+	delete(s.events)
+}
+
+windows_init :: proc(
+	screen_width: int,
+	screen_height: int,
+	window_title: string,
+	options: Window_Options,
+) {
+	instance := win32.HINSTANCE(win32.GetModuleHandleW(nil))
 
 	dpix, dpiy: win32.UINT
 	win32.GetDpiForMonitor(win32.MonitorFromWindow(nil, .MONITOR_DEFAULTTOPRIMARY), {}, &dpix, &dpiy)
@@ -116,8 +146,6 @@ windows_init :: proc(
 	assert(s.hwnd != nil, "Failed creating window")
 
 	windows_set_window_mode(options.window_mode)
-	
-	win32.XInputEnable(true)
 
 	when RENDER_BACKEND_NAME == "d3d11" {
 		s.window_render_glue = {
@@ -133,13 +161,8 @@ windows_init :: proc(
 }
 
 windows_shutdown :: proc() {
-	for it := hm.dynamic_iterator_make(&s.custom_cursors); cd, _ in hm.dynamic_iterate(&it) {
-		win32.DestroyCursor(cd.hcursor)
-	}
-	hm.dynamic_destroy(&s.custom_cursors)
-
 	win32.DestroyWindow(s.hwnd)
-	delete(s.events)
+	s.hwnd = nil
 }
 
 windows_get_window_render_glue :: proc() -> Window_Render_Glue {
@@ -473,6 +496,10 @@ Windows_State :: struct {
 	// Half of UTF-16 characters when it is a character when the character is outside the Basic
 	// Multilingual Plane (BMP). Emojis are examples of such characters.
 	char_high_surrogate: rune,
+
+	// Filled in by `windows_refresh_monitors`, which runs during `windows_init_process` and again
+	// whenever WM_DISPLAYCHANGE says the display setup changed.
+	monitors: Windows_Monitor_List,
 }
 
 Windows_Cursor :: struct {
@@ -528,6 +555,90 @@ windows_set_window_mode :: proc(window_mode: Window_Mode) {
 			win32.SWP_NOOWNERZORDER | win32.SWP_FRAMECHANGED)
 		}
 	}
+}
+
+WINDOWS_MAX_MONITORS :: 16
+
+// `MONITORINFO.dwFlags` isn't bound as a named constant anywhere in `core:sys/windows`.
+MONITORINFOF_PRIMARY :: 0x00000001
+
+Windows_Monitor :: struct {
+	hmonitor: win32.HMONITOR,
+	rect: win32.RECT,
+	primary: bool,
+}
+
+Windows_Monitor_List :: struct {
+	monitors: [WINDOWS_MAX_MONITORS]Windows_Monitor,
+	count: int,
+}
+
+// Enumerates connected monitors into `s.monitors`, primary first. Called by
+// `windows_init_process`, so the monitor queries work before a window exists, and again on
+// WM_DISPLAYCHANGE so the list doesn't go stale when a display is plugged in or unplugged.
+//
+// The process must already be DPI aware when this runs, otherwise the rects come back virtualized.
+windows_refresh_monitors :: proc() {
+	list: Windows_Monitor_List
+
+	enum_proc :: proc "system" (
+		hmonitor: win32.HMONITOR,
+		hdc: win32.HDC,
+		rect: win32.LPRECT,
+		lparam: win32.LPARAM,
+	) -> win32.BOOL {
+		context = runtime.default_context()
+		list := (^Windows_Monitor_List)(rawptr(uintptr(lparam)))
+
+		if list.count >= WINDOWS_MAX_MONITORS {
+			return true
+		}
+
+		info := win32.MONITORINFO { cbSize = size_of(win32.MONITORINFO) }
+
+		if win32.GetMonitorInfoW(hmonitor, &info) {
+			list.monitors[list.count] = Windows_Monitor {
+				hmonitor = hmonitor,
+				rect = info.rcMonitor,
+				primary = (info.dwFlags & MONITORINFOF_PRIMARY) != 0,
+			}
+			list.count += 1
+		}
+
+		return true
+	}
+
+	win32.EnumDisplayMonitors(nil, nil, enum_proc, win32.LPARAM(uintptr(rawptr(&list))))
+
+	// The primary monitor must be at index 0.
+	for i in 0..<list.count {
+		if list.monitors[i].primary && i != 0 {
+			list.monitors[0], list.monitors[i] = list.monitors[i], list.monitors[0]
+			break
+		}
+	}
+
+	s.monitors = list
+}
+
+windows_get_monitor_count :: proc() -> int {
+	return s.monitors.count
+}
+
+windows_get_monitor_size :: proc(monitor: int) -> [2]int {
+	r := s.monitors.monitors[monitor].rect
+	return { int(r.right - r.left), int(r.bottom - r.top) }
+}
+
+windows_get_monitor_position :: proc(monitor: int) -> [2]int {
+	r := s.monitors.monitors[monitor].rect
+	return { int(r.left), int(r.top) }
+}
+
+windows_get_monitor_scale :: proc(monitor: int) -> f32 {
+	dpix, dpiy: win32.UINT
+	win32.GetDpiForMonitor(s.monitors.monitors[monitor].hmonitor, {}, &dpix, &dpiy)
+	return f32(dpix) / 96.0
 }
 
 windows_set_cursor_hidden :: proc(hidden: bool) {
@@ -737,6 +848,11 @@ _windows_window_proc :: proc "stdcall" (hwnd: win32.HWND, msg: win32.UINT, wpara
 	switch msg {
 	case win32.WM_DESTROY:
 		win32.PostQuitMessage(0)
+
+	case win32.WM_DISPLAYCHANGE:
+		// A display was plugged in, unplugged or had its resolution changed, so the cached monitor
+		// list is out of date.
+		windows_refresh_monitors()
 
 	case win32.WM_CLOSE:
 		append(&s.events, Event_Close_Window_Requested{})

--- a/platform_windows_glue_gl.odin
+++ b/platform_windows_glue_gl.odin
@@ -23,7 +23,10 @@ make_windows_gl_glue :: proc(
 		state = (^Window_Render_Glue_State)(state),
 
 		// these casts just make the proc take a Windows_GL_Glue_State instead of a Window_Render_Glue_State
-		make_context = cast(proc(state: ^Window_Render_Glue_State, init_options: Init_Options) -> bool)(windows_gl_glue_make_context),
+		make_context = cast(proc(
+			state: ^Window_Render_Glue_State,
+			init_options: Rendering_Options,
+		) -> bool)(windows_gl_glue_make_context),
 		present = cast(proc(state: ^Window_Render_Glue_State))(windows_gl_glue_present),
 		destroy = cast(proc(state: ^Window_Render_Glue_State))(windows_gl_glue_destroy),
 		viewport_resized = cast(proc(state: ^Window_Render_Glue_State))(windows_gl_glue_viewport_resized),
@@ -37,7 +40,10 @@ Windows_GL_Glue_State :: struct {
 	allocator: runtime.Allocator,
 }
 
-windows_gl_glue_make_context :: proc(s: ^Windows_GL_Glue_State, options: Init_Options) -> bool {
+windows_gl_glue_make_context :: proc(
+	s: ^Windows_GL_Glue_State,
+	options: Rendering_Options,
+) -> bool {
 	// We make an invisible dummy window and use that to get a dummy context. We need the dummy
 	// context because we can't get the actual context we need without already having a context.
 	DUMMY_CLASS :: "karl2d_wgl_dummy"

--- a/render_backend_d3d11.odin
+++ b/render_backend_d3d11.odin
@@ -50,7 +50,7 @@ d3d11_init :: proc(
 	glue: Window_Render_Glue,
 	swapchain_width: int,
 	swapchain_height: int,
-	options: Init_Options,
+	options: Rendering_Options,
 	allocator := context.allocator,
 ) {
 	s = (^D3D11_State)(state)

--- a/render_backend_gl.odin
+++ b/render_backend_gl.odin
@@ -126,7 +126,7 @@ gl_init :: proc(
 	glue: Window_Render_Glue,
 	swapchain_width: int,
 	swapchain_height: int,
-	options: Init_Options,
+	options: Rendering_Options,
 	allocator := context.allocator
 ) {
 	s = (^GL_State)(state)

--- a/render_backend_interface.odin
+++ b/render_backend_interface.odin
@@ -74,7 +74,7 @@ Render_Backend_Interface :: struct #all_or_none {
 		glue: Window_Render_Glue,
 		swapchain_width: int,
 		swapchain_height: int,
-		options: Init_Options,
+		options: Rendering_Options,
 		allocator: runtime.Allocator,
 	),
 

--- a/render_backend_nil.odin
+++ b/render_backend_nil.odin
@@ -56,8 +56,8 @@ rbnil_init :: proc(
 	state: rawptr,
 	glue: Window_Render_Glue,
 	swapchain_width,
-	swapchain_height: int, 
-	options: Init_Options,
+	swapchain_height: int,
+	options: Rendering_Options,
 	allocator := context.allocator
 ) {
 	log.info("Render Backend nil init")

--- a/render_backend_webgl.odin
+++ b/render_backend_webgl.odin
@@ -124,7 +124,7 @@ webgl_init :: proc(
 	glue: Window_Render_Glue,
 	swapchain_width: int,
 	swapchain_height: int,
-	options: Init_Options,
+	options: Rendering_Options,
 	allocator := context.allocator
 ) {
 	s = (^WebGL_State)(state)


### PR DESCRIPTION
Splits `k2.init` into `init_platform`, `open_window`, `init_rendering` and `init_sound`, the same way `k2.update` is already split. `init` and `shutdown` stay as wrappers over them. The point is to let a program do work between the steps, so this also adds monitor queries that work before a window exists.

## API changes

Nothing that existed before changed shape, so no existing game stops compiling. `Init_Options` keeps every field it had: it is now composed from `Window_Options` and `Rendering_Options` with `using`, and Odin lets a struct literal name those subfields directly, so `Init_Options { window_mode = .Windowed_Resizable }` still works. No example needed a change.

New:

- `init_platform`, `open_window`, `init_rendering`, `init_sound`
- `shutdown_sound`, `shutdown_rendering`, `close_window`, `shutdown_platform`
- `get_monitor_count`, `get_monitor_size`, `get_monitor_position`, `get_monitor_scale`
- `Window_Options`, `Rendering_Options`

## Other changes

- The sub-inits are optional. Skipping `init_sound` or `init_rendering` is allowed, and procedures that need a subsystem assert with a message naming the one to call. `update` skips the audio mixer when there is no audio.
- `Platform_Interface` gains `init_process`/`shutdown_process` for setup that has to happen before any window: DPI awareness and the window class on Windows, the `NSApplication` on Mac, the X/Wayland connection and gamepads on Linux. Without this the monitor queries would run in a DPI unaware process and report virtualized sizes.
- Windows enumerates monitors with `EnumDisplayMonitors` into a cached list, primary first, refreshed on `WM_DISPLAYCHANGE`.
- Mac uses `NSScreen.screens`. Web reports the one screen the page runs on.
- X11 reports the whole X screen as a single monitor. Per-monitor enumeration needs XRandR bindings, which do not exist in `platform_bindings/linux/` yet.
- Wayland reports zero monitors. Real support needs a `wl_output` global and listener, which is not written yet.
- New `examples/monitors`, which queries the display before choosing its window size.

Created with the help of Claude Code
