### PR TITLE
Stop using deprecated procs in examples

### DIFF
--- a/examples/raylib_ports/bunnymark/bunnymark.odin
+++ b/examples/raylib_ports/bunnymark/bunnymark.odin
@@ -81,7 +81,7 @@ step :: proc() -> bool {
 		dest := src
 		dest.x = b.position.x 
 		dest.y = b.position.y
-		k2.draw_texture_ex(tex_bunny, src, dest, {dest.w/2, dest.h/2}, b.rot, b.color)
+		k2.draw_texture_fit(tex_bunny, src, dest, {dest.w/2, dest.h/2}, b.rot, b.color)
 	}
 
 	k2.draw_text(

--- a/examples/scraps/karl_playground/karl_playground.odin
+++ b/examples/scraps/karl_playground/karl_playground.odin
@@ -64,7 +64,13 @@ step :: proc() -> bool {
 		rot += k2.get_frame_time() * 5
 	}
 
-	k2.draw_texture_ex(tex, {0, 0, f32(tex.width), f32(tex.height)}, {400, 450, 900, 500}, {450, 250}, rot)
+	k2.draw_texture_fit(
+		tex,
+		{0, 0, f32(tex.width), f32(tex.height)},
+		{400, 450, 900, 500},
+		{450, 250},
+		rot,
+	)
 
 	k2.draw_rect({pos_x + 10, 10, 60, 60}, k2.GREEN)
 	k2.draw_rect({20, 20, 40, 40}, k2.LIGHT_GREEN)


### PR DESCRIPTION
Replaced the deprecated `draw_texture_ex` calls in the examples with `draw_texture_fit`.

No API changes.

- `examples/raylib_ports/bunnymark` and `examples/scraps/karl_playground` now call `draw_texture_fit`.
- Split the `karl_playground` call over several lines since it went past the 100 character limit.

Created with the help of Claude Code