### PR TITLE
Load ALSA at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ main :: proc() {
 
 >[!NOTE]
 >On *Linux*, you may run into build errors due to missing dependencies. Exactly what you need to install may vary from distribution to distribution. On Ubuntu / Debian, something like this may help:
->`sudo apt install libasound2-dev libudev-dev`
+>`sudo apt install libudev-dev`
 >Did you have to install something else on your distro? Let me know!
 
 ## Get help

--- a/audio_backend_alsa.odin
+++ b/audio_backend_alsa.odin
@@ -48,6 +48,13 @@ alsa_init :: proc(state: rawptr, allocator: runtime.Allocator) {
 	s = (^Alsa_State)(state)
 	log.debug("Init audio backend alsa")
 
+	missing, load_ok := alsa.load()
+
+	if !load_ok {
+		log.errorf("No sound. Could not load %v.", missing)
+		return
+	}
+
 	alsa_err: c.int
 	pcm: alsa.PCM
 	alsa_err = alsa.pcm_open(&pcm, "default", .PLAYBACK, 0)
@@ -147,6 +154,8 @@ alsa_shutdown :: proc() {
 		alsa.pcm_close(s.pcm)
 		s.pcm = nil
 	}
+
+	alsa.unload()
 }
 
 alsa_set_internal_state :: proc(state: rawptr) {

--- a/platform_bindings/linux/alsa/alsa.odin
+++ b/platform_bindings/linux/alsa/alsa.odin
@@ -1,9 +1,10 @@
 // Minimal ALSA bindings. The enums are missing some members. This is just the stuff Karl2D needs.
+// Loaded with dlopen instead of a static foreign import. A static foreign import would need
+// libasound to be present just to start the game, and sound is not worth refusing to launch over.
 package alsa
 
 import "core:c"
-
-foreign import lib "system:asound"
+import "core:dynlib"
 
 PCM :: distinct rawptr
 
@@ -25,24 +26,77 @@ PCM_Format :: enum c.int {
 	FLOAT_LE = 14,
 }
 
-@(default_calling_convention="c", link_prefix="snd_")
-foreign lib {
-	pcm_open :: proc(pcm: ^PCM, name: cstring, stream: PCM_Stream, mode: c.int) -> c.int ---
-	pcm_close :: proc(pcm: PCM) -> c.int ---
-	
-	pcm_set_params :: proc(
-		pcm: PCM,
-		format: PCM_Format,
-		access: PCM_Access,
-		channels: c.uint,
-		rate: c.uint,
-		soft_resample: c.int,
-		latency: c.ulong,
-	) -> c.int ---
+pcm_open: proc "c" (pcm: ^PCM, name: cstring, stream: PCM_Stream, mode: c.int) -> c.int
 
-	pcm_prepare :: proc(pcm: PCM) -> c.int ---
-	pcm_writei :: proc(pcm: PCM, buffer: rawptr, size: c.ulong) -> c.long ---
-	pcm_delay :: proc(pcm: PCM, delay: ^c.long) -> c.int ---
-	pcm_recover :: proc(pcm: PCM, err: c.int, silent: c.int) -> c.int ---
-	strerror :: proc(errnum: c.int) -> cstring ---
+pcm_close: proc "c" (pcm: PCM) -> c.int
+
+pcm_set_params: proc "c" (
+	pcm:           PCM,
+	format:        PCM_Format,
+	access:        PCM_Access,
+	channels:      c.uint,
+	rate:          c.uint,
+	soft_resample: c.int,
+	latency:       c.ulong,
+) -> c.int
+
+pcm_prepare: proc "c" (pcm: PCM) -> c.int
+
+pcm_writei: proc "c" (pcm: PCM, buffer: rawptr, size: c.ulong) -> c.long
+
+pcm_delay: proc "c" (pcm: PCM, delay: ^c.long) -> c.int
+
+pcm_recover: proc "c" (pcm: PCM, err: c.int, silent: c.int) -> c.int
+
+strerror: proc "c" (errnum: c.int) -> cstring
+
+LIB_ASOUND :: "libasound.so.2"
+
+@(private)
+lib: dynlib.Library
+
+// Loads libasound. On failure `missing` names the library or the symbol that was not found.
+load :: proc() -> (missing: string, ok: bool) {
+	symbols := [?]struct {
+		name: string,
+		ptr:  rawptr,
+	} {
+		{"snd_pcm_open", &pcm_open},
+		{"snd_pcm_close", &pcm_close},
+		{"snd_pcm_set_params", &pcm_set_params},
+		{"snd_pcm_prepare", &pcm_prepare},
+		{"snd_pcm_writei", &pcm_writei},
+		{"snd_pcm_delay", &pcm_delay},
+		{"snd_pcm_recover", &pcm_recover},
+		{"snd_strerror", &strerror},
+	}
+
+	lib_ok: bool
+	lib, lib_ok = dynlib.load_library(LIB_ASOUND)
+
+	if !lib_ok {
+		lib = nil
+		return LIB_ASOUND, false
+	}
+
+	for s in symbols {
+		addr, addr_ok := dynlib.symbol_address(lib, s.name)
+
+		if !addr_ok {
+			unload()
+			return s.name, false
+		}
+
+		(^rawptr)(s.ptr)^ = addr
+	}
+
+	return "", true
+}
+
+// Closes the library again.
+unload :: proc() {
+	if lib != nil {
+		dynlib.unload_library(lib)
+		lib = nil
+	}
 }


### PR DESCRIPTION
Loads libasound with `dlopen` instead of linking it statically. A statically linked libasound has to be present for the game to even start, so a machine without it could not launch a Karl2D game at all, not even one that makes no sound. This is the same treatment the windowing libraries got in #244.

No API changes.

- The ALSA bindings fetch their procedure pointers from the opened library.
- The ALSA audio backend logs and then runs without sound when the library is missing.
- Dropped `libasound2-dev` from the Linux dependencies in the README.

Created with the help of Claude Code
