### PR TITLE
Stop unloading ALSA at shutdown

### DIFF
--- a/audio_backend_alsa.odin
+++ b/audio_backend_alsa.odin
@@ -154,8 +154,6 @@ alsa_shutdown :: proc() {
 		alsa.pcm_close(s.pcm)
 		s.pcm = nil
 	}
-
-	alsa.unload()
 }
 
 alsa_set_internal_state :: proc(state: rawptr) {

--- a/platform_bindings/linux/alsa/alsa.odin
+++ b/platform_bindings/linux/alsa/alsa.odin
@@ -93,7 +93,7 @@ load :: proc() -> (missing: string, ok: bool) {
 	return "", true
 }
 
-// Closes the library again.
+// Closes the library again, for when one of the symbols turns out to be missing.
 unload :: proc() {
 	if lib != nil {
 		dynlib.unload_library(lib)


### PR DESCRIPTION
Drops the `alsa.unload()` call from `alsa_shutdown`. libasound stays mapped after the dlclose anyway, both with and without the PipeWire ALSA plugin holding a reference to it, so the call only leaves the bindings procedure pointers aimed at a library that may be gone. `unload` stays for the failure path in `load`, which is how the other Linux bindings use it.

No API changes.

- `alsa_shutdown` no longer closes libasound.
- The comment on `alsa.unload` says when it is used.

Created with the help of Claude Code