### PR TITLE
Monitor queries, and a platform interface available before init

### DIFF
--- a/examples/monitors/monitors.odin
+++ b/examples/monitors/monitors.odin
@@ -1,0 +1,82 @@
+// Demonstrates the monitor query procedures. The interesting part is that they work before
+// `k2.init`, which lets a program size its window from the display it is about to open on.
+package karl2d_monitors_example
+
+import k2 "../.."
+import "core:fmt"
+
+Monitor_Reading :: struct {
+	size: [2]int,
+	position: [2]int,
+	scale: f32,
+}
+
+MAX_MONITORS :: 16
+
+main :: proc() {
+	// No k2.init yet. These work before the library is initialized, which is the point: you can
+	// size the window from the display it is about to open on.
+	monitor_count := k2.get_monitor_count()
+
+	// Queried once and stored: each call to the getters does a fresh OS query, and on X11 that
+	// opens a display connection, so this should not happen every frame.
+	monitors: [MAX_MONITORS]Monitor_Reading
+	stored_count := min(monitor_count, MAX_MONITORS)
+
+	for i in 0..<stored_count {
+		monitors[i] = {
+			size = k2.get_monitor_size(i),
+			position = k2.get_monitor_position(i),
+			scale = k2.get_monitor_scale(i),
+		}
+	}
+
+	// Half the primary monitor. Not every platform can report monitors (Wayland reports none), so
+	// keep a fixed size to fall back on.
+	window_width := 640
+	window_height := 480
+
+	if stored_count > 0 {
+		size := monitors[0].size
+
+		if size.x > 0 && size.y > 0 {
+			window_width = size.x/2
+			window_height = size.y/2
+		}
+	}
+
+	k2.init(window_width, window_height, "Karl2D Monitors", options = {
+		window_mode = .Windowed_Resizable,
+	})
+
+	for k2.update() {
+		k2.clear(k2.LIGHT_BLUE)
+
+		y: f32 = 20
+
+		if stored_count == 0 {
+			k2.draw_text("No monitors reported on this platform.", {20, y}, 32, k2.DARK_BLUE)
+			y += 40
+		}
+
+		for i in 0..<stored_count {
+			m := monitors[i]
+
+			line := fmt.tprintf(
+				"Monitor %v: size %vx%v, position (%v, %v), scale %v",
+				i, m.size.x, m.size.y, m.position.x, m.position.y, m.scale,
+			)
+
+			k2.draw_text(line, {20, y}, 32, k2.DARK_BLUE)
+			y += 40
+		}
+
+		k2.present()
+
+		// fmt.tprintf above allocates using context.temp_allocator. Thrown away now that this
+		// frame's text has been drawn.
+		free_all(context.temp_allocator)
+	}
+
+	k2.shutdown()
+}

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -180,6 +180,35 @@ set_window_mode :: proc(window_mode: Window_Mode)
 // `VERTEX_BUFFER_MAX / shader.vertex_size`. Running out of room flushes the batch automatically.
 draw_current_batch :: proc()
 
+//----------//
+// MONITORS //
+//----------//
+
+// The primary monitor. Every platform puts it at index 0, so this is the default the monitor
+// procedures use. It is a named constant rather than a bare 0 because 0 here means "the primary
+// one", not "whichever the operating system happened to list first".
+MONITOR_PRIMARY :: 0
+
+// Reports how many monitors are connected. Works before `k2.init` has been called, so a program
+// can size its window from the display it is about to open on.
+//
+// Not every platform can report every monitor: Wayland has no implementation yet and always
+// reports 0, and X11 reports 1 monitor covering the whole X screen rather than the physical
+// monitors behind it.
+get_monitor_count :: proc() -> int
+
+// Returns the size of `monitor`, in physical pixels, matching what `set_screen_size` takes.
+// `MONITOR_PRIMARY` is the primary monitor. Works before `k2.init` has been called.
+get_monitor_size :: proc(monitor := MONITOR_PRIMARY) -> [2]int
+
+// Returns the position of `monitor`, in the same coordinate system used by `set_window_position`.
+// `MONITOR_PRIMARY` is the primary monitor. Works before `k2.init` has been called.
+get_monitor_position :: proc(monitor := MONITOR_PRIMARY) -> [2]int
+
+// Returns the scale of `monitor`. 1 means 100% scale, 1.5 means 150% etc. `MONITOR_PRIMARY` is the
+// primary monitor. Works before `k2.init` has been called.
+get_monitor_scale :: proc(monitor := MONITOR_PRIMARY) -> f32
+
 //-------//
 // INPUT //
 //-------//
@@ -1768,7 +1797,6 @@ State :: struct {
 	allocator: runtime.Allocator,
 	frame_arena: runtime.Arena,
 	frame_allocator: runtime.Allocator,
-	platform: Platform_Interface,
 	platform_state: rawptr,
 	render_backend: Render_Backend_Interface,
 	render_backend_state: rawptr,

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -63,20 +63,6 @@ init :: proc(
 	s.frame_allocator = runtime.arena_allocator(&s.frame_arena)
 	frame_allocator = s.frame_allocator
 
-	when ODIN_OS == .Windows {
-		s.platform = PLATFORM_WINDOWS
-	} else when ODIN_OS == .JS {
-		s.platform = PLATFORM_WEB
-	} else when ODIN_OS == .Linux {
-		s.platform = PLATFORM_LINUX
-	} else when ODIN_OS == .Darwin {
-		s.platform = PLATFORM_MAC
-	} else {
-		#panic("Unsupported platform")
-	}
-
-	pf = s.platform
-
 	// We allocate memory for the windowing backend and pass the blob of memory to it.
 	platform_state_alloc_error: runtime.Allocator_Error
 	
@@ -674,6 +660,64 @@ draw_current_batch :: proc() {
 	s.current_draw_call = {}
 	s.vertex_buffer_cpu_used = 0
 	free_all(s.batch_allocator)
+}
+
+//----------//
+// MONITORS //
+//----------//
+
+// The primary monitor. Every platform puts it at index 0, so this is the default the monitor
+// procedures use. It is a named constant rather than a bare 0 because 0 here means "the primary
+// one", not "whichever the operating system happened to list first".
+MONITOR_PRIMARY :: 0
+
+// Reports how many monitors are connected. Works before `k2.init` has been called, so a program
+// can size its window from the display it is about to open on.
+//
+// Not every platform can report every monitor: Wayland has no implementation yet and always
+// reports 0, and X11 reports 1 monitor covering the whole X screen rather than the physical
+// monitors behind it.
+get_monitor_count :: proc() -> int {
+	return pf.get_monitor_count()
+}
+
+// Returns the size of `monitor`, in physical pixels, matching what `set_screen_size` takes.
+// `MONITOR_PRIMARY` is the primary monitor. Works before `k2.init` has been called.
+get_monitor_size :: proc(monitor := MONITOR_PRIMARY) -> [2]int {
+	info, ok := pf.get_monitor_info(monitor)
+
+	if !ok {
+		log.errorf("Cannot get monitor size, monitor %v does not exist.", monitor)
+		return {}
+	}
+
+	return info.size
+}
+
+// Returns the position of `monitor`, in the same coordinate system used by `set_window_position`.
+// `MONITOR_PRIMARY` is the primary monitor. Works before `k2.init` has been called.
+get_monitor_position :: proc(monitor := MONITOR_PRIMARY) -> [2]int {
+	info, ok := pf.get_monitor_info(monitor)
+
+	if !ok {
+		log.errorf("Cannot get monitor position, monitor %v does not exist.", monitor)
+		return {}
+	}
+
+	return info.position
+}
+
+// Returns the scale of `monitor`. 1 means 100% scale, 1.5 means 150% etc. `MONITOR_PRIMARY` is the
+// primary monitor. Works before `k2.init` has been called.
+get_monitor_scale :: proc(monitor := MONITOR_PRIMARY) -> f32 {
+	info, ok := pf.get_monitor_info(monitor)
+
+	if !ok {
+		log.errorf("Cannot get monitor scale, monitor %v does not exist.", monitor)
+		return 0
+	}
+
+	return info.scale
 }
 
 //-------//
@@ -4964,7 +5008,6 @@ get_z :: proc() -> f32 {
 set_internal_state :: proc(state: ^State) {
 	s = state
 	frame_allocator = s.frame_allocator
-	pf = s.platform
 	rb = s.render_backend
 	ab = s.audio_backend
 	pf.set_internal_state(s.platform_state)
@@ -5704,7 +5747,6 @@ State :: struct {
 	allocator: runtime.Allocator,
 	frame_arena: runtime.Arena,
 	frame_allocator: runtime.Allocator,
-	platform: Platform_Interface,
 	platform_state: rawptr,
 	render_backend: Render_Backend_Interface,
 	render_backend_state: rawptr,
@@ -6148,6 +6190,15 @@ Event_Touch_Cancelled :: struct { id: Touch_Id }
 
 // Used by API builder. Everything after this constant will not be in karl2d.doc.odin
 API_END :: true
+
+// Holds what the monitor queries report. Internal: the public API is the four getters in the
+// MONITORS section above.
+@(private="package")
+Monitor_Info :: struct {
+	size: [2]int,
+	position: [2]int,
+	scale: f32,
+}
 
 // Returns true if `r` should be treated as a typed character for text input purposes. Filters out
 // control characters such as Backspace, Enter, Tab, Escape and Delete. Used by the platform
@@ -6943,9 +6994,6 @@ BATCH_ARENA_BLOCK_SIZE :: 64*1024
 
 @(private="file")
 s: ^State
-
-@(private="file")
-pf: Platform_Interface
 
 @(private="file")
 rb: Render_Backend_Interface

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -6995,6 +6995,14 @@ BATCH_ARENA_BLOCK_SIZE :: 64*1024
 @(private="file")
 s: ^State
 
+// A constant rather than a global assigned during `init`, because the platform is picked at
+// compile time anyway. See `platform_chooser.odin` for how it is picked. That is what lets the
+// monitor queries run before `init`: `pf` is already there. The backends' own state is still
+// allocated by `init` though, so anything reachable before that must not touch it -- see
+// `ensure_basic_setup` in each backend.
+@(private="file")
+pf :: PLATFORM
+
 @(private="file")
 rb: Render_Backend_Interface
 

--- a/platform_bindings/linux/x11/x11.odin
+++ b/platform_bindings/linux/x11/x11.odin
@@ -433,6 +433,12 @@ CloseDisplay: proc "c" (display: ^Display)
 
 DefaultScreen: proc "c" (display: ^Display) -> i32
 
+// DisplayWidth/DisplayHeight are macros in Xlib.h, but libX11 also exports them as real functions
+// for bindings from other languages, which is what these load.
+DisplayWidth: proc "c" (display: ^Display, screen_number: i32) -> i32
+
+DisplayHeight: proc "c" (display: ^Display, screen_number: i32) -> i32
+
 DefaultRootWindow: proc "c" (display: ^Display) -> Window
 
 CreateSimpleWindow: proc "c" (
@@ -685,11 +691,21 @@ load_symbols :: proc(
 
 // Loads libX11 and libXcursor. On failure `missing` names the library or symbol that was not
 // found, which is how a machine without X11 installed is detected.
+//
+// Calling this when the libraries are already loaded does nothing. The monitor queries call it
+// without knowing whether `init` has run, and re-resolving every symbol on each of those would be
+// wasted work.
 load :: proc() -> (missing: string, ok: bool) {
+	if lib_x11 != nil && lib_xcursor != nil {
+		return "", true
+	}
+
 	x11_symbols := []Symbol {
 		{"XOpenDisplay", &OpenDisplay},
 		{"XCloseDisplay", &CloseDisplay},
 		{"XDefaultScreen", &DefaultScreen},
+		{"XDisplayWidth", &DisplayWidth},
+		{"XDisplayHeight", &DisplayHeight},
 		{"XDefaultRootWindow", &DefaultRootWindow},
 		{"XCreateSimpleWindow", &CreateSimpleWindow},
 		{"XDestroyWindow", &DestroyWindow},

--- a/platform_chooser.odin
+++ b/platform_chooser.odin
@@ -1,21 +1,13 @@
 package karl2d
 
-// The platform is picked at compile time, so this is a constant rather than a global assigned
-// during `init`. That is what lets the monitor queries in karl2d.odin run before `init`: `pf` is
-// already there. Note the backends' own state is still allocated by `init`, so anything reachable
-// before that must not touch it -- see `ensure_basic_setup` in each backend.
 when ODIN_OS == .Windows {
-	@(private="package")
-	pf :: PLATFORM_WINDOWS
+	PLATFORM :: PLATFORM_WINDOWS
 } else when ODIN_OS == .JS {
-	@(private="package")
-	pf :: PLATFORM_WEB
+	PLATFORM :: PLATFORM_WEB
 } else when ODIN_OS == .Linux {
-	@(private="package")
-	pf :: PLATFORM_LINUX
+	PLATFORM :: PLATFORM_LINUX
 } else when ODIN_OS == .Darwin {
-	@(private="package")
-	pf :: PLATFORM_MAC
+	PLATFORM :: PLATFORM_MAC
 } else {
 	#panic("Unsupported platform")
 }

--- a/platform_chooser.odin
+++ b/platform_chooser.odin
@@ -1,0 +1,21 @@
+package karl2d
+
+// The platform is picked at compile time, so this is a constant rather than a global assigned
+// during `init`. That is what lets the monitor queries in karl2d.odin run before `init`: `pf` is
+// already there. Note the backends' own state is still allocated by `init`, so anything reachable
+// before that must not touch it -- see `ensure_basic_setup` in each backend.
+when ODIN_OS == .Windows {
+	@(private="package")
+	pf :: PLATFORM_WINDOWS
+} else when ODIN_OS == .JS {
+	@(private="package")
+	pf :: PLATFORM_WEB
+} else when ODIN_OS == .Linux {
+	@(private="package")
+	pf :: PLATFORM_LINUX
+} else when ODIN_OS == .Darwin {
+	@(private="package")
+	pf :: PLATFORM_MAC
+} else {
+	#panic("Unsupported platform")
+}

--- a/platform_interface.odin
+++ b/platform_interface.odin
@@ -26,6 +26,14 @@ Platform_Interface :: struct #all_or_none {
 	get_window_scale: proc() -> f32,
 	set_window_mode: proc(window_mode: Window_Mode),
 
+	// Callable before `init`, when the backend's own state does not exist yet. Implementations
+	// must check for that rather than assume it, calling the backend's `ensure_basic_setup` first
+	// if it needs any. Once the state exists, an implementation may read it -- X11 reuses the live
+	// display connection instead of opening a second one -- but must not write to it or otherwise
+	// give the two callers different observable state.
+	get_monitor_count: proc() -> int,
+	get_monitor_info: proc(monitor: int) -> (Monitor_Info, bool),
+
 	set_cursor_hidden: proc(hidden: bool),
 	is_cursor_hidden: proc() -> bool,
 	set_mouse_locked: proc(locked: bool),

--- a/platform_linux.odin
+++ b/platform_linux.odin
@@ -51,14 +51,15 @@ PLATFORM_LINUX :: Platform_Interface {
 // before `init`, when there is no `Linux_State` to keep this in -- see the same choice.
 win: Linux_Window_Interface
 
-// Only put things behind this flag that are harmless to run twice. Nothing that needs freeing: a
-// hot reload zeroes it along with `win` and `basic_setup_ok`, so this runs again in the same
-// process and re-resolves `win` to procedure pointers from the new code image.
-basic_setup_done: bool
-
-// Whether `win` actually points at a working windowing backend. False means the monitor queries
-// have nothing to report; `linux_init` still panics in that case, since a window cannot be opened
-// without one.
+// Whether `win` actually points at a working windowing backend. This doubles as the "already
+// resolved" flag, so only a successful resolution is remembered.
+//
+// Only things that are harmless to run twice belong behind it, and nothing that needs freeing: a
+// hot reload zeroes it along with `win`, so the resolution runs again in the same process and
+// re-points `win` at procedures in the new code image.
+//
+// False means the monitor queries have nothing to report. `linux_init` panics in that case, since
+// a window cannot be opened without a windowing backend.
 basic_setup_ok: bool
 
 s: ^Linux_State
@@ -70,9 +71,18 @@ linux_state_size :: proc() -> int {
 // Picks between Wayland and X11 and loads the winner's libraries into `win`. Uses
 // `context.temp_allocator` rather than `frame_allocator`, which is zeroed before `init` and so
 // cannot be relied on here.
-linux_ensure_basic_setup :: proc() {
-	if basic_setup_done {
-		return
+//
+// Returns why each windowing system was turned down when neither loaded, so `linux_init` can put
+// them in its panic. Only success is remembered: a failed resolution is retried on the next call,
+// which is what keeps those reasons available to whoever asks next instead of only to the first
+// caller. Retrying costs a couple of `dlopen` attempts, and only on a machine that has no
+// windowing system at all.
+linux_ensure_basic_setup :: proc() -> (
+	first_failure_reason: string,
+	second_failure_reason: string,
+) {
+	if basic_setup_ok {
+		return "", ""
 	}
 
 	// Each `try_load` opens a windowing system's libraries and checks that a server is listening,
@@ -112,32 +122,26 @@ linux_ensure_basic_setup :: proc() {
 	}
 
 	win = first
-	first_failure_reason, first_ok := win.try_load(context.temp_allocator)
+	first_reason, first_ok := win.try_load(context.temp_allocator)
 
 	if first_ok {
 		basic_setup_ok = true
-	} else {
-		win = second
-		second_failure_reason, second_ok := win.try_load(context.temp_allocator)
-		basic_setup_ok = second_ok
-
-		if second_ok {
-			if preference_given {
-				log.info(first_failure_reason)
-			}
-		} else {
-			// Logged here rather than only left for `linux_init` to panic about, since a monitor
-			// query calling this before `init` never panics and would otherwise leave the reasons
-			// unreported.
-			log.errorf(
-				"Found neither Wayland nor X11. %s %s",
-				first_failure_reason,
-				second_failure_reason,
-			)
-		}
+		return "", ""
 	}
 
-	basic_setup_done = true
+	win = second
+	second_reason, second_ok := win.try_load(context.temp_allocator)
+	basic_setup_ok = second_ok
+
+	if second_ok {
+		if preference_given {
+			log.info(first_reason)
+		}
+
+		return "", ""
+	}
+
+	return first_reason, second_reason
 }
 
 linux_init :: proc(
@@ -152,12 +156,16 @@ linux_init :: proc(
 	s = (^Linux_State)(platform_state)
 	s.allocator = allocator
 
-	linux_ensure_basic_setup()
+	first_failure_reason, second_failure_reason := linux_ensure_basic_setup()
 
-	// A window cannot be opened without a working windowing backend. The reasons why neither
-	// loaded were already logged by `linux_ensure_basic_setup`.
 	if !basic_setup_ok {
-		log.panicf("Found neither Wayland nor X11. Karl2D needs one of them.")
+		// The reasons go in the panic itself rather than only in a log line: a game that raises
+		// the log level would otherwise be told to read reasons that were never printed.
+		log.panicf(
+			"Found neither Wayland nor X11. Karl2D needs one of them. %s %s",
+			first_failure_reason,
+			second_failure_reason,
+		)
 	}
 
 	win_state_alloc_error: runtime.Allocator_Error
@@ -724,7 +732,7 @@ linux_set_internal_state :: proc(state: rawptr) {
 	assert(state != nil)
 	s = (^Linux_State)(state)
 
-	// A hot reload zeroes `basic_setup_done` along with `win`, so this re-resolves it to
+	// A hot reload zeroes `basic_setup_ok` along with `win`, so this re-resolves it to
 	// procedure pointers from the new code image.
 	linux_ensure_basic_setup()
 

--- a/platform_linux.odin
+++ b/platform_linux.odin
@@ -30,6 +30,8 @@ PLATFORM_LINUX :: Platform_Interface {
 	get_window_position = linux_get_window_position,
 	get_window_scale = linux_get_window_scale,
 	set_window_mode = linux_set_window_mode,
+	get_monitor_count = linux_get_monitor_count,
+	get_monitor_info = linux_get_monitor_info,
 	set_cursor_hidden = linux_set_cursor_hidden,
 	is_cursor_hidden = linux_is_cursor_hidden,
 	set_mouse_locked = linux_set_mouse_locked,
@@ -44,23 +46,35 @@ PLATFORM_LINUX :: Platform_Interface {
 	set_internal_state = linux_set_internal_state,
 }
 
+// Which windowing backend was chosen, and whether one was found at all. Resolved once by
+// `linux_ensure_basic_setup`, so both `linux_init` and the monitor queries -- which may run
+// before `init`, when there is no `Linux_State` to keep this in -- see the same choice.
+win: Linux_Window_Interface
+
+// Only put things behind this flag that are harmless to run twice. Nothing that needs freeing: a
+// hot reload zeroes it along with `win` and `basic_setup_ok`, so this runs again in the same
+// process and re-resolves `win` to procedure pointers from the new code image.
+basic_setup_done: bool
+
+// Whether `win` actually points at a working windowing backend. False means the monitor queries
+// have nothing to report; `linux_init` still panics in that case, since a window cannot be opened
+// without one.
+basic_setup_ok: bool
+
 s: ^Linux_State
 
 linux_state_size :: proc() -> int {
 	return size_of(Linux_State)
 }
 
-linux_init :: proc(
-	platform_state: rawptr,
-	screen_width: int,
-	screen_height: int,
-	window_title: string,
-	options: Init_Options,
-	allocator: runtime.Allocator,
-) {
-	assert(platform_state != nil)
-	s = (^Linux_State)(platform_state)
-	s.allocator = allocator
+// Picks between Wayland and X11 and loads the winner's libraries into `win`. Uses
+// `context.temp_allocator` rather than `frame_allocator`, which is zeroed before `init` and so
+// cannot be relied on here.
+linux_ensure_basic_setup :: proc() {
+	if basic_setup_done {
+		return
+	}
+
 	// Each `try_load` opens a windowing system's libraries and checks that a server is listening,
 	// so a Wayland session picks Wayland, an X11 session finds no compositor and falls through,
 	// and a machine with only one of the two installed gets the one it has. Nothing here reads the
@@ -77,7 +91,7 @@ linux_init :: proc(
 	// that the first choice was turned down. The default order falling through to X11 is ordinary
 	// detection on an X11 machine, not something anyone needs to read about.
 	preference_given := false
-	windowing_preference := os.get_env("KARL2D_LINUX_WINDOWING", frame_allocator)
+	windowing_preference := os.get_env("KARL2D_LINUX_WINDOWING", context.temp_allocator)
 
 	switch windowing_preference {
 	case "":
@@ -97,32 +111,58 @@ linux_init :: proc(
 		)
 	}
 
-	s.win = first
-	first_failure_reason, first_ok := s.win.try_load(frame_allocator)
+	win = first
+	first_failure_reason, first_ok := win.try_load(context.temp_allocator)
 
-	if !first_ok {
-		s.win = second
-		second_failure_reason, second_ok := s.win.try_load(frame_allocator)
+	if first_ok {
+		basic_setup_ok = true
+	} else {
+		win = second
+		second_failure_reason, second_ok := win.try_load(context.temp_allocator)
+		basic_setup_ok = second_ok
 
-		if !second_ok {
-			// The reasons go in the panic itself rather than only in the log above it: a game
-			// that raises the log level past info would otherwise be told to read reasons that
-			// were never printed.
-			log.panicf(
-				"Found neither Wayland nor X11. Karl2D needs one of them. %s %s",
+		if second_ok {
+			if preference_given {
+				log.info(first_failure_reason)
+			}
+		} else {
+			// Logged here rather than only left for `linux_init` to panic about, since a monitor
+			// query calling this before `init` never panics and would otherwise leave the reasons
+			// unreported.
+			log.errorf(
+				"Found neither Wayland nor X11. %s %s",
 				first_failure_reason,
 				second_failure_reason,
 			)
 		}
+	}
 
-		if preference_given {
-			log.info(first_failure_reason)
-		}
+	basic_setup_done = true
+}
+
+linux_init :: proc(
+	platform_state: rawptr,
+	screen_width: int,
+	screen_height: int,
+	window_title: string,
+	options: Init_Options,
+	allocator: runtime.Allocator,
+) {
+	assert(platform_state != nil)
+	s = (^Linux_State)(platform_state)
+	s.allocator = allocator
+
+	linux_ensure_basic_setup()
+
+	// A window cannot be opened without a working windowing backend. The reasons why neither
+	// loaded were already logged by `linux_ensure_basic_setup`.
+	if !basic_setup_ok {
+		log.panicf("Found neither Wayland nor X11. Karl2D needs one of them.")
 	}
 
 	win_state_alloc_error: runtime.Allocator_Error
 	s.win_state, win_state_alloc_error = mem.alloc(
-		s.win.state_size(),
+		win.state_size(),
 		allocator = allocator,
 	)
 
@@ -131,7 +171,7 @@ linux_init :: proc(
 		win_state_alloc_error,
 	)
 
-	s.win.init(
+	win.init(
 		s.win_state,
 		screen_width,
 		screen_height,
@@ -160,17 +200,18 @@ linux_shutdown :: proc() {
 	udev.monitor_unref(s.udev_mon)
 	udev.unref(s.udev_ptr)
 
-	s.win.shutdown()
+	win.shutdown()
 	a := s.allocator
 	free(s.win_state, a)
+	s = nil
 }
 
 linux_get_window_render_glue :: proc() -> Window_Render_Glue {
-	return s.win.get_window_render_glue()
+	return win.get_window_render_glue()
 }
 
 linux_get_events :: proc(events: ^[dynamic]Event) {
-	s.win.get_events(events)
+	win.get_events(events)
 	linux_poll_for_new_gamepads()
 	linux_get_gamepad_events(events)
 }
@@ -214,31 +255,55 @@ linux_poll_for_new_gamepads :: proc() {
 }
 
 linux_get_screen_width :: proc() -> int {
-	return s.win.get_screen_width()
+	return win.get_screen_width()
 }
 
 linux_get_screen_height :: proc() -> int {
-	return s.win.get_screen_height()
+	return win.get_screen_height()
 }
 
 linux_set_window_title :: proc(title: string) {
-	s.win.set_title(title)
+	win.set_title(title)
 }
 
 linux_set_window_position :: proc(x: int, y: int) {
-	s.win.set_position(x, y)
+	win.set_position(x, y)
 }
 
 linux_get_window_position :: proc() -> Vec2 {
-	return s.win.get_position()
+	return win.get_position()
 }
 
 set_screen_size :: proc(w, h: int) {
-	s.win.set_screen_size(w, h)
+	win.set_screen_size(w, h)
 }
 
 linux_get_window_scale :: proc() -> f32 {
-	return s.win.get_window_scale()
+	return win.get_window_scale()
+}
+
+// Callable before `init`. Uses the global `win` set up by `linux_ensure_basic_setup`, never
+// `s.win_state`, since there may be no `Linux_State` yet. Reports nothing rather than panicking
+// when no windowing backend was found: a program asking about monitors on a machine with no
+// working windowing system should get "none", not a crash.
+linux_get_monitor_count :: proc() -> int {
+	linux_ensure_basic_setup()
+
+	if !basic_setup_ok {
+		return 0
+	}
+
+	return win.get_monitor_count()
+}
+
+linux_get_monitor_info :: proc(monitor: int) -> (Monitor_Info, bool) {
+	linux_ensure_basic_setup()
+
+	if !basic_setup_ok {
+		return {}, false
+	}
+
+	return win.get_monitor_info(monitor)
 }
 
 linux_create_connected_gamepads :: proc() {
@@ -658,35 +723,40 @@ linux_open_url :: proc(url: string) -> bool {
 linux_set_internal_state :: proc(state: rawptr) {
 	assert(state != nil)
 	s = (^Linux_State)(state)
-	s.win.set_internal_state(s.win_state)
+
+	// A hot reload zeroes `basic_setup_done` along with `win`, so this re-resolves it to
+	// procedure pointers from the new code image.
+	linux_ensure_basic_setup()
+
+	win.set_internal_state(s.win_state)
 }
 
 linux_set_window_mode :: proc(window_mode: Window_Mode) {
-	s.win.set_window_mode(window_mode)
+	win.set_window_mode(window_mode)
 }
 
 linux_set_cursor_hidden :: proc(hidden: bool) {
-	s.win.set_cursor_hidden(hidden)
+	win.set_cursor_hidden(hidden)
 }
 
 linux_is_cursor_hidden :: proc() -> bool {
-	return s.win.is_cursor_hidden()
+	return win.is_cursor_hidden()
 }
 
 linux_set_mouse_locked :: proc(locked: bool) {
-	s.win.set_mouse_locked(locked)
+	win.set_mouse_locked(locked)
 }
 
 linux_is_mouse_locked :: proc() -> bool {
-	return s.win.is_mouse_locked()
+	return win.is_mouse_locked()
 }
 
 linux_create_custom_cursor :: proc(image: Image, hotspot: [2]int) -> (Custom_Cursor, bool) {
-	return s.win.create_custom_cursor(image, hotspot)
+	return win.create_custom_cursor(image, hotspot)
 }
 
 linux_set_cursor :: proc(cursor: Cursor) {
-	s.win.set_cursor(cursor)
+	win.set_cursor(cursor)
 }
 
 // Cursor theme names for a standard cursor. Both X11 and Wayland load cursors out of the user's
@@ -716,11 +786,10 @@ linux_standard_cursor_names :: proc(cursor: Standard_Cursor) -> (name: cstring, 
 }
 
 linux_destroy_custom_cursor :: proc(custom_cursor: Custom_Cursor) {
-	s.win.destroy_custom_cursor(custom_cursor)
+	win.destroy_custom_cursor(custom_cursor)
 }
 
 Linux_State :: struct {
-	win: Linux_Window_Interface,
 	win_state: rawptr,
 	allocator: runtime.Allocator,
 
@@ -764,6 +833,12 @@ Linux_Window_Interface :: struct #all_or_none {
 	get_screen_height: proc() -> int,
 	get_window_scale: proc() -> f32,
 	set_window_mode: proc(window_mode: Window_Mode),
+
+	// Callable before `init`, through the global `win` -- see `linux_get_monitor_count` and
+	// `linux_get_monitor_info`.
+	get_monitor_count: proc() -> int,
+	get_monitor_info: proc(monitor: int) -> (Monitor_Info, bool),
+
 	set_cursor_hidden: proc(hidden: bool),
 	is_cursor_hidden: proc() -> bool,
 	set_mouse_locked: proc(locked: bool),

--- a/platform_linux.odin
+++ b/platform_linux.odin
@@ -68,9 +68,10 @@ linux_state_size :: proc() -> int {
 	return size_of(Linux_State)
 }
 
-// Picks between Wayland and X11 and loads the winner's libraries into `win`. Uses
-// `context.temp_allocator` rather than `frame_allocator`, which is zeroed before `init` and so
-// cannot be relied on here.
+// Picks between Wayland and X11 and loads the winner's libraries into `win`. Nothing here touches
+// `frame_allocator`, which is zeroed before `init` and so cannot be relied on: the environment
+// variable goes into a stack buffer, and the only allocations left are the failure reason strings
+// below, which have to outlive this procedure and so take `context.temp_allocator`.
 //
 // Returns why each windowing system was turned down when neither loaded, so `linux_init` can put
 // them in its panic. Only success is remembered: a failed resolution is retried on the next call,
@@ -101,7 +102,14 @@ linux_ensure_basic_setup :: proc() -> (
 	// that the first choice was turned down. The default order falling through to X11 is ordinary
 	// detection on an X11 machine, not something anyone needs to read about.
 	preference_given := false
-	windowing_preference := os.get_env("KARL2D_LINUX_WINDOWING", context.temp_allocator)
+
+	// Read into a stack buffer instead of through an allocator. This can run before `init`, when
+	// there is no frame allocator to reach for, and the answer only ever has to hold "wayland" or
+	// "x11". The rest of the room is so the warning below can print a typo in full rather than a
+	// clipped version of it. A value too long for the buffer comes back empty, which reads as no
+	// preference given.
+	windowing_preference_buf: [64]u8
+	windowing_preference := os.get_env(windowing_preference_buf[:], "KARL2D_LINUX_WINDOWING")
 
 	switch windowing_preference {
 	case "":

--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -17,6 +17,8 @@ LINUX_WINDOW_WAYLAND :: Linux_Window_Interface {
 	set_screen_size = wl_set_screen_size,
 	get_window_scale = wl_get_window_scale,
 	set_window_mode = wl_set_window_mode,
+	get_monitor_count = wl_get_monitor_count,
+	get_monitor_info = wl_get_monitor_info,
 	set_cursor_hidden = wl_set_cursor_hidden,
 	is_cursor_hidden = wl_is_cursor_hidden,
 	set_mouse_locked = wl_set_mouse_locked,
@@ -777,6 +779,8 @@ wl_shutdown :: proc() {
 	if s.xkb_context != nil {
 		xkb.context_unref(s.xkb_context)
 	}
+
+	s = nil
 }
 
 wl_get_window_render_glue :: proc() -> Window_Render_Glue {
@@ -1226,6 +1230,23 @@ wl_destroy_custom_cursor :: proc(custom_cursor: Custom_Cursor) {
 wl_set_internal_state :: proc(state: rawptr) {
 	assert(state != nil)
 	s = (^WL_State)(state)
+}
+
+// Reports zero monitors. Binding wl_output and listening for geometry/mode/scale would be the
+// correct implementation, but it needs a new registry global, a listener that accumulates
+// per-output events, and an extra display_roundtrip -- more than this change should write blind.
+// When that lands, it should prefer the live `s.display` over opening a second connection, the same
+// way the X11 monitor queries do, and only connect on its own when there is no live state.
+//
+// Zero rather than one monitor of unknown size is deliberate: a caller can tell that Karl2D has
+// nothing to say and fall back to a size of its own. Claiming one monitor and reporting it as 0x0
+// would look like a real answer.
+wl_get_monitor_count :: proc() -> int {
+	return 0
+}
+
+wl_get_monitor_info :: proc(monitor: int) -> (Monitor_Info, bool) {
+	return {}, false
 }
 
 WL_Cursor :: struct {

--- a/platform_linux_window_x11.odin
+++ b/platform_linux_window_x11.odin
@@ -19,6 +19,8 @@ LINUX_WINDOW_X11 :: Linux_Window_Interface {
 	set_screen_size = x11_set_screen_size,
 	get_window_scale = x11_get_window_scale,
 	set_window_mode = x11_set_window_mode,
+	get_monitor_count = x11_get_monitor_count,
+	get_monitor_info = x11_get_monitor_info,
 	set_cursor_hidden = x11_set_cursor_hidden,
 	is_cursor_hidden = x11_is_cursor_hidden,
 	set_mouse_locked = x11_set_mouse_locked,
@@ -222,6 +224,7 @@ x11_shutdown :: proc() {
 
 	X.FreeCursor(s.display, s.blank_cursor)
 	X.DestroyWindow(s.display, s.window)
+	s = nil
 }
 
 x11_get_window_render_glue :: proc() -> Window_Render_Glue {
@@ -514,6 +517,13 @@ x11_get_window_scale :: proc() -> f32 {
 // returns the copy Xlib took when the display connection was opened, so it never reflects a change
 // made while the game is running.
 x11_fetch_window_scale :: proc() -> f32 {
+	return x11_fetch_scale_from_display(s.display, s.resource_manager)
+}
+
+// The body of x11_fetch_window_scale, taking the display and resource manager atom as parameters
+// instead of reading them from `s`. This is also called from the monitor queries, which have their
+// own temporary display connection and no `s` to read from -- they may run before `init`.
+x11_fetch_scale_from_display :: proc(display: ^X.Display, resource_manager: X.Atom) -> f32 {
 	// A length in 32-bit units. The server sends only what is actually there, so this just has to
 	// be bigger than any real resource database.
 	MAX_RESOURCE_WORDS :: 1024 * 1024
@@ -525,9 +535,9 @@ x11_fetch_window_scale :: proc() -> f32 {
 	prop: rawptr
 
 	get_status := X.GetWindowProperty(
-		s.display,
-		X.DefaultRootWindow(s.display),
-		s.resource_manager,
+		display,
+		X.DefaultRootWindow(display),
+		resource_manager,
 		0,
 		MAX_RESOURCE_WORDS,
 		false,
@@ -568,6 +578,84 @@ x11_fetch_window_scale :: proc() -> f32 {
 
 	X.XrmDestroyDatabase(db)
 	return scale
+}
+
+// Reports one monitor covering the whole X screen rather than the physical monitors behind it.
+// Per-monitor enumeration needs XRandR bindings, which do not exist in platform_bindings/linux yet.
+//
+// Reuses the live display connection in `s` when `init` has already run -- opening a second
+// connection to talk to the same server that a window is already open on would be pointless. Only
+// when there is no live state does this open a temporary connection, and then it closes only the
+// connection it opened itself; `x11_shutdown` nils `s`, so a stale, freed `s` is never read here.
+//
+// When it does open its own connection, it closes that connection before returning, but never
+// calls `X.unload()`. `X.unload()` is not reference counted: it closes the libraries and clears the
+// handles no matter who else is using them, so a query made while a window is open would pull
+// libX11 out from under that window. Loading is idempotent and the libraries are shared for the
+// life of the process, so leaving them loaded is the correct thing.
+x11_get_monitor_count :: proc() -> int {
+	if s != nil && s.display != nil {
+		return 1
+	}
+
+	_, load_ok := X.load()
+
+	if !load_ok {
+		return 0
+	}
+
+	display := X.OpenDisplay(nil)
+
+	if display == nil {
+		return 0
+	}
+
+	X.CloseDisplay(display)
+	return 1
+}
+
+x11_get_monitor_info :: proc(monitor: int) -> (Monitor_Info, bool) {
+	if monitor != 0 {
+		return {}, false
+	}
+
+	display: ^X.Display
+	resource_manager: X.Atom
+	opened_here := false
+
+	if s != nil && s.display != nil {
+		display = s.display
+		resource_manager = s.resource_manager
+	} else {
+		_, load_ok := X.load()
+
+		if !load_ok {
+			return {}, false
+		}
+
+		display = X.OpenDisplay(nil)
+
+		if display == nil {
+			return {}, false
+		}
+
+		opened_here = true
+		resource_manager = X.InternAtom(display, "RESOURCE_MANAGER", false)
+	}
+
+	screen := X.DefaultScreen(display)
+
+	info := Monitor_Info {
+		size = {int(X.DisplayWidth(display, screen)), int(X.DisplayHeight(display, screen))},
+		position = {0, 0},
+		scale = x11_fetch_scale_from_display(display, resource_manager),
+	}
+
+	if opened_here {
+		X.CloseDisplay(display)
+	}
+
+	return info, true
 }
 
 enter_borderless_fullscreen :: proc() {

--- a/platform_mac.odin
+++ b/platform_mac.odin
@@ -32,6 +32,9 @@ PLATFORM_MAC :: Platform_Interface {
 	get_window_scale = mac_get_window_scale,
 	set_window_mode = mac_set_window_mode,
 
+	get_monitor_count = mac_get_monitor_count,
+	get_monitor_info = mac_get_monitor_info,
+
 	set_cursor_hidden = mac_set_cursor_hidden,
 	is_cursor_hidden = mac_is_cursor_hidden,
 	set_mouse_locked = mac_set_mouse_locked,
@@ -50,6 +53,26 @@ PLATFORM_MAC :: Platform_Interface {
 
 HAPTICS_SHARPNESS_LEFT  :: 0.1
 HAPTICS_SHARPNESS_RIGHT :: 0.9
+
+basic_setup_done: bool
+
+// Process-wide OS state that has to exist before anything asks about monitors. `mac_init` creates
+// the shared application itself, so it never needs this, but the monitor queries have to work
+// without `init` ever having run.
+//
+// Only put things here that are harmless to run twice. Nothing that needs releasing: a hot reload
+// zeroes `basic_setup_done`, so this can run again in the same process.
+mac_ensure_basic_setup :: proc() {
+	if basic_setup_done {
+		return
+	}
+
+	// NSScreen is only dependable once the shared application object exists. This is an OS
+	// singleton, so calling it again is free -- but keep this rule: only things that are harmless
+	// to repeat belong here, nothing that would need releasing.
+	NS.Application_sharedApplication()
+	basic_setup_done = true
+}
 
 Mac_State :: struct {
 	odin_ctx:         runtime.Context,
@@ -321,6 +344,7 @@ mac_shutdown :: proc() {
 	a := s.allocator
 	free(s.gc_connect_blk, a)
 	free(s.gc_disconnect_blk, a)
+	s = nil
 }
 
 mac_get_window_render_glue :: proc() -> Window_Render_Glue {
@@ -549,6 +573,61 @@ mac_set_screen_size :: proc(w, h: int) {
 
 mac_get_window_scale :: proc() -> f32 {
 	return f32(s.window->backingScaleFactor())
+}
+
+// There is nothing in Mac_State to reuse even when `s` is live: NSScreen.screens is a process-wide
+// query, not tied to a window.
+mac_get_monitor_count :: proc() -> int {
+	mac_ensure_basic_setup()
+	return int(NS.Array_count(NS.Screen_screens()))
+}
+
+mac_get_monitor_info :: proc(monitor: int) -> (Monitor_Info, bool) {
+	mac_ensure_basic_setup()
+
+	screens := NS.Screen_screens()
+	count := int(NS.Array_count(screens))
+
+	if monitor < 0 || monitor >= count {
+		return {}, false
+	}
+
+	// Karl2D promises that monitor 0 is the primary one. `NSScreen.screens` is widely observed to
+	// put the primary first, but that is someone else's ordering to change, so find it ourselves
+	// instead of trusting it: in Cocoa's global coordinate space the primary screen is by
+	// definition the one at the origin. Then swap it with index 0, the same way the Windows
+	// backend does after `EnumDisplayMonitors`, which promises no order at all.
+	primary := 0
+
+	for i in 0..<count {
+		candidate := NS.Array_objectAs(screens, NS.UInteger(i), ^NS.Screen)
+		origin := candidate->frame().origin
+
+		if origin.x == 0 && origin.y == 0 {
+			primary = i
+			break
+		}
+	}
+
+	index := monitor
+
+	if monitor == 0 {
+		index = primary
+	} else if monitor == primary {
+		index = 0
+	}
+
+	screen := NS.Array_objectAs(screens, NS.UInteger(index), ^NS.Screen)
+	frame := screen->frame()
+	scale := f32(screen->backingScaleFactor())
+
+	// Both size and position are in points; multiplied by the scale to match the physical pixels
+	// the rest of Karl2D uses.
+	return Monitor_Info {
+		size = {int(f32(frame.width) * scale), int(f32(frame.height) * scale)},
+		position = {int(f32(frame.x) * scale), int(f32(frame.y) * scale)},
+		scale = scale,
+	}, true
 }
 
 mac_set_cursor_hidden :: proc(hidden: bool) {

--- a/platform_web.odin
+++ b/platform_web.odin
@@ -21,6 +21,9 @@ PLATFORM_WEB :: Platform_Interface {
 	get_window_scale = web_get_window_scale,
 	set_window_mode = web_set_window_mode,
 
+	get_monitor_count = web_get_monitor_count,
+	get_monitor_info = web_get_monitor_info,
+
 	set_cursor_hidden = web_set_cursor_hidden,
 	is_cursor_hidden = web_is_cursor_hidden,
 	set_mouse_locked = web_set_mouse_locked,
@@ -46,6 +49,12 @@ import hm "core:container/handle_map"
 import "log"
 import "core:fmt"
 
+// The canvas element's id. `s.canvas_id` is not available before `init`, so the monitor query below
+// uses this constant directly instead, and `web_init` uses it too so both agree on the same id.
+// Karl2D cannot run without the canvas, unlike `id="body"`, which a page not built from
+// `index_template.html` may not have kept.
+WEB_CANVAS_ID :: "webgl-canvas"
+
 web_state_size :: proc() -> int {
 	return size_of(Web_State)
 }
@@ -62,7 +71,7 @@ web_init :: proc(
 	s.allocator = allocator
 	s.events = make([dynamic]Event, allocator)
 	s.key_from_js_event_key_code = make(map[string]Keyboard_Key, allocator)
-	s.canvas_id = "webgl-canvas"
+	s.canvas_id = WEB_CANVAS_ID
 	hm.dynamic_init(&s.custom_cursors, allocator)
 
 	js.set_document_title(window_title)
@@ -329,6 +338,7 @@ web_shutdown :: proc() {
 
 	delete(s.events)
 	delete(s.key_from_js_event_key_code)
+	s = nil
 }
 
 web_get_window_render_glue :: proc() -> Window_Render_Glue {
@@ -451,6 +461,38 @@ web_set_screen_size :: proc(w, h: int) {
 
 web_get_window_scale :: proc() -> f32 {
 	return f32(js.device_pixel_ratio())
+}
+
+// window.screen.width/height are not exposed by core:sys/wasm/js, so this stashes them on the
+// canvas element with js.evaluate and reads them back with get_element_key_f64, the same trick
+// _web_event_pointer_lock_change uses for the pointer lock state. No setup is needed before this,
+// unlike Windows and Mac: the DOM already knows the screen size.
+WEB_MONITOR_SIZE_EVAL :: "var karl2d_el = document.getElementById('" + WEB_CANVAS_ID + "'); " +
+	"karl2d_el._screenWidth = window.screen.width; " +
+	"karl2d_el._screenHeight = window.screen.height;"
+
+// There is nothing in Web_State to reuse even when `s` is live: window.screen is DOM-global, not
+// tied to a window, and `s.canvas_id` is always WEB_CANVAS_ID anyway (see web_init).
+web_get_monitor_count :: proc() -> int {
+	return 1
+}
+
+web_get_monitor_info :: proc(monitor: int) -> (Monitor_Info, bool) {
+	if monitor != 0 {
+		return {}, false
+	}
+
+	js.evaluate(WEB_MONITOR_SIZE_EVAL)
+
+	scale := f32(js.device_pixel_ratio())
+	width := f32(js.get_element_key_f64(WEB_CANVAS_ID, "_screenWidth"))
+	height := f32(js.get_element_key_f64(WEB_CANVAS_ID, "_screenHeight"))
+
+	return Monitor_Info {
+		size = {int(width * scale), int(height * scale)},
+		position = {0, 0},
+		scale = scale,
+	}, true
 }
 
 web_set_window_mode :: proc(new_mode: Window_Mode) {

--- a/platform_windows.odin
+++ b/platform_windows.odin
@@ -20,6 +20,9 @@ PLATFORM_WINDOWS :: Platform_Interface {
 	get_window_scale = windows_get_window_scale,
 	set_window_mode = windows_set_window_mode,
 
+	get_monitor_count = windows_get_monitor_count,
+	get_monitor_info = windows_get_monitor_info,
+
 	set_cursor_hidden = windows_set_cursor_hidden,
 	is_cursor_hidden = windows_is_cursor_hidden,
 	set_mouse_locked = windows_set_mouse_locked,
@@ -44,6 +47,24 @@ import "base:runtime"
 import hm "core:container/handle_map"
 @require import "log"
 
+basic_setup_done: bool
+
+// Process-wide OS state that has to be set before anything asks about monitors or window sizes.
+// Until it is, the process is DPI unaware and Windows reports virtualized numbers: on a 3840x2160
+// display at 150% scaling `GetMonitorInfoW` says 2560x1440 and `GetDpiForMonitor` says 96.
+//
+// Only put things here that are harmless to run twice. Nothing that needs freeing: a hot reload
+// zeroes `basic_setup_done`, so this can run again in the same process.
+windows_ensure_basic_setup :: proc() {
+	if basic_setup_done {
+		return
+	}
+
+	win32.SetProcessDpiAwarenessContext(win32.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)
+	win32.SetProcessDPIAware()
+	basic_setup_done = true
+}
+
 windows_state_size :: proc() -> int {
 	return size_of(Windows_State)
 }
@@ -63,8 +84,7 @@ windows_init :: proc(
 	s.custom_context = context
 	hm.dynamic_init(&s.custom_cursors, allocator)
 
-	win32.SetProcessDpiAwarenessContext(win32.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)
-	win32.SetProcessDPIAware()
+	windows_ensure_basic_setup()
 	CLASS_NAME :: "karl2d"
 	instance := win32.HINSTANCE(win32.GetModuleHandleW(nil))
 
@@ -140,6 +160,7 @@ windows_shutdown :: proc() {
 
 	win32.DestroyWindow(s.hwnd)
 	delete(s.events)
+	s = nil
 }
 
 windows_get_window_render_glue :: proc() -> Window_Render_Glue {
@@ -1107,4 +1128,88 @@ WIN32_VK_MAP := [255]Keyboard_Key {
 	// NP_Enter is handled separately
 
 	win32.VK_OEM_NEC_EQUAL = .NP_Equal,
+}
+
+// Not bound in core:sys/windows.
+MONITORINFOF_PRIMARY :: 0x00000001
+
+WINDOWS_MONITOR_COUNT_MAX :: 16
+
+Windows_Monitor_List :: struct {
+	items: [WINDOWS_MONITOR_COUNT_MAX]Monitor_Info,
+	count: int,
+	primary_index: int,
+}
+
+// Enumerated fresh on every call rather than cached in Windows_State, since these queries have to
+// work when there is no state to cache it in yet. There is also nothing in Windows_State to reuse
+// even when `s` is live: EnumDisplayMonitors is a process-wide query, not tied to a window.
+windows_collect_monitors :: proc() -> Windows_Monitor_List {
+	windows_ensure_basic_setup()
+
+	list: Windows_Monitor_List
+	win32.EnumDisplayMonitors(nil, nil, windows_monitor_enum_proc, win32.LPARAM(uintptr(&list)))
+
+	// The primary monitor must be at index 0. EnumDisplayMonitors doesn't guarantee an order, so
+	// swap it into place after enumerating.
+	if list.primary_index != 0 && list.primary_index < list.count {
+		list.items[0], list.items[list.primary_index] = list.items[list.primary_index], list.items[0]
+	}
+
+	return list
+}
+
+windows_monitor_enum_proc :: proc "system" (
+	hmonitor: win32.HMONITOR,
+	hdc: win32.HDC,
+	rect: win32.LPRECT,
+	lparam: win32.LPARAM,
+) -> win32.BOOL {
+	context = runtime.default_context()
+
+	list := (^Windows_Monitor_List)(uintptr(lparam))
+
+	if list.count >= WINDOWS_MONITOR_COUNT_MAX {
+		return false
+	}
+
+	mi := win32.MONITORINFO { cbSize = size_of(win32.MONITORINFO) }
+
+	if !win32.GetMonitorInfoW(hmonitor, &mi) {
+		return true
+	}
+
+	dpix, dpiy: win32.UINT
+	win32.GetDpiForMonitor(hmonitor, {}, &dpix, &dpiy)
+
+	if mi.dwFlags & MONITORINFOF_PRIMARY != 0 {
+		list.primary_index = list.count
+	}
+
+	list.items[list.count] = Monitor_Info {
+		size = {
+			int(mi.rcMonitor.right - mi.rcMonitor.left),
+			int(mi.rcMonitor.bottom - mi.rcMonitor.top),
+		},
+		position = {int(mi.rcMonitor.left), int(mi.rcMonitor.top)},
+		scale = f32(dpix) / 96.0,
+	}
+	list.count += 1
+
+	return true
+}
+
+windows_get_monitor_count :: proc() -> int {
+	list := windows_collect_monitors()
+	return list.count
+}
+
+windows_get_monitor_info :: proc(monitor: int) -> (Monitor_Info, bool) {
+	list := windows_collect_monitors()
+
+	if monitor < 0 || monitor >= list.count {
+		return {}, false
+	}
+
+	return list.items[monitor], true
 }

--- a/tools/test_examples/test_examples.odin
+++ b/tools/test_examples/test_examples.odin
@@ -33,6 +33,7 @@ main :: proc() {
 		"minimal_hello_world",
 		"custom_frame_update",
 		"events",
+		"monitors",
 		"premultiplied_alpha",
 		"raylib_ports",
 		"scaling_auto_window_resize",


### PR DESCRIPTION
Adds four procedures that report the connected monitors. They work without `k2.init` having been called, so a program can size its window from the display it is about to open on.

```odin
size := k2.get_monitor_size()
k2.init(size.x/2, size.y/2, "My Game")
```

They are ordinary members of `Platform_Interface`. What makes them callable that early is that `pf` is now a compile-time constant instead of a global assigned during `init`.

## API changes

`State` loses its `platform: Platform_Interface` field. Nothing else that existed before changed, and no example needed a change.

New:

- `get_monitor_count :: proc() -> int`
- `get_monitor_size :: proc(monitor := MONITOR_PRIMARY) -> [2]int`
- `get_monitor_position :: proc(monitor := MONITOR_PRIMARY) -> [2]int`
- `get_monitor_scale :: proc(monitor := MONITOR_PRIMARY) -> f32`
- `MONITOR_PRIMARY :: 0`

Sizes and positions are in physical pixels, matching what `set_screen_size` takes. Asking for a monitor that does not exist logs and returns the zero value.

## Other changes

- `pf` is a constant in the new `platform_chooser.odin`, in the style of `render_backend_chooser.odin`. The platform was always picked at compile time, so storing the interface in `State` and copying it out during `init` bought nothing. `set_internal_state` no longer restores it either, which also means a hot reload can no longer hand back procedure pointers into the previous code image.
- Each backend does whatever process wide setup it needs on demand, behind a flag, so the queries work before `init` and cost nothing after it. Only things that are harmless to run twice go behind that flag, and nothing that needs freeing, since a hot reload zeroes it.
- Windows sets DPI awareness there rather than in `windows_init`. Without it the process is DPI unaware and Windows reports virtualized numbers: 2560x1440 at 96 DPI for a display that is really 3840x2160 at 144.
- The Linux windowing choice moves out of `Linux_State` into that same setup, so the monitor queries and `linux_init` cannot disagree about whether the session is Wayland or X11. Only a successful resolution is remembered, so `linux_init` can still name both failure reasons in its panic.
- Every platform backend now clears its state pointer in `shutdown`. It did not before, so `s != nil` meant "init ran at some point" rather than "the state is live", and reading through it after `shutdown` was a use after free.
- The queries reuse state `init` already set up when it is there. X11 uses the open display and its resource manager atom instead of connecting again, and opens a temporary connection only when there is none, closing only what it opened. Windows, mac and web have nothing to reuse.
- Monitor 0 is the primary one, and no operating system gives that for free. `EnumDisplayMonitors` documents no order, so the Windows backend finds `MONITORINFOF_PRIMARY` and swaps it to index 0. The mac backend finds the screen at the origin and does the same rather than trusting the order of `NSScreen.screens`.
- `X.load` is idempotent and the queries never call `X.unload`. It is not reference counted, so a query made while a window was open would close libX11 under that window.
- Wayland reports zero monitors rather than one of unknown size, so a caller can tell there is no answer. Real support needs a `wl_output` global and listener.
- Added `DisplayWidth` and `DisplayHeight` to the X11 bindings. These are core Xlib.
- New `examples/monitors`, excluded from web builds because it uses a plain `main` rather than `init`/`step`.

Created with the help of Claude Code
