### PR TITLE
Require server-side decorations on Wayland

### DIFF
--- a/platform_linux.odin
+++ b/platform_linux.odin
@@ -70,25 +70,23 @@ linux_init :: proc(
 	//
 	// Wayland goes first, the way SDL and GLFW order them. `KARL2D_LINUX_WINDOWING` swaps the
 	// order, for when both work but the preferred one behaves badly.
+	//
+	// Wayland also turns itself down where the compositor leaves decorations to the client, since
+	// Karl2D draws no titlebar of its own. That is what sends GNOME here to X11, where the
+	// compositor decorates the window.
 	first := LINUX_WINDOW_WAYLAND
 	second := LINUX_WINDOW_X11
 
-	// Whether the player asked for a particular windowing system. Only then is it worth saying
-	// that the first choice was turned down. The default order falling through to X11 is ordinary
-	// detection on an X11 machine, not something anyone needs to read about.
-	preference_given := false
 	windowing_preference := os.get_env("KARL2D_LINUX_WINDOWING", frame_allocator)
 
 	switch windowing_preference {
 	case "":
 
 	case "wayland":
-		preference_given = true
 
 	case "x11":
 		first = LINUX_WINDOW_X11
 		second = LINUX_WINDOW_WAYLAND
-		preference_given = true
 
 	case:
 		log.warnf(
@@ -115,9 +113,10 @@ linux_init :: proc(
 			)
 		}
 
-		if preference_given {
-			log.info(first_failure_reason)
-		}
+		// Always said, not just when the player asked for a windowing system by name. Wayland is
+		// now turned down on compositors that work fine but leave decorations to the client, and
+		// landing on X11 for that reason is worth a line rather than a silent switch.
+		log.info(first_failure_reason)
 	}
 
 	win_state_alloc_error: runtime.Allocator_Error

--- a/platform_linux_window_wayland.odin
+++ b/platform_linux_window_wayland.odin
@@ -73,7 +73,23 @@ wl_try_load :: proc(
 		return "Not using Wayland. Could not connect to a compositor.", false
 	}
 
+	// Karl2D never draws a titlebar, so a Wayland window is only usable where the compositor
+	// draws one. The same connection answers that: zxdg_decoration_manager_v1 is how a
+	// compositor offers server-side decorations, and its absence is how GNOME says that clients
+	// are expected to decorate themselves.
+	decorations_offered := false
+	registry := wl.display_get_registry(display)
+	wl.add_listener(registry, &decoration_probe_listener, &decorations_offered)
+	wl.display_roundtrip(display)
+	wl.destroy(registry)
+
 	wl.display_disconnect(display)
+
+	if !decorations_offered {
+		wl.unload()
+		return "Not using Wayland. The compositor does not offer server-side window decorations " +
+			"and Karl2D does not draw its own titlebar.", false
+	}
 
 	if missing, load_ok := xkb.load(); !load_ok {
 		wl.unload()
@@ -135,12 +151,19 @@ wl_init :: proc(
 
 	wl_set_window_mode(options.window_mode)
 
-	if s.decoration_manager != nil {
-		decoration := wl.zxdg_decoration_manager_v1_get_toplevel_decoration(s.decoration_manager, s.toplevel)
+	// `wl_try_load` turns Wayland down where this global is missing, so it is always here.
+	log.ensure(s.decoration_manager != nil, "Wayland compositor offers no window decorations")
 
-		// This adds titlebar and buttons to the window.
-		wl.zxdg_toplevel_decoration_v1_set_mode(decoration, wl.ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE)
-	}
+	decoration := wl.zxdg_decoration_manager_v1_get_toplevel_decoration(
+		s.decoration_manager,
+		s.toplevel,
+	)
+
+	// This adds titlebar and buttons to the window.
+	wl.zxdg_toplevel_decoration_v1_set_mode(
+		decoration,
+		wl.ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE,
+	)
 
 	if s.fractional_scale_manager != nil {
 		fractional_scale := wl.wp_fractional_scale_manager_get_fractional_scale(
@@ -196,6 +219,24 @@ wl_init :: proc(
 	if options.disable_auto_scale_hint {
 		log.warn("disable_auto_scale_hint not supported on linux/wayland")
 	}
+}
+
+// Used by `wl_try_load`, which runs before there is a `WL_State` to write into, so this reports
+// through its `data` pointer instead of through `s`. It also binds nothing: the connection it
+// looks at is thrown away again, and `registry_listener` binds the globals on the one that stays.
+decoration_probe_listener := wl.Registry_Listener {
+	global = proc "c" (
+		data: rawptr,
+		registry: ^wl.Registry,
+		name: u32,
+		interface: cstring,
+		version: u32,
+	) {
+		if interface == wl.zxdg_decoration_manager_v1_interface.name {
+			(^bool)(data)^ = true
+		}
+	},
+	global_remove = proc "c" (data: rawptr, registry: ^wl.Registry, name: u32) {},
 }
 
 registry_listener := wl.Registry_Listener {


### PR DESCRIPTION
Wayland now turns itself down when the compositor does not offer `zxdg_decoration_manager_v1`, and the backend chooser falls through to X11. Karl2D draws no titlebar of its own, so a Wayland window is only usable where the compositor draws one. On GNOME this means the game runs on X11, where Mutter decorates the window server-side. KDE, sway and Hyprland are unaffected and keep using Wayland.

This replaces #252, which drew the decorations with libdecor instead. libdecor turned out to repaint the whole decoration on every hover state change, which drops a 1280x720 window from 90 fps to 1 fps when the pointer rests on a decoration edge. SDL3 has the same problem on the same machine, so it is a libdecor bug rather than ours, but it makes the libdecor path worse than X11 on GNOME today.

No API changes.

- The check lives in `wl_try_load`, on the connection it already makes and throws away. `decoration_probe_listener` reports through its `data` pointer, since there is no `WL_State` yet at that point and it binds nothing.
- `wl_init` no longer treats the decoration manager as optional. `wl_try_load` guarantees it, so there is a `log.ensure` and the decoration is always created.
- The reason the first windowing system was turned down is now always logged, not only when `KARL2D_LINUX_WINDOWING` named one. Landing on X11 because the compositor will not decorate is worth a line rather than a silent switch, and `preference_given` goes away with it.

Created with the help of Claude Code