### PR TITLE
fix switching to windowed

### DIFF
--- a/platform_windows.odin
+++ b/platform_windows.odin
@@ -120,6 +120,11 @@ windows_init :: proc(
 
 	assert(s.hwnd != nil, "Failed creating window")
 
+	// A window that starts in fullscreen has no previous windowed WM_MOVE/WM_SIZE messages from
+	// which to populate the restore rectangle. But the window was initially created at a requested
+	// size, so remember it before expanding to the monitor.
+	windows_capture_windowed_geometry()
+
 	windows_set_window_mode(options.window_mode)
 	
 	win32.XInputEnable(true)
@@ -328,6 +333,29 @@ windows_get_window_position :: proc() -> Vec2 {
 	return {f32(r.left), f32(r.top)}
 }
 
+windows_capture_windowed_geometry :: proc() {
+	r: win32.RECT
+	if !win32.GetClientRect(s.hwnd, &r) {
+		return
+	}
+
+	client_origin := win32.POINT{r.left, r.top}
+	if !win32.ClientToScreen(s.hwnd, &client_origin) {
+		return
+	}
+
+	width := int(r.right - r.left)
+	height := int(r.bottom - r.top)
+	if width <= 0 || height <= 0 {
+		return
+	}
+
+	s.restore_window_pos_x = int(client_origin.x)
+	s.restore_window_pos_y = int(client_origin.y)
+	s.restore_screen_width = width
+	s.restore_screen_height = height
+}
+
 windows_get_style :: proc(window_mode: Window_Mode) -> win32.DWORD {
 	style: win32.DWORD
 
@@ -505,7 +533,7 @@ windows_set_window_mode :: proc(window_mode: Window_Mode) {
 	switch window_mode {
 	case .Windowed, .Windowed_Resizable:
 		r: win32.RECT
-		set_window_pos_style: win32.DWORD = win32.SWP_NOACTIVATE | win32.SWP_NOZORDER
+		set_window_pos_style: win32.DWORD = win32.SWP_NOACTIVATE | win32.SWP_NOZORDER | win32.SWP_FRAMECHANGED
 
 		if old_window_mode == .Borderless_Fullscreen {
 			r.left = i32(s.restore_window_pos_x)


### PR DESCRIPTION
My game has a toggle (F11) for Fullscreen/Windowed modes, and it opens in fullscreen from the get go. But once it's up, if I hit F11 to go into Windowed, then the window will be super small and almost invisible (Windows backend). Happens because the backend doesn't record the initial window size for the fullscreen path. This PR fixes that.

---

## Rules Checklist

You can always submit a draft pull request. But when you make your Pull Request "ready for review", then please make sure these rules are followed (put an x between each [ ]):
- [x] Make sure that the code you submit is working and tested.
- [x] Do not submit "basic" or "rudimentary" code that needs further work to actually be finished. Finish the code to the best of your abilities.
- [x] Do not modify any code that is unrelated to your changes. That just makes reviewing your code harder: I'll have a hard time seeing what you actually did. Do not use auto formatters such as odinfmt.
- [x] If you used an LLM to generate any code, then make that you understand every single line. In other words: No form of "vibe coded" PRs are allowed.
- [x] If you commit changes that were unintended, just do additional commits that undo them. Don't worry about polluting the commit history: I will do a "squash merge" of your Pull Request. Just make sure that the diff in the "Files changed" tab looks tidy.
- [x] If the GitHub testing action complain about the `karl2d.doc.odin` file being out-of-date, then please regenerate it by running `odin run tools/api_doc_builder`. This way you'll have an easier time seeing if you've made changes to the user-facing API.
- [x] Make sure that the code follows the same style as in `karl2d.odin`:
	- Please look through that file and pay attention to how characters such as `:` `=`, `(` `{` etc are placed.
	- Use tabs, not spaces.
	- Lines cannot be longer than 100 characters. See the `init` proc in `karl2d.odin` for an example of how to split up procedure signatures that are too long. That proc also shows how to write API comments. Use a ruler in your editor to make it easy to spot long lines.
