### PR TITLE
Add main.wasm preload link to html template

### DIFF
--- a/build_web/web_entry_templates/index_template.html
+++ b/build_web/web_entry_templates/index_template.html
@@ -7,6 +7,7 @@
 
 		<!-- Karl2D fills in the href: with its default icon at init and from set_window_icon. -->
 		<link id="karl2d-favicon" rel="icon" href="">
+		<link rel="preload" href="main.wasm" as="fetch" type="application/wasm" crossorigin="anonymous" />
 	</head>
 	<body id="body" style="height: 100%; padding: 0; margin: 0; overflow: hidden; background-color: black;">
 		<!-- touch-action: none keeps the browser from turning touches into page scroll/zoom, and stops

--- a/build_web/web_entry_templates/index_template.html
+++ b/build_web/web_entry_templates/index_template.html
@@ -7,7 +7,7 @@
 
 		<!-- Karl2D fills in the href: with its default icon at init and from set_window_icon. -->
 		<link id="karl2d-favicon" rel="icon" href="">
-		<link rel="preload" href="main.wasm" as="fetch" type="application/wasm" crossorigin="anonymous" />
+		<link rel="preload" href="main.wasm" as="fetch" type="application/wasm" crossorigin="anonymous">
 	</head>
 	<body id="body" style="height: 100%; padding: 0; margin: 0; overflow: hidden; background-color: black;">
 		<!-- touch-action: none keeps the browser from turning touches into page scroll/zoom, and stops


### PR DESCRIPTION
This just makes the browser start downloading the `main.wasm` file when it's parsing the html, instead of when executing the inline js.