### PR TITLE
Replace fontstash with own font cache

### DIFF
--- a/font_cache/font_cache.odin
+++ b/font_cache/font_cache.odin
@@ -317,7 +317,7 @@ kern :: proc(font: ^Font, prev_index: i32, index: i32, size: int) -> f32 {
 	return f32(advance) * stbtt.ScaleForPixelHeight(&font.info, f32(size))
 }
 
-iterator_init :: proc(text: string, size: int, time: f64) -> Iterator {
+place_text_iterator_init :: proc(text: string, size: int, time: f64) -> Iterator {
 	return {
 		text = text,
 		size = size,
@@ -326,7 +326,7 @@ iterator_init :: proc(text: string, size: int, time: f64) -> Iterator {
 	}
 }
 
-iterate :: proc(font: ^Font, it: ^Iterator) -> (Placed_Glyph, Iterator_Result) {
+place_text_iterate :: proc(font: ^Font, it: ^Iterator) -> (Placed_Glyph, Iterator_Result) {
 	for len(it.text) > 0 {
 		codepoint, codepoint_width := utf8.decode_rune(it.text)
 
@@ -376,13 +376,13 @@ iterate :: proc(font: ^Font, it: ^Iterator) -> (Placed_Glyph, Iterator_Result) {
 }
 
 measure :: proc(font: ^Font, text: string, size: int, time: f64) -> ([2]f32, bool) {
-	it := iterator_init(text, size, time)
+	it := place_text_iterator_init(text, size, time)
 	width: f32
 
 	placed_res := Iterator_Result.Placed
 
 	for placed_res == .Placed {
-		_, placed_res = iterate(font, &it)
+		_, placed_res = place_text_iterate(font, &it)
 		width = max(width, it.x)
 	}
 

--- a/font_cache/font_cache.odin
+++ b/font_cache/font_cache.odin
@@ -146,9 +146,9 @@ get_glyph :: proc(
 	glyph := Glyph {
 		offset = {
 			f32(x0 - GLYPH_PADDING),
-			f32(y0 - GLYPH_PADDING) + font.ascent * f32(size),
+			f32(y0 - GLYPH_PADDING) + math.round(font.ascent * f32(size)),
 		},
-		advance = f32(advance) * scale,
+		advance = math.round(f32(advance) * scale),
 		index = index,
 	}
 
@@ -303,7 +303,7 @@ kern :: proc(font: ^Font, prev_index: i32, index: i32, size: int) -> f32 {
 		font.kerning[pair] = advance
 	}
 
-	return f32(advance) * (f32(size) / font.height_units)
+	return math.round(f32(advance) * (f32(size) / font.height_units))
 }
 
 // ---
@@ -384,8 +384,8 @@ place_text_iterate :: proc(
 
 		placed := Placed_Glyph {
 			glyph = glyph,
-			x = math.floor(it.x + glyph.offset.x),
-			y = math.floor(it.y + glyph.offset.y),
+			x = it.x + glyph.offset.x,
+			y = it.y + glyph.offset.y,
 		}
 
 		it.x += glyph.advance

--- a/font_cache/font_cache.odin
+++ b/font_cache/font_cache.odin
@@ -1,0 +1,489 @@
+// The skyline rectangle packing in this file is ported from Fontstash by Mikko Mononen. Fontstash
+// is licensed under the zlib license: https://github.com/memononen/fontstash
+package karl2d_font_cache
+
+import "base:runtime"
+import "core:math"
+import "core:slice"
+import "core:unicode/utf8"
+import stbtt "vendor:stb/truetype"
+
+PAGE_START_SIZE :: 256
+PAGE_MAX_SIZE :: 1024
+MAX_PAGES :: 4
+GLYPH_PADDING :: 1
+
+Font_Cache :: struct {
+	info: stbtt.fontinfo,
+	data: []u8,
+	ascent: f32,
+	glyphs: map[Glyph_Key]Glyph,
+	kerning: map[[2]i32]i32,
+	pages: [dynamic]Page,
+	frame: int,
+	allocator: runtime.Allocator,
+}
+
+Glyph_Key :: struct {
+	codepoint: rune,
+	size: int,
+}
+
+Glyph :: struct {
+	page: int,
+	x: int,
+	y: int,
+	width: int,
+	height: int,
+	offset: [2]f32,
+	advance: f32,
+	index: i32,
+}
+
+Page :: struct {
+	pixels: []u8,
+	width: int,
+	height: int,
+	nodes: [dynamic]Skyline_Node,
+	glyph_keys: [dynamic]Glyph_Key,
+	dirty_min: [2]int,
+	dirty_max: [2]int,
+	last_used: int,
+	reset_frame: int,
+}
+
+Skyline_Node :: struct {
+	x: int,
+	y: int,
+	width: int,
+}
+
+Text_Iterator :: struct {
+	text: string,
+	size: int,
+	x: f32,
+	y: f32,
+	prev_index: i32,
+}
+
+Placed_Glyph :: struct {
+	glyph: Glyph,
+	x: f32,
+	y: f32,
+}
+
+Text_Iterator_Result :: enum {
+	Placed,
+	Done,
+	No_Room,
+}
+
+init :: proc(cache: ^Font_Cache, data: []u8, allocator: runtime.Allocator) -> bool {
+	info: stbtt.fontinfo
+	font_offset := stbtt.GetFontOffsetForIndex(raw_data(data), 0)
+
+	if !stbtt.InitFont(&info, raw_data(data), font_offset) {
+		return false
+	}
+
+	cache^ = {
+		info = info,
+		data = slice.clone(data, allocator),
+		glyphs = make(map[Glyph_Key]Glyph, allocator),
+		kerning = make(map[[2]i32]i32, allocator),
+		pages = make([dynamic]Page, allocator),
+		frame = 1,
+		allocator = allocator,
+	}
+
+	cache.info.data = raw_data(cache.data)
+
+	ascent, descent, line_gap: i32
+	stbtt.GetFontVMetrics(&cache.info, &ascent, &descent, &line_gap)
+	cache.ascent = f32(ascent) / f32(ascent - descent)
+
+	add_page(cache)
+	return true
+}
+
+destroy :: proc(cache: ^Font_Cache) {
+	for page in cache.pages {
+		delete(page.pixels, cache.allocator)
+		delete(page.nodes)
+		delete(page.glyph_keys)
+	}
+
+	delete(cache.pages)
+	delete(cache.glyphs)
+	delete(cache.kerning)
+	delete(cache.data, cache.allocator)
+	cache^ = {}
+}
+
+new_frame :: proc(cache: ^Font_Cache) {
+	cache.frame += 1
+}
+
+get_glyph :: proc(cache: ^Font_Cache, codepoint: rune, size: int) -> (Glyph, bool) {
+	key := Glyph_Key {
+		codepoint = codepoint,
+		size = size,
+	}
+
+	if glyph, glyph_ok := cache.glyphs[key]; glyph_ok {
+		if glyph.width > 0 {
+			cache.pages[glyph.page].last_used = cache.frame
+		}
+
+		return glyph, true
+	}
+
+	index := stbtt.FindGlyphIndex(&cache.info, codepoint)
+	scale := stbtt.ScaleForPixelHeight(&cache.info, f32(size))
+
+	advance, left_side_bearing: i32
+	stbtt.GetGlyphHMetrics(&cache.info, index, &advance, &left_side_bearing)
+
+	x0, y0, x1, y1: i32
+	stbtt.GetGlyphBitmapBox(&cache.info, index, scale, scale, &x0, &y0, &x1, &y1)
+
+	glyph := Glyph {
+		offset = {
+			f32(x0 - GLYPH_PADDING),
+			f32(y0 - GLYPH_PADDING) + cache.ascent * f32(size),
+		},
+		advance = f32(advance) * scale,
+		index = index,
+	}
+
+	bitmap_width := int(x1 - x0)
+	bitmap_height := int(y1 - y0)
+	padded_width := bitmap_width + GLYPH_PADDING * 2
+	padded_height := bitmap_height + GLYPH_PADDING * 2
+
+	if bitmap_width > 0 && bitmap_height > 0 &&
+	   padded_width <= PAGE_MAX_SIZE && padded_height <= PAGE_MAX_SIZE {
+		placed := false
+
+		for &page, page_idx in cache.pages {
+			x, y, fits := page_add_rect(&page, padded_width, padded_height)
+
+			if !fits {
+				continue
+			}
+
+			bitmap_x := x + GLYPH_PADDING
+			bitmap_y := y + GLYPH_PADDING
+
+			stbtt.MakeGlyphBitmap(
+				&cache.info,
+				raw_data(page.pixels[bitmap_x + bitmap_y * page.width:]),
+				i32(bitmap_width),
+				i32(bitmap_height),
+				i32(page.width),
+				scale,
+				scale,
+				index,
+			)
+
+			glyph.page = page_idx
+			glyph.x = x
+			glyph.y = y
+			glyph.width = padded_width
+			glyph.height = padded_height
+
+			page.dirty_min.x = min(page.dirty_min.x, x)
+			page.dirty_min.y = min(page.dirty_min.y, y)
+			page.dirty_max.x = max(page.dirty_max.x, x + padded_width)
+			page.dirty_max.y = max(page.dirty_max.y, y + padded_height)
+			page.last_used = cache.frame
+			append(&page.glyph_keys, key)
+			placed = true
+			break
+		}
+
+		if !placed {
+			return glyph, false
+		}
+	}
+
+	cache.glyphs[key] = glyph
+	return glyph, true
+}
+
+make_room :: proc(cache: ^Font_Cache) -> bool {
+	newest := &cache.pages[len(cache.pages) - 1]
+
+	if newest.width < PAGE_MAX_SIZE {
+		old_width := newest.width
+		old_height := newest.height
+		new_width := old_width * 2
+		new_height := old_height * 2
+		new_pixels := make([]u8, new_width * new_height, cache.allocator)
+
+		for y in 0..<old_height {
+			copy(new_pixels[y * new_width:], newest.pixels[y * old_width:(y + 1) * old_width])
+		}
+
+		delete(newest.pixels, cache.allocator)
+		newest.pixels = new_pixels
+		newest.width = new_width
+		newest.height = new_height
+		newest.dirty_min = {}
+		newest.dirty_max = { old_width, old_height }
+
+		append(&newest.nodes, Skyline_Node {
+			x = old_width,
+			y = 0,
+			width = new_width - old_width,
+		})
+
+		return true
+	}
+
+	if len(cache.pages) < MAX_PAGES {
+		add_page(cache)
+		return true
+	}
+
+	oldest := -1
+
+	for page, page_idx in cache.pages {
+		if page.reset_frame == cache.frame {
+			continue
+		}
+
+		if oldest == -1 || page.last_used < cache.pages[oldest].last_used {
+			oldest = page_idx
+		}
+	}
+
+	if oldest == -1 {
+		return false
+	}
+
+	page := &cache.pages[oldest]
+
+	for key in page.glyph_keys {
+		delete_key(&cache.glyphs, key)
+	}
+
+	clear(&page.glyph_keys)
+	clear(&page.nodes)
+	append(&page.nodes, Skyline_Node {
+		width = page.width,
+	})
+
+	slice.zero(page.pixels)
+	page.dirty_min = { page.width, page.height }
+	page.dirty_max = {}
+	page.reset_frame = cache.frame
+	return true
+}
+
+add_page :: proc(cache: ^Font_Cache) {
+	page := Page {
+		pixels = make([]u8, PAGE_START_SIZE * PAGE_START_SIZE, cache.allocator),
+		width = PAGE_START_SIZE,
+		height = PAGE_START_SIZE,
+		nodes = make([dynamic]Skyline_Node, cache.allocator),
+		glyph_keys = make([dynamic]Glyph_Key, cache.allocator),
+		dirty_min = { PAGE_START_SIZE, PAGE_START_SIZE },
+	}
+
+	append(&page.nodes, Skyline_Node {
+		width = PAGE_START_SIZE,
+	})
+
+	append(&cache.pages, page)
+}
+
+kern :: proc(cache: ^Font_Cache, prev_index: i32, index: i32, size: int) -> f32 {
+	pair := [2]i32 { prev_index, index }
+	advance, advance_ok := cache.kerning[pair]
+
+	if !advance_ok {
+		advance = stbtt.GetGlyphKernAdvance(&cache.info, prev_index, index)
+		cache.kerning[pair] = advance
+	}
+
+	return f32(advance) * stbtt.ScaleForPixelHeight(&cache.info, f32(size))
+}
+
+text_iterator_init :: proc(text: string, size: int) -> Text_Iterator {
+	return {
+		text = text,
+		size = size,
+		prev_index = -1,
+	}
+}
+
+text_iterator_next :: proc(
+	cache: ^Font_Cache,
+	it: ^Text_Iterator,
+) -> (
+	Placed_Glyph,
+	Text_Iterator_Result,
+) {
+	for len(it.text) > 0 {
+		codepoint, codepoint_width := utf8.decode_rune(it.text)
+
+		switch codepoint {
+		case '\r':
+			it.text = it.text[codepoint_width:]
+			continue
+
+		case '\n':
+			it.text = it.text[codepoint_width:]
+			it.x = 0
+			it.y += f32(it.size)
+			it.prev_index = -1
+			continue
+
+		case '\t':
+			it.text = it.text[codepoint_width:]
+			it.x += 2 * f32(it.size)
+			it.prev_index = -1
+			continue
+		}
+
+		glyph, glyph_ok := get_glyph(cache, codepoint, it.size)
+
+		if !glyph_ok {
+			return {}, .No_Room
+		}
+
+		it.text = it.text[codepoint_width:]
+
+		if it.prev_index != -1 {
+			it.x += kern(cache, it.prev_index, glyph.index, it.size)
+		}
+
+		placed := Placed_Glyph {
+			glyph = glyph,
+			x = math.floor(it.x + glyph.offset.x),
+			y = math.floor(it.y + glyph.offset.y),
+		}
+
+		it.x += glyph.advance
+		it.prev_index = glyph.index
+		return placed, .Placed
+	}
+
+	return {}, .Done
+}
+
+measure :: proc(cache: ^Font_Cache, text: string, size: int) -> ([2]f32, bool) {
+	it := text_iterator_init(text, size)
+	width: f32
+
+	placed_res := Text_Iterator_Result.Placed
+
+	for placed_res == .Placed {
+		_, placed_res = text_iterator_next(cache, &it)
+		width = max(width, it.x)
+	}
+
+	return { width, it.y + f32(size) }, placed_res == .Done
+}
+
+page_add_rect :: proc(page: ^Page, width: int, height: int) -> (int, int, bool) {
+	best_width := page.width
+	best_height := page.height
+	best_idx := -1
+	best_x := -1
+	best_y := -1
+
+	// Bottom left fit heuristic.
+	for node, node_idx in page.nodes {
+		y := page_rect_fits(page^, node_idx, width, height)
+
+		if y != -1 {
+			if y + height < best_height || (y + height == best_height && node.width < best_width) {
+				best_idx = node_idx
+				best_width = node.width
+				best_height = y + height
+				best_x = node.x
+				best_y = y
+			}
+		}
+	}
+
+	if best_idx == -1 {
+		return 0, 0, false
+	}
+
+	// Perform the actual packing.
+	page_add_skyline_level(page, best_idx, best_x, best_y, width, height)
+	return best_x, best_y, true
+}
+
+page_rect_fits :: proc(page: Page, idx: int, width: int, height: int) -> int {
+	// Checks if there is enough space at the location of skyline span 'i',
+	// and return the max height of all skyline spans under that at that location,
+	// (think tetris block being dropped at that position). Or -1 if no space found.
+
+	idx := idx
+	x := page.nodes[idx].x
+	y := page.nodes[idx].y
+
+	if x + width > page.width {
+		return -1
+	}
+
+	space_left := width
+
+	for space_left > 0 {
+		if idx == len(page.nodes) {
+			return -1
+		}
+
+		y = max(y, page.nodes[idx].y)
+
+		if y + height > page.height {
+			return -1
+		}
+
+		space_left -= page.nodes[idx].width
+		idx += 1
+	}
+
+	return y
+}
+
+page_add_skyline_level :: proc(page: ^Page, idx: int, x: int, y: int, width: int, height: int) {
+	// insert new node
+	inject_at(&page.nodes, idx, Skyline_Node {
+		x = x,
+		y = y + height,
+		width = width,
+	})
+
+	// Delete skyline segments that fall under the shadow of the new segment.
+	for i := idx + 1; i < len(page.nodes); i += 1 {
+		if page.nodes[i].x >= page.nodes[i-1].x + page.nodes[i-1].width {
+			break
+		}
+
+		shrink := page.nodes[i-1].x + page.nodes[i-1].width - page.nodes[i].x
+		page.nodes[i].x += shrink
+		page.nodes[i].width -= shrink
+
+		if page.nodes[i].width > 0 {
+			break
+		}
+
+		ordered_remove(&page.nodes, i)
+		i -= 1
+	}
+
+	// Merge same height skyline segments that are next to each other.
+	for i := 0; i < len(page.nodes) - 1; /**/ {
+		if page.nodes[i].y == page.nodes[i+1].y {
+			page.nodes[i].width += page.nodes[i+1].width
+			ordered_remove(&page.nodes, i+1)
+		} else {
+			i += 1
+		}
+	}
+}

--- a/font_cache/font_cache.odin
+++ b/font_cache/font_cache.odin
@@ -41,7 +41,8 @@ Glyph :: struct {
 	index: i32,
 }
 
-// A page will usually map to a texture. But the font cache doesn't know about textures.
+// A page is a CPU-side image into which glyphs have been blitted. Use dirty_min and dirty_max to
+// figure out which rectangle in it you need to upload to the GPU.
 Page :: struct {
 	pixels: []u8,
 	width: int,

--- a/font_cache/font_cache.odin
+++ b/font_cache/font_cache.odin
@@ -19,16 +19,14 @@ Font :: struct {
 	info: stbtt.fontinfo,
 	data: []u8,
 	ascent: f32,
+	scale_per_pixel: f32,
 	glyphs: map[Glyph_Key]Glyph,
 	kerning: map[[2]i32]i32,
 	pages: [dynamic]Page,
 	allocator: runtime.Allocator,
 }
 
-Glyph_Key :: struct {
-	codepoint: rune,
-	size: int,
-}
+Glyph_Key :: distinct u64
 
 Glyph :: struct {
 	page: int,
@@ -83,6 +81,7 @@ init :: proc(font: ^Font, data: []u8, allocator: runtime.Allocator) -> bool {
 	ascent, descent, line_gap: i32
 	stbtt.GetFontVMetrics(&font.info, &ascent, &descent, &line_gap)
 	font.ascent = f32(ascent) / f32(ascent - descent)
+	font.scale_per_pixel = 1 / f32(ascent - descent)
 
 	add_page(font)
 	return true
@@ -111,10 +110,7 @@ get_glyph :: proc(
 	Glyph,
 	bool,
 ) {
-	key := Glyph_Key {
-		codepoint = codepoint,
-		size = size,
-	}
+	key := Glyph_Key(u64(codepoint) << 32 | u64(u32(size)))
 
 	if glyph, glyph_ok := font.glyphs[key]; glyph_ok {
 		if glyph.width > 0 {
@@ -293,7 +289,7 @@ kern :: proc(font: ^Font, prev_index: i32, index: i32, size: int) -> f32 {
 		font.kerning[pair] = advance
 	}
 
-	return f32(advance) * stbtt.ScaleForPixelHeight(&font.info, f32(size))
+	return f32(advance) * f32(size) * font.scale_per_pixel
 }
 
 // ---

--- a/font_cache/font_cache.odin
+++ b/font_cache/font_cache.odin
@@ -5,7 +5,6 @@
 package karl2d_font_cache
 
 import "base:runtime"
-import "../log"
 import "core:math"
 import "core:slice"
 import "core:unicode/utf8"
@@ -60,16 +59,22 @@ Skyline_Node :: struct {
 	width: int,
 }
 
-init :: proc(font: ^Font, data: []u8, font_index: int, allocator: runtime.Allocator) -> bool {
+Init_Error :: enum {
+	None,
+	Font_Index_Out_Of_Range,
+	Invalid_Font_Data,
+}
+
+init :: proc(
+	font: ^Font,
+	data: []u8,
+	font_index: int,
+	allocator: runtime.Allocator,
+) -> Init_Error {
 	num_fonts := int(stbtt.GetNumberOfFonts(raw_data(data)))
 
 	if num_fonts > 0 && (font_index < 0 || font_index >= num_fonts) {
-		log.errorf(
-			"Cannot load font index %v, the font data contains %v fonts",
-			font_index,
-			num_fonts,
-		)
-		return false
+		return .Font_Index_Out_Of_Range
 	}
 
 	font^ = {
@@ -83,9 +88,8 @@ init :: proc(font: ^Font, data: []u8, font_index: int, allocator: runtime.Alloca
 	font_offset := stbtt.GetFontOffsetForIndex(raw_data(font.data), i32(font_index))
 
 	if !stbtt.InitFont(&font.info, raw_data(font.data), font_offset) {
-		log.error("Failed loading TTF/TTC font")
 		destroy(font)
-		return false
+		return .Invalid_Font_Data
 	}
 
 	ascent, descent, line_gap: i32
@@ -94,7 +98,7 @@ init :: proc(font: ^Font, data: []u8, font_index: int, allocator: runtime.Alloca
 	font.height_units = f32(ascent - descent)
 
 	add_page(font)
-	return true
+	return .None
 }
 
 destroy :: proc(font: ^Font) {

--- a/font_cache/font_cache.odin
+++ b/font_cache/font_cache.odin
@@ -314,7 +314,8 @@ Place_Text_Iterator_Result :: enum {
 	No_Room,
 }
 
-// A glyph that has been placed by the iterator. The x and y are moved along as it iterates.
+// A glyph that has been placed by the iterator. The x and y are the top-left of the glyph, relative
+// to the start of the text.
 Placed_Glyph :: struct {
 	glyph: Glyph,
 	x: f32,
@@ -330,7 +331,13 @@ place_text_iterator_init :: proc(text: string, size: int, time: f64) -> Place_Te
 	}
 }
 
-place_text_iterate :: proc(font: ^Font, it: ^Place_Text_Iterator) -> (Placed_Glyph, Place_Text_Iterator_Result) {
+place_text_iterate :: proc(
+	font: ^Font,
+	it: ^Place_Text_Iterator,
+) -> (
+	Placed_Glyph,
+	Place_Text_Iterator_Result,
+) {
 	for len(it.text) > 0 {
 		codepoint, codepoint_width := utf8.decode_rune(it.text)
 
@@ -383,14 +390,14 @@ measure :: proc(font: ^Font, text: string, size: int, time: f64) -> ([2]f32, boo
 	it := place_text_iterator_init(text, size, time)
 	width: f32
 
-	placed_res := Place_Text_Iterator_Result.Placed
+	place_res := Place_Text_Iterator_Result.Placed
 
-	for placed_res == .Placed {
-		_, placed_res = place_text_iterate(font, &it)
+	for place_res == .Placed {
+		_, place_res = place_text_iterate(font, &it)
 		width = max(width, it.x)
 	}
 
-	return { width, it.y + f32(size) }, placed_res == .Done
+	return { width, it.y + f32(size) }, place_res == .Done
 }
 
 page_add_rect :: proc(page: ^Page, width: int, height: int) -> (int, int, bool) {

--- a/font_cache/font_cache.odin
+++ b/font_cache/font_cache.odin
@@ -5,6 +5,7 @@
 package karl2d_font_cache
 
 import "base:runtime"
+import "../log"
 import "core:math"
 import "core:slice"
 import "core:unicode/utf8"
@@ -60,6 +61,17 @@ Skyline_Node :: struct {
 }
 
 init :: proc(font: ^Font, data: []u8, font_index: int, allocator: runtime.Allocator) -> bool {
+	num_fonts := int(stbtt.GetNumberOfFonts(raw_data(data)))
+
+	if num_fonts > 0 && (font_index < 0 || font_index >= num_fonts) {
+		log.errorf(
+			"Cannot load font index %v, the font data contains %v fonts",
+			font_index,
+			num_fonts,
+		)
+		return false
+	}
+
 	font^ = {
 		data = slice.clone(data, allocator),
 		glyphs = make(map[Glyph_Key]Glyph, allocator),
@@ -71,6 +83,7 @@ init :: proc(font: ^Font, data: []u8, font_index: int, allocator: runtime.Alloca
 	font_offset := stbtt.GetFontOffsetForIndex(raw_data(font.data), i32(font_index))
 
 	if !stbtt.InitFont(&font.info, raw_data(font.data), font_offset) {
+		log.error("Failed loading TTF/TTC font")
 		destroy(font)
 		return false
 	}

--- a/font_cache/font_cache.odin
+++ b/font_cache/font_cache.odin
@@ -23,7 +23,6 @@ Font_Cache :: struct {
 	glyphs: map[Glyph_Key]Glyph,
 	kerning: map[[2]i32]i32,
 	pages: [dynamic]Page,
-	frame: int,
 	allocator: runtime.Allocator,
 }
 
@@ -52,8 +51,8 @@ Page :: struct {
 	glyph_keys: [dynamic]Glyph_Key,
 	dirty_min: [2]int,
 	dirty_max: [2]int,
-	last_used: int,
-	reset_frame: int,
+	last_used: f64,
+	reset_time: f64,
 }
 
 Skyline_Node :: struct {
@@ -65,6 +64,7 @@ Skyline_Node :: struct {
 Text_Iterator :: struct {
 	text: string,
 	size: int,
+	time: f64,
 	x: f32,
 	y: f32,
 	prev_index: i32,
@@ -96,7 +96,6 @@ init :: proc(cache: ^Font_Cache, data: []u8, allocator: runtime.Allocator) -> bo
 		glyphs = make(map[Glyph_Key]Glyph, allocator),
 		kerning = make(map[[2]i32]i32, allocator),
 		pages = make([dynamic]Page, allocator),
-		frame = 1,
 		allocator = allocator,
 	}
 
@@ -124,11 +123,15 @@ destroy :: proc(cache: ^Font_Cache) {
 	cache^ = {}
 }
 
-new_frame :: proc(cache: ^Font_Cache) {
-	cache.frame += 1
-}
-
-get_glyph :: proc(cache: ^Font_Cache, codepoint: rune, size: int) -> (Glyph, bool) {
+get_glyph :: proc(
+	cache: ^Font_Cache,
+	codepoint: rune,
+	size: int,
+	time: f64,
+) -> (
+	Glyph,
+	bool,
+) {
 	key := Glyph_Key {
 		codepoint = codepoint,
 		size = size,
@@ -136,7 +139,7 @@ get_glyph :: proc(cache: ^Font_Cache, codepoint: rune, size: int) -> (Glyph, boo
 
 	if glyph, glyph_ok := cache.glyphs[key]; glyph_ok {
 		if glyph.width > 0 {
-			cache.pages[glyph.page].last_used = cache.frame
+			cache.pages[glyph.page].last_used = time
 		}
 
 		return glyph, true
@@ -200,7 +203,7 @@ get_glyph :: proc(cache: ^Font_Cache, codepoint: rune, size: int) -> (Glyph, boo
 			page.dirty_min.y = min(page.dirty_min.y, y)
 			page.dirty_max.x = max(page.dirty_max.x, x + padded_width)
 			page.dirty_max.y = max(page.dirty_max.y, y + padded_height)
-			page.last_used = cache.frame
+			page.last_used = time
 			append(&page.glyph_keys, key)
 			placed = true
 			break
@@ -215,7 +218,7 @@ get_glyph :: proc(cache: ^Font_Cache, codepoint: rune, size: int) -> (Glyph, boo
 	return glyph, true
 }
 
-make_room :: proc(cache: ^Font_Cache) -> bool {
+make_room :: proc(cache: ^Font_Cache, time: f64) -> bool {
 	newest := &cache.pages[len(cache.pages) - 1]
 
 	if newest.width < PAGE_MAX_SIZE {
@@ -253,7 +256,7 @@ make_room :: proc(cache: ^Font_Cache) -> bool {
 	oldest := -1
 
 	for page, page_idx in cache.pages {
-		if page.reset_frame == cache.frame {
+		if page.reset_time == time {
 			continue
 		}
 
@@ -281,7 +284,7 @@ make_room :: proc(cache: ^Font_Cache) -> bool {
 	slice.zero(page.pixels)
 	page.dirty_min = { page.width, page.height }
 	page.dirty_max = {}
-	page.reset_frame = cache.frame
+	page.reset_time = time
 	return true
 }
 
@@ -314,10 +317,11 @@ kern :: proc(cache: ^Font_Cache, prev_index: i32, index: i32, size: int) -> f32 
 	return f32(advance) * stbtt.ScaleForPixelHeight(&cache.info, f32(size))
 }
 
-text_iterator_init :: proc(text: string, size: int) -> Text_Iterator {
+text_iterator_init :: proc(text: string, size: int, time: f64) -> Text_Iterator {
 	return {
 		text = text,
 		size = size,
+		time = time,
 		prev_index = -1,
 	}
 }
@@ -351,7 +355,7 @@ text_iterator_next :: proc(
 			continue
 		}
 
-		glyph, glyph_ok := get_glyph(cache, codepoint, it.size)
+		glyph, glyph_ok := get_glyph(cache, codepoint, it.size, it.time)
 
 		if !glyph_ok {
 			return {}, .No_Room
@@ -377,8 +381,8 @@ text_iterator_next :: proc(
 	return {}, .Done
 }
 
-measure :: proc(cache: ^Font_Cache, text: string, size: int) -> ([2]f32, bool) {
-	it := text_iterator_init(text, size)
+measure :: proc(cache: ^Font_Cache, text: string, size: int, time: f64) -> ([2]f32, bool) {
+	it := text_iterator_init(text, size, time)
 	width: f32
 
 	placed_res := Text_Iterator_Result.Placed

--- a/font_cache/font_cache.odin
+++ b/font_cache/font_cache.odin
@@ -1,3 +1,5 @@
+// For dynamically building fonts.
+//
 // The skyline rectangle packing in this file is ported from Fontstash by Mikko Mononen. Fontstash
 // is licensed under the zlib license: https://github.com/memononen/fontstash
 package karl2d_font_cache
@@ -9,10 +11,11 @@ import "core:unicode/utf8"
 import stbtt "vendor:stb/truetype"
 
 PAGE_START_SIZE :: 256
-PAGE_MAX_SIZE :: 1024
+PAGE_MAX_SIZE :: 2048
 MAX_PAGES :: 4
 GLYPH_PADDING :: 1
 
+// You have one of these per font.
 Font_Cache :: struct {
 	info: stbtt.fontinfo,
 	data: []u8,
@@ -40,6 +43,7 @@ Glyph :: struct {
 	index: i32,
 }
 
+// A page will usually map to a texture. But the font cache doesn't know about textures.
 Page :: struct {
 	pixels: []u8,
 	width: int,

--- a/font_cache/font_cache.odin
+++ b/font_cache/font_cache.odin
@@ -59,7 +59,7 @@ Skyline_Node :: struct {
 	width: int,
 }
 
-init :: proc(font: ^Font, data: []u8, allocator: runtime.Allocator) -> bool {
+init :: proc(font: ^Font, data: []u8, font_index: int, allocator: runtime.Allocator) -> bool {
 	font^ = {
 		data = slice.clone(data, allocator),
 		glyphs = make(map[Glyph_Key]Glyph, allocator),
@@ -68,7 +68,7 @@ init :: proc(font: ^Font, data: []u8, allocator: runtime.Allocator) -> bool {
 		allocator = allocator,
 	}
 
-	font_offset := stbtt.GetFontOffsetForIndex(raw_data(font.data), 0)
+	font_offset := stbtt.GetFontOffsetForIndex(raw_data(font.data), i32(font_index))
 
 	if !stbtt.InitFont(&font.info, raw_data(font.data), font_offset) {
 		destroy(font)

--- a/font_cache/font_cache.odin
+++ b/font_cache/font_cache.odin
@@ -16,7 +16,7 @@ MAX_PAGES :: 4
 GLYPH_PADDING :: 1
 
 // You have one of these per font.
-Font_Cache :: struct {
+Font :: struct {
 	info: stbtt.fontinfo,
 	data: []u8,
 	ascent: f32,
@@ -61,7 +61,7 @@ Skyline_Node :: struct {
 	width: int,
 }
 
-Text_Iterator :: struct {
+Iterator :: struct {
 	text: string,
 	size: int,
 	time: f64,
@@ -76,13 +76,13 @@ Placed_Glyph :: struct {
 	y: f32,
 }
 
-Text_Iterator_Result :: enum {
+Iterator_Result :: enum {
 	Placed,
 	Done,
 	No_Room,
 }
 
-init :: proc(cache: ^Font_Cache, data: []u8, allocator: runtime.Allocator) -> bool {
+init :: proc(font: ^Font, data: []u8, allocator: runtime.Allocator) -> bool {
 	info: stbtt.fontinfo
 	font_offset := stbtt.GetFontOffsetForIndex(raw_data(data), 0)
 
@@ -90,7 +90,7 @@ init :: proc(cache: ^Font_Cache, data: []u8, allocator: runtime.Allocator) -> bo
 		return false
 	}
 
-	cache^ = {
+	font^ = {
 		info = info,
 		data = slice.clone(data, allocator),
 		glyphs = make(map[Glyph_Key]Glyph, allocator),
@@ -99,32 +99,32 @@ init :: proc(cache: ^Font_Cache, data: []u8, allocator: runtime.Allocator) -> bo
 		allocator = allocator,
 	}
 
-	cache.info.data = raw_data(cache.data)
+	font.info.data = raw_data(font.data)
 
 	ascent, descent, line_gap: i32
-	stbtt.GetFontVMetrics(&cache.info, &ascent, &descent, &line_gap)
-	cache.ascent = f32(ascent) / f32(ascent - descent)
+	stbtt.GetFontVMetrics(&font.info, &ascent, &descent, &line_gap)
+	font.ascent = f32(ascent) / f32(ascent - descent)
 
-	add_page(cache)
+	add_page(font)
 	return true
 }
 
-destroy :: proc(cache: ^Font_Cache) {
-	for page in cache.pages {
-		delete(page.pixels, cache.allocator)
+destroy :: proc(font: ^Font) {
+	for page in font.pages {
+		delete(page.pixels, font.allocator)
 		delete(page.nodes)
 		delete(page.glyph_keys)
 	}
 
-	delete(cache.pages)
-	delete(cache.glyphs)
-	delete(cache.kerning)
-	delete(cache.data, cache.allocator)
-	cache^ = {}
+	delete(font.pages)
+	delete(font.glyphs)
+	delete(font.kerning)
+	delete(font.data, font.allocator)
+	font^ = {}
 }
 
 get_glyph :: proc(
-	cache: ^Font_Cache,
+	font: ^Font,
 	codepoint: rune,
 	size: int,
 	time: f64,
@@ -137,27 +137,27 @@ get_glyph :: proc(
 		size = size,
 	}
 
-	if glyph, glyph_ok := cache.glyphs[key]; glyph_ok {
+	if glyph, glyph_ok := font.glyphs[key]; glyph_ok {
 		if glyph.width > 0 {
-			cache.pages[glyph.page].last_used = time
+			font.pages[glyph.page].last_used = time
 		}
 
 		return glyph, true
 	}
 
-	index := stbtt.FindGlyphIndex(&cache.info, codepoint)
-	scale := stbtt.ScaleForPixelHeight(&cache.info, f32(size))
+	index := stbtt.FindGlyphIndex(&font.info, codepoint)
+	scale := stbtt.ScaleForPixelHeight(&font.info, f32(size))
 
 	advance, left_side_bearing: i32
-	stbtt.GetGlyphHMetrics(&cache.info, index, &advance, &left_side_bearing)
+	stbtt.GetGlyphHMetrics(&font.info, index, &advance, &left_side_bearing)
 
 	x0, y0, x1, y1: i32
-	stbtt.GetGlyphBitmapBox(&cache.info, index, scale, scale, &x0, &y0, &x1, &y1)
+	stbtt.GetGlyphBitmapBox(&font.info, index, scale, scale, &x0, &y0, &x1, &y1)
 
 	glyph := Glyph {
 		offset = {
 			f32(x0 - GLYPH_PADDING),
-			f32(y0 - GLYPH_PADDING) + cache.ascent * f32(size),
+			f32(y0 - GLYPH_PADDING) + font.ascent * f32(size),
 		},
 		advance = f32(advance) * scale,
 		index = index,
@@ -172,7 +172,7 @@ get_glyph :: proc(
 	   padded_width <= PAGE_MAX_SIZE && padded_height <= PAGE_MAX_SIZE {
 		placed := false
 
-		for &page, page_idx in cache.pages {
+		for &page, page_idx in font.pages {
 			x, y, fits := page_add_rect(&page, padded_width, padded_height)
 
 			if !fits {
@@ -183,7 +183,7 @@ get_glyph :: proc(
 			bitmap_y := y + GLYPH_PADDING
 
 			stbtt.MakeGlyphBitmap(
-				&cache.info,
+				&font.info,
 				raw_data(page.pixels[bitmap_x + bitmap_y * page.width:]),
 				i32(bitmap_width),
 				i32(bitmap_height),
@@ -214,25 +214,25 @@ get_glyph :: proc(
 		}
 	}
 
-	cache.glyphs[key] = glyph
+	font.glyphs[key] = glyph
 	return glyph, true
 }
 
-make_room :: proc(cache: ^Font_Cache, time: f64) -> bool {
-	newest := &cache.pages[len(cache.pages) - 1]
+make_room :: proc(font: ^Font, time: f64) -> bool {
+	newest := &font.pages[len(font.pages) - 1]
 
 	if newest.width < PAGE_MAX_SIZE {
 		old_width := newest.width
 		old_height := newest.height
 		new_width := old_width * 2
 		new_height := old_height * 2
-		new_pixels := make([]u8, new_width * new_height, cache.allocator)
+		new_pixels := make([]u8, new_width * new_height, font.allocator)
 
 		for y in 0..<old_height {
 			copy(new_pixels[y * new_width:], newest.pixels[y * old_width:(y + 1) * old_width])
 		}
 
-		delete(newest.pixels, cache.allocator)
+		delete(newest.pixels, font.allocator)
 		newest.pixels = new_pixels
 		newest.width = new_width
 		newest.height = new_height
@@ -248,19 +248,19 @@ make_room :: proc(cache: ^Font_Cache, time: f64) -> bool {
 		return true
 	}
 
-	if len(cache.pages) < MAX_PAGES {
-		add_page(cache)
+	if len(font.pages) < MAX_PAGES {
+		add_page(font)
 		return true
 	}
 
 	oldest := -1
 
-	for page, page_idx in cache.pages {
+	for page, page_idx in font.pages {
 		if page.reset_time == time {
 			continue
 		}
 
-		if oldest == -1 || page.last_used < cache.pages[oldest].last_used {
+		if oldest == -1 || page.last_used < font.pages[oldest].last_used {
 			oldest = page_idx
 		}
 	}
@@ -269,10 +269,10 @@ make_room :: proc(cache: ^Font_Cache, time: f64) -> bool {
 		return false
 	}
 
-	page := &cache.pages[oldest]
+	page := &font.pages[oldest]
 
 	for key in page.glyph_keys {
-		delete_key(&cache.glyphs, key)
+		delete_key(&font.glyphs, key)
 	}
 
 	clear(&page.glyph_keys)
@@ -288,13 +288,13 @@ make_room :: proc(cache: ^Font_Cache, time: f64) -> bool {
 	return true
 }
 
-add_page :: proc(cache: ^Font_Cache) {
+add_page :: proc(font: ^Font) {
 	page := Page {
-		pixels = make([]u8, PAGE_START_SIZE * PAGE_START_SIZE, cache.allocator),
+		pixels = make([]u8, PAGE_START_SIZE * PAGE_START_SIZE, font.allocator),
 		width = PAGE_START_SIZE,
 		height = PAGE_START_SIZE,
-		nodes = make([dynamic]Skyline_Node, cache.allocator),
-		glyph_keys = make([dynamic]Glyph_Key, cache.allocator),
+		nodes = make([dynamic]Skyline_Node, font.allocator),
+		glyph_keys = make([dynamic]Glyph_Key, font.allocator),
 		dirty_min = { PAGE_START_SIZE, PAGE_START_SIZE },
 	}
 
@@ -302,22 +302,22 @@ add_page :: proc(cache: ^Font_Cache) {
 		width = PAGE_START_SIZE,
 	})
 
-	append(&cache.pages, page)
+	append(&font.pages, page)
 }
 
-kern :: proc(cache: ^Font_Cache, prev_index: i32, index: i32, size: int) -> f32 {
+kern :: proc(font: ^Font, prev_index: i32, index: i32, size: int) -> f32 {
 	pair := [2]i32 { prev_index, index }
-	advance, advance_ok := cache.kerning[pair]
+	advance, advance_ok := font.kerning[pair]
 
 	if !advance_ok {
-		advance = stbtt.GetGlyphKernAdvance(&cache.info, prev_index, index)
-		cache.kerning[pair] = advance
+		advance = stbtt.GetGlyphKernAdvance(&font.info, prev_index, index)
+		font.kerning[pair] = advance
 	}
 
-	return f32(advance) * stbtt.ScaleForPixelHeight(&cache.info, f32(size))
+	return f32(advance) * stbtt.ScaleForPixelHeight(&font.info, f32(size))
 }
 
-text_iterator_init :: proc(text: string, size: int, time: f64) -> Text_Iterator {
+iterator_init :: proc(text: string, size: int, time: f64) -> Iterator {
 	return {
 		text = text,
 		size = size,
@@ -326,13 +326,7 @@ text_iterator_init :: proc(text: string, size: int, time: f64) -> Text_Iterator 
 	}
 }
 
-text_iterator_next :: proc(
-	cache: ^Font_Cache,
-	it: ^Text_Iterator,
-) -> (
-	Placed_Glyph,
-	Text_Iterator_Result,
-) {
+iterate :: proc(font: ^Font, it: ^Iterator) -> (Placed_Glyph, Iterator_Result) {
 	for len(it.text) > 0 {
 		codepoint, codepoint_width := utf8.decode_rune(it.text)
 
@@ -355,7 +349,7 @@ text_iterator_next :: proc(
 			continue
 		}
 
-		glyph, glyph_ok := get_glyph(cache, codepoint, it.size, it.time)
+		glyph, glyph_ok := get_glyph(font, codepoint, it.size, it.time)
 
 		if !glyph_ok {
 			return {}, .No_Room
@@ -364,7 +358,7 @@ text_iterator_next :: proc(
 		it.text = it.text[codepoint_width:]
 
 		if it.prev_index != -1 {
-			it.x += kern(cache, it.prev_index, glyph.index, it.size)
+			it.x += kern(font, it.prev_index, glyph.index, it.size)
 		}
 
 		placed := Placed_Glyph {
@@ -381,14 +375,14 @@ text_iterator_next :: proc(
 	return {}, .Done
 }
 
-measure :: proc(cache: ^Font_Cache, text: string, size: int, time: f64) -> ([2]f32, bool) {
-	it := text_iterator_init(text, size, time)
+measure :: proc(font: ^Font, text: string, size: int, time: f64) -> ([2]f32, bool) {
+	it := iterator_init(text, size, time)
 	width: f32
 
-	placed_res := Text_Iterator_Result.Placed
+	placed_res := Iterator_Result.Placed
 
 	for placed_res == .Placed {
-		_, placed_res = text_iterator_next(cache, &it)
+		_, placed_res = iterate(font, &it)
 		width = max(width, it.x)
 	}
 

--- a/font_cache/font_cache.odin
+++ b/font_cache/font_cache.odin
@@ -19,7 +19,7 @@ Font :: struct {
 	info: stbtt.fontinfo,
 	data: []u8,
 	ascent: f32,
-	scale_per_pixel: f32,
+	height_units: f32,
 	glyphs: map[Glyph_Key]Glyph,
 	kerning: map[[2]i32]i32,
 	pages: [dynamic]Page,
@@ -50,7 +50,7 @@ Page :: struct {
 	dirty_min: [2]int,
 	dirty_max: [2]int,
 	last_used: f64,
-	reset_time: f64,
+	last_reset: f64,
 }
 
 Skyline_Node :: struct {
@@ -60,15 +60,7 @@ Skyline_Node :: struct {
 }
 
 init :: proc(font: ^Font, data: []u8, allocator: runtime.Allocator) -> bool {
-	info: stbtt.fontinfo
-	font_offset := stbtt.GetFontOffsetForIndex(raw_data(data), 0)
-
-	if !stbtt.InitFont(&info, raw_data(data), font_offset) {
-		return false
-	}
-
 	font^ = {
-		info = info,
 		data = slice.clone(data, allocator),
 		glyphs = make(map[Glyph_Key]Glyph, allocator),
 		kerning = make(map[[2]i32]i32, allocator),
@@ -76,12 +68,17 @@ init :: proc(font: ^Font, data: []u8, allocator: runtime.Allocator) -> bool {
 		allocator = allocator,
 	}
 
-	font.info.data = raw_data(font.data)
+	font_offset := stbtt.GetFontOffsetForIndex(raw_data(font.data), 0)
+
+	if !stbtt.InitFont(&font.info, raw_data(font.data), font_offset) {
+		destroy(font)
+		return false
+	}
 
 	ascent, descent, line_gap: i32
 	stbtt.GetFontVMetrics(&font.info, &ascent, &descent, &line_gap)
 	font.ascent = f32(ascent) / f32(ascent - descent)
-	font.scale_per_pixel = 1 / f32(ascent - descent)
+	font.height_units = f32(ascent - descent)
 
 	add_page(font)
 	return true
@@ -121,7 +118,7 @@ get_glyph :: proc(
 	}
 
 	index := stbtt.FindGlyphIndex(&font.info, codepoint)
-	scale := stbtt.ScaleForPixelHeight(&font.info, f32(size))
+	scale := f32(size) / font.height_units
 
 	advance, left_side_bearing: i32
 	stbtt.GetGlyphHMetrics(&font.info, index, &advance, &left_side_bearing)
@@ -231,7 +228,7 @@ make_room :: proc(font: ^Font, time: f64) -> bool {
 	oldest := -1
 
 	for page, page_idx in font.pages {
-		if page.reset_time == time {
+		if page.last_reset == time {
 			continue
 		}
 
@@ -259,7 +256,7 @@ make_room :: proc(font: ^Font, time: f64) -> bool {
 	slice.zero(page.pixels)
 	page.dirty_min = { page.width, page.height }
 	page.dirty_max = {}
-	page.reset_time = time
+	page.last_reset = time
 	return true
 }
 
@@ -289,7 +286,7 @@ kern :: proc(font: ^Font, prev_index: i32, index: i32, size: int) -> f32 {
 		font.kerning[pair] = advance
 	}
 
-	return f32(advance) * f32(size) * font.scale_per_pixel
+	return f32(advance) * (f32(size) / font.height_units)
 }
 
 // ---
@@ -396,7 +393,7 @@ measure :: proc(font: ^Font, text: string, size: int, time: f64) -> ([2]f32, boo
 	return { width, it.y + f32(size) }, place_res == .Done
 }
 
-page_add_rect :: proc(page: ^Page, width: int, height: int) -> (int, int, bool) {
+page_add_rect :: proc(page: ^Page, width: int, height: int) -> (x: int, y: int, ok: bool) {
 	best_width := page.width
 	best_height := page.height
 	best_idx := -1
@@ -405,15 +402,16 @@ page_add_rect :: proc(page: ^Page, width: int, height: int) -> (int, int, bool) 
 
 	// Bottom left fit heuristic.
 	for node, node_idx in page.nodes {
-		y := page_rect_fits(page^, node_idx, width, height)
+		fit_y := page_rect_fits(page^, node_idx, width, height)
 
-		if y != -1 {
-			if y + height < best_height || (y + height == best_height && node.width < best_width) {
+		if fit_y != -1 {
+			if fit_y + height < best_height ||
+			   (fit_y + height == best_height && node.width < best_width) {
 				best_idx = node_idx
 				best_width = node.width
-				best_height = y + height
+				best_height = fit_y + height
 				best_x = node.x
-				best_y = y
+				best_y = fit_y
 			}
 		}
 	}

--- a/font_cache/font_cache.odin
+++ b/font_cache/font_cache.odin
@@ -15,7 +15,6 @@ PAGE_MAX_SIZE :: 2048
 MAX_PAGES :: 4
 GLYPH_PADDING :: 1
 
-// You have one of these per font.
 Font :: struct {
 	info: stbtt.fontinfo,
 	data: []u8,
@@ -59,27 +58,6 @@ Skyline_Node :: struct {
 	x: int,
 	y: int,
 	width: int,
-}
-
-Iterator :: struct {
-	text: string,
-	size: int,
-	time: f64,
-	x: f32,
-	y: f32,
-	prev_index: i32,
-}
-
-Placed_Glyph :: struct {
-	glyph: Glyph,
-	x: f32,
-	y: f32,
-}
-
-Iterator_Result :: enum {
-	Placed,
-	Done,
-	No_Room,
 }
 
 init :: proc(font: ^Font, data: []u8, allocator: runtime.Allocator) -> bool {
@@ -317,7 +295,32 @@ kern :: proc(font: ^Font, prev_index: i32, index: i32, size: int) -> f32 {
 	return f32(advance) * stbtt.ScaleForPixelHeight(&font.info, f32(size))
 }
 
-place_text_iterator_init :: proc(text: string, size: int, time: f64) -> Iterator {
+// ---
+// ITERATOR FOR PLACING TEXT
+
+Place_Text_Iterator :: struct {
+	text: string,
+	size: int,
+	time: f64,
+	x: f32,
+	y: f32,
+	prev_index: i32,
+}
+
+Place_Text_Iterator_Result :: enum {
+	Placed,
+	Done,
+	No_Room,
+}
+
+// A glyph that has been placed by the iterator. The x and y are moved along as it iterates.
+Placed_Glyph :: struct {
+	glyph: Glyph,
+	x: f32,
+	y: f32,
+}
+
+place_text_iterator_init :: proc(text: string, size: int, time: f64) -> Place_Text_Iterator {
 	return {
 		text = text,
 		size = size,
@@ -326,7 +329,7 @@ place_text_iterator_init :: proc(text: string, size: int, time: f64) -> Iterator
 	}
 }
 
-place_text_iterate :: proc(font: ^Font, it: ^Iterator) -> (Placed_Glyph, Iterator_Result) {
+place_text_iterate :: proc(font: ^Font, it: ^Place_Text_Iterator) -> (Placed_Glyph, Place_Text_Iterator_Result) {
 	for len(it.text) > 0 {
 		codepoint, codepoint_width := utf8.decode_rune(it.text)
 
@@ -379,7 +382,7 @@ measure :: proc(font: ^Font, text: string, size: int, time: f64) -> ([2]f32, boo
 	it := place_text_iterator_init(text, size, time)
 	width: f32
 
-	placed_res := Iterator_Result.Placed
+	placed_res := Place_Text_Iterator_Result.Placed
 
 	for placed_res == .Placed {
 		_, placed_res = place_text_iterate(font, &it)

--- a/font_cache/font_cache.odin
+++ b/font_cache/font_cache.odin
@@ -11,8 +11,8 @@ import "core:unicode/utf8"
 import stbtt "vendor:stb/truetype"
 
 PAGE_START_SIZE :: 256
-PAGE_MAX_SIZE :: 2048
-MAX_PAGES :: 4
+PAGE_MAX_SIZE :: 1024
+MAX_PAGES :: 8
 GLYPH_PADDING :: 1
 
 Font :: struct {

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -1500,6 +1500,8 @@ Font_Options :: struct {
 	filter: Texture_Filter,
 }
 
+// TODO-UPDATE-COMMENT dynamic fonts use the `font_cache` package, not fontstash.
+// ---
 // Supported font types:
 // - Static: A pre-baked font where you specify a range of characters that are baked into a texture.
 // - Dynamic: A font where an atlas is continuously updated as you need need new characters. This
@@ -1515,19 +1517,20 @@ Font_Type :: enum {
 }
 
 Font_Data :: struct {
-	atlas: Texture,
 	options: Font_Options,
 
 	type: Font_Type,
 
 	// type == .Static
+	static_atlas: Texture,
 	static_glyphs: []Font_Baked_Glyph,
 	static_glyph_ranges: []Font_Baked_Glyph_Range,
 	static_font_size: f32,
 	static_line_spacing: f32,
 
 	// type == .Dynamic
-	dynamic_fontstash_handle: int,
+	dynamic_cache: fc.Font_Cache,
+	dynamic_pages: [dynamic]Texture,
 }
 
 Handle :: hm.Handle64
@@ -1860,8 +1863,6 @@ State :: struct {
 	render_backend: Render_Backend_Interface,
 	render_backend_state: rawptr,
 
-	fs: fs.FontContext,
-	
 	close_window_requested: bool,
 
 	// All events for this frame. Cleared when `process_events` run
@@ -1897,7 +1898,6 @@ State :: struct {
 	shape_drawing_texture: Texture_Handle,
 	// The settings the next draw call will be recorded with. Changing one of these does not affect
 	// draw calls that are already recorded.
-	current_font: Font,
 	current_camera: Maybe(Camera),
 	current_shader: Shader,
 	current_scissor: Maybe(Rect),

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -1529,7 +1529,7 @@ Font_Data :: struct {
 	static_line_spacing: f32,
 
 	// type == .Dynamic
-	dynamic_cache: fc.Font_Cache,
+	dynamic_font: fc.Font,
 	dynamic_pages: [dynamic]Texture,
 }
 

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -1500,12 +1500,10 @@ Font_Options :: struct {
 	filter: Texture_Filter,
 }
 
-// TODO-UPDATE-COMMENT dynamic fonts use the `font_cache` package, not fontstash.
-// ---
 // Supported font types:
 // - Static: A pre-baked font where you specify a range of characters that are baked into a texture.
-// - Dynamic: A font where an atlas is continuously updated as you need need new characters. This
-//            mode current uses fontstash.
+// - Dynamic: A font that is continuously updated as you need new characters. Each font can have up
+//            to four 2048x2048 textures (pages) filled with glyphs. Uses the `font_cache` package.
 //
 // Future types (TODO):
 // - Slug: Upload the character bezier curves to the GPU and render the text on the GPU without the

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -1503,7 +1503,7 @@ Font_Options :: struct {
 // Supported font types:
 // - Static: A pre-baked font where you specify a range of characters that are baked into a texture.
 // - Dynamic: A font that is continuously updated as you need new characters. Each font can have up
-//            to four 2048x2048 textures (pages) filled with glyphs. Uses the `font_cache` package.
+//            to eight 1024x1024 textures (pages) filled with glyphs. Uses the `font_cache` package.
 //
 // Future types (TODO):
 // - Slug: Upload the character bezier curves to the GPU and render the text on the GPU without the

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -1499,6 +1499,8 @@ Font_Options :: struct {
 	// Passed on to font atlas creation.
 	filter: Texture_Filter,
 
+	// Font formats like .ttc can contain multiple fonts. Use this parameter to pick one. For fonts
+	// that only contain a single font, leave this at zero.
 	font_index: int,
 }
 

--- a/karl2d.doc.odin
+++ b/karl2d.doc.odin
@@ -1498,6 +1498,8 @@ Font_Options :: struct {
 
 	// Passed on to font atlas creation.
 	filter: Texture_Filter,
+
+	font_index: int,
 }
 
 // Supported font types:

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -5862,6 +5862,8 @@ Font_Options :: struct {
 	// Passed on to font atlas creation.
 	filter: Texture_Filter,
 
+	// Font formats like .ttc can contain multiple fonts. Use this parameter to pick one. For fonts
+	// that only contain a single font, leave this at zero.
 	font_index: int,
 }
 

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -4759,21 +4759,9 @@ load_dynamic_font_from_bytes :: proc(
 	data: []u8,
 	options: Font_Options = {},
 ) -> (Font, bool) #optional_ok {
-	num_fonts := int(stbtt.GetNumberOfFonts(raw_data(data)))
-
-	if num_fonts > 0 && (options.font_index < 0 || options.font_index >= num_fonts) {
-		log.errorf(
-			"Cannot load font index %v, the font data contains %v fonts",
-			options.font_index,
-			num_fonts,
-		)
-		return FONT_NONE, false
-	}
-
 	dynamic_font: fc.Font
 
 	if !fc.init(&dynamic_font, data, options.font_index, s.allocator) {
-		log.error("Failed loading TTF/TTC font")
 		return FONT_NONE, false
 	}
 

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1659,7 +1659,7 @@ draw_text :: proc(
 		}
 
 		// `_font_render_size` will scale the font size by the camera zoom and round it to nearest
-		// pixel size. We'll ue `inv_render_scale` further down to cancel out the scale, since the
+		// pixel size. We'll use `inv_render_scale` further down to cancel out the scale, since the
 		// scaling happens in the camera.
 		render_size := _font_render_size(font_size)
 		inv_render_scale := font_size / f32(render_size)
@@ -1674,7 +1674,6 @@ draw_text :: proc(
 		}
 
 		// The font_cache iterator will go through the text and lay the letters out.
-
 		it := fc.place_text_iterator_init(text, render_size, s.time)
 
 		for {
@@ -7535,10 +7534,10 @@ _sync_font_pages :: proc(font: ^Font_Data) {
 }
 
 // For each dynamic font, this procedure updates the GPU-side atlases based on if the CPU-side
-// atlases have "dirty data". This means that there are areas on the CPU-side atlses that are not on
+// atlases have "dirty data". This means that there are areas on the CPU-side atlases that are not on
 // the GPU yet. This happens when `draw_text` uses previously unused glyphs.
-// 
-// Dynamic fonts use the font_cache. It maintains up to four 2048x2048 CPU-side atlases. This
+//
+// Dynamic fonts use the `font_cache` package. It maintains the CPU-side atlases (pages). This
 // procedure goes through the pages and checks if there are "dirty rects" set for any of them, which
 // means that that region of the GPU texture needs to be updated.
 //

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -5844,7 +5844,7 @@ Font_Options :: struct {
 // Supported font types:
 // - Static: A pre-baked font where you specify a range of characters that are baked into a texture.
 // - Dynamic: A font that is continuously updated as you need new characters. Each font can have up
-//            to four 2048x2048 textures (pages) filled with glyphs. Uses the `font_cache` package.
+//            to eight 1024x1024 textures (pages) filled with glyphs. Uses the `font_cache` package.
 //
 // Future types (TODO):
 // - Slug: Upload the character bezier curves to the GPU and render the text on the GPU without the

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1457,21 +1457,21 @@ measure_text :: proc(text: string, font_size: f32, font: Font = FONT_DEFAULT) ->
 
 		font_object := &s.fonts[font]
 
-		if len(font_object.dynamic_cache.pages) == 0 {
+		if len(font_object.dynamic_font.pages) == 0 {
 			return {}
 		}
 
 		render_size := _font_render_size(font_size)
-		size, size_ok := fc.measure(&font_object.dynamic_cache, text, render_size, s.time)
+		size, size_ok := fc.measure(&font_object.dynamic_font, text, render_size, s.time)
 
 		for !size_ok {
 			draw_current_batch()
 
-			if !fc.make_room(&font_object.dynamic_cache, s.time) {
+			if !fc.make_room(&font_object.dynamic_font, s.time) {
 				break
 			}
 
-			size, size_ok = fc.measure(&font_object.dynamic_cache, text, render_size, s.time)
+			size, size_ok = fc.measure(&font_object.dynamic_font, text, render_size, s.time)
 		}
 
 		return size * (font_size / f32(render_size))
@@ -1654,7 +1654,7 @@ draw_text :: proc(
 
 		font_object := &s.fonts[font]
 
-		if len(font_object.dynamic_cache.pages) == 0 {
+		if len(font_object.dynamic_font.pages) == 0 {
 			return
 		}
 
@@ -1680,10 +1680,10 @@ draw_text :: proc(
 			block_top += f32(count_text_lines(text))*font_size
 		}
 
-		it := fc.text_iterator_init(text, render_size, s.time)
+		it := fc.iterator_init(text, render_size, s.time)
 
 		for {
-			placed, placed_res := fc.text_iterator_next(&font_object.dynamic_cache, &it)
+			placed, placed_res := fc.iterate(&font_object.dynamic_font, &it)
 
 			if placed_res == .Done {
 				break
@@ -1692,7 +1692,7 @@ draw_text :: proc(
 			if placed_res == .No_Room {
 				draw_current_batch()
 
-				if !fc.make_room(&font_object.dynamic_cache, s.time) {
+				if !fc.make_room(&font_object.dynamic_font, s.time) {
 					break
 				}
 
@@ -4754,9 +4754,9 @@ load_dynamic_font_from_bytes :: proc(
 	data: []u8,
 	options: Font_Options = {},
 ) -> (Font, bool) #optional_ok {
-	cache: fc.Font_Cache
+	dynamic_font: fc.Font
 
-	if !fc.init(&cache, data, s.allocator) {
+	if !fc.init(&dynamic_font, data, s.allocator) {
 		log.error("Failed loading TTF/TTC font")
 		return FONT_NONE, false
 	}
@@ -4766,7 +4766,7 @@ load_dynamic_font_from_bytes :: proc(
 	append(&s.fonts, Font_Data {
 		type = .Dynamic,
 		options = options,
-		dynamic_cache = cache,
+		dynamic_font = dynamic_font,
 		dynamic_pages = make([dynamic]Texture, s.allocator),
 	})
 
@@ -4810,7 +4810,7 @@ destroy_font :: proc(font: Font) {
 
 		delete(f.dynamic_pages)
 		f.dynamic_pages = {}
-		fc.destroy(&f.dynamic_cache)
+		fc.destroy(&f.dynamic_font)
 	}
 }
 
@@ -5876,7 +5876,7 @@ Font_Data :: struct {
 	static_line_spacing: f32,
 
 	// type == .Dynamic
-	dynamic_cache: fc.Font_Cache,
+	dynamic_font: fc.Font,
 	dynamic_pages: [dynamic]Texture,
 }
 
@@ -7518,7 +7518,7 @@ _font_render_size :: proc(font_size: f32) -> int {
 }
 
 _sync_font_pages :: proc(font: ^Font_Data) {
-	for page, page_idx in font.dynamic_cache.pages {
+	for page, page_idx in font.dynamic_font.pages {
 		if page_idx == len(font.dynamic_pages) {
 			append(&font.dynamic_pages, Texture {})
 		}
@@ -7567,7 +7567,7 @@ _update_font_atlases :: proc() {
 			continue
 		}
 
-		for &page, page_idx in font.dynamic_cache.pages {
+		for &page, page_idx in font.dynamic_font.pages {
 			if page.dirty_max.x <= page.dirty_min.x || page.dirty_max.y <= page.dirty_min.y {
 				continue
 			}

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -4469,8 +4469,19 @@ load_static_font_from_bytes :: proc(
 	options: Font_Options = {},
 ) -> (_font: Font, _ok: bool) #optional_ok {
 	codepoints := codepoints
+	num_fonts := int(stbtt.GetNumberOfFonts(raw_data(data)))
+
+	if num_fonts > 0 && (options.font_index < 0 || options.font_index >= num_fonts) {
+		log.errorf(
+			"Cannot load font index %v, the font data contains %v fonts",
+			options.font_index,
+			num_fonts,
+		)
+		return
+	}
+
 	font_info: stbtt.fontinfo
-	font_offset := stbtt.GetFontOffsetForIndex(raw_data(data), 0)
+	font_offset := stbtt.GetFontOffsetForIndex(raw_data(data), i32(options.font_index))
 	init_ok := stbtt.InitFont(&font_info, raw_data(data), font_offset)
 
 	if !init_ok {
@@ -4748,9 +4759,20 @@ load_dynamic_font_from_bytes :: proc(
 	data: []u8,
 	options: Font_Options = {},
 ) -> (Font, bool) #optional_ok {
+	num_fonts := int(stbtt.GetNumberOfFonts(raw_data(data)))
+
+	if num_fonts > 0 && (options.font_index < 0 || options.font_index >= num_fonts) {
+		log.errorf(
+			"Cannot load font index %v, the font data contains %v fonts",
+			options.font_index,
+			num_fonts,
+		)
+		return FONT_NONE, false
+	}
+
 	dynamic_font: fc.Font
 
-	if !fc.init(&dynamic_font, data, s.allocator) {
+	if !fc.init(&dynamic_font, data, options.font_index, s.allocator) {
 		log.error("Failed loading TTF/TTC font")
 		return FONT_NONE, false
 	}
@@ -5839,6 +5861,8 @@ Font_Options :: struct {
 
 	// Passed on to font atlas creation.
 	filter: Texture_Filter,
+
+	font_index: int,
 }
 
 // Supported font types:

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -14,7 +14,7 @@ import "core:time"
 import "core:sync"
 import "core:encoding/endian"
 
-import fs "vendor:fontstash"
+import fc "font_cache"
 import stbv "vendor:stb/vorbis"
 import stbtt "vendor:stb/truetype"
 import stbrp "vendor:stb/rect_pack"
@@ -173,20 +173,11 @@ init :: proc(
 	s.default_shader = load_shader_from_bytes(rb.default_shader_vertex_source(), rb.default_shader_fragment_source())
 	s.current_shader = s.default_shader
 
-	// FontStash enables us to bake fonts from TTF files on-the-fly.
-	//
-	// Note that FontStash is always set up top-down, regardless of the coordinate system. The text
-	// drawing procedures lay glyphs out top-down and place the finished block themselves. That way
-	// the layout is identical in both coordinate systems.
-	fs.Init(&s.fs, FONT_DEFAULT_ATLAS_SIZE, FONT_DEFAULT_ATLAS_SIZE, .TOPLEFT)
-	fs.SetAlignVertical(&s.fs, .TOP)
-
 	// Dummy element so font with index 0 means 'no font'.
 	s.fonts = make([dynamic]Font_Data, s.allocator)
 	append_nothing(&s.fonts)
 	default_font := load_dynamic_font_from_bytes(DEFAULT_FONT_DATA)
 	log.assertf(default_font == FONT_DEFAULT, "Default font must be at index %i", FONT_DEFAULT)
-	_set_font(FONT_DEFAULT)
 
 	s.events = make([dynamic]Event, s.allocator)
 	s.typed_runes = make([dynamic]rune, s.allocator)
@@ -267,6 +258,13 @@ update :: proc() -> bool {
 	calculate_frame_time()
 	update_audio()
 	process_events()
+
+	for &font in s.fonts {
+		if font.type == .Dynamic {
+			fc.new_frame(&font.dynamic_cache)
+		}
+	}
+
 	return !close_window_requested()
 }
 
@@ -305,7 +303,6 @@ shutdown :: proc() {
 
 	pf.shutdown()
 
-	fs.Destroy(&s.fs)
 	delete(s.fonts)
 
 	delete(s.typed_runes)
@@ -1465,59 +1462,26 @@ measure_text :: proc(text: string, font_size: f32, font: Font = FONT_DEFAULT) ->
 			return {}
 		}
 
-		font_object := s.fonts[font]
+		font_object := &s.fonts[font]
 
-		// Temporary until I rewrite the font caching system.
-		_set_font(font)
-
-		// TextBounds from fontstash, but fixed and simplified for my purposes.
-		// The version in there is broken.
-		TextBounds :: proc(
-			ctx:  ^fs.FontContext,
-			font_idx: int,
-			size: f32,
-			text: string,
-		) -> Vec2 {
-			font  := fs.__getFont(ctx, font_idx)
-			isize := i16(size * 10)
-
-			x, y: f32
-			max_x := x
-
-			scale := fs.__getPixelHeightScale(font, f32(isize) / 10)
-			previousGlyphIndex: fs.Glyph_Index = -1
-			quad: fs.Quad
-			lines := 1
-
-			for codepoint in text {
-				if codepoint == '\n' {
-					x = 0
-					lines += 1
-					continue
-				}
-
-				if glyph, ok := fs.__getGlyph(ctx, font, codepoint, isize); ok {
-					if glyph.xadvance > 0 {
-						x += f32(int(f32(glyph.xadvance) / 10 + 0.5))
-					} else {
-						// updates x
-						fs.__getQuad(ctx, font, previousGlyphIndex, glyph, scale, 0, &x, &y, &quad)
-					}
-
-					if x > max_x {
-						max_x = x
-					}
-
-					previousGlyphIndex = glyph.index
-				} else {
-					previousGlyphIndex = -1
-				}
-
-			}
-			return { max_x, f32(lines)*size }
+		if len(font_object.dynamic_cache.pages) == 0 {
+			return {}
 		}
 
-		return TextBounds(&s.fs, font_object.dynamic_fontstash_handle, font_size, text)
+		render_size := _font_render_size(font_size)
+		size, size_ok := fc.measure(&font_object.dynamic_cache, text, render_size)
+
+		for !size_ok {
+			draw_current_batch()
+
+			if !fc.make_room(&font_object.dynamic_cache) {
+				break
+			}
+
+			size, size_ok = fc.measure(&font_object.dynamic_cache, text, render_size)
+		}
+
+		return size * (font_size / f32(render_size))
 	}
 
 }
@@ -1653,7 +1617,7 @@ draw_text :: proc(
 				char_origin := origin + position - { glyph_x, glyph_y }
 
 				draw_texture_fit(
-					font_object.atlas,
+					font_object.static_atlas,
 					src,
 					dst,
 					tint = color,
@@ -1695,19 +1659,23 @@ draw_text :: proc(
 			return
 		}
 
-		_set_font(font)
 		font_object := &s.fonts[font]
 
-		camera_zoom: f32 = 1
-
-		if cam, cam_ok := s.current_camera.?; cam_ok && cam.zoom > 0.001 {
-			camera_zoom = cam.zoom
+		if len(font_object.dynamic_cache.pages) == 0 {
+			return
 		}
 
+		// TODO-UPDATE-COMMENT the size is rounded to whole pixels in `_font_render_size`, and the
+		// quads are scaled by `world_scale` instead of divided by the zoom.
+		// ---
 		// Bake the glyph at font_size*camera_zoom pixels so it is sharp at the current zoom level.
 		// We then divide quad positions back by camera_zoom to recover world-space coordinates.
-		render_size := font_size * camera_zoom
+		render_size := _font_render_size(font_size)
+		world_scale := font_size / f32(render_size)
+		_sync_font_pages(font_object)
 
+		// TODO-UPDATE-COMMENT the layout comes from the font cache's text iterator.
+		// ---
 		// FontStash lays the text out top-down starting at (0, 0), so its quads come out as offsets
 		// from the top-left of the text block. This is where that corner goes. With flipped Y
 		// `position` is the bottom-left corner of the block, so the top is a whole block higher. The
@@ -1719,39 +1687,42 @@ draw_text :: proc(
 			block_top += f32(count_text_lines(text))*font_size
 		}
 
-		fs.SetSize(&s.fs, render_size)
-		iter := fs.TextIterInit(&s.fs, 0, 0, text)
+		it := fc.text_iterator_init(text, render_size)
 
-		q: fs.Quad
-		for fs.TextIterNext(&s.fs, &iter, &q) {
-			if iter.codepoint == '\n' {
-				iter.nexty += render_size
-				iter.nextx = 0
+		for {
+			placed, placed_res := fc.text_iterator_next(&font_object.dynamic_cache, &it)
+
+			if placed_res == .Done {
+				break
+			}
+
+			if placed_res == .No_Room {
+				draw_current_batch()
+
+				if !fc.make_room(&font_object.dynamic_cache) {
+					break
+				}
+
+				_sync_font_pages(font_object)
 				continue
 			}
 
-			if iter.codepoint == '\t' {
-				iter.nextx += 2*render_size
+			g := placed.glyph
+
+			if g.width == 0 {
 				continue
 			}
 
 			src := Rect {
-				q.s0, q.t0,
-				q.s1 - q.s0, q.t1 - q.t0,
+				f32(g.x), f32(g.y),
+				f32(g.width), f32(g.height),
 			}
 
-			w := f32(FONT_DEFAULT_ATLAS_SIZE)
-			h := f32(FONT_DEFAULT_ATLAS_SIZE)
-			src.x *= w
-			src.y *= h
-			src.w *= w
-			src.h *= h
-
 			// Unscale quad positions from render-size space back to text-local world units.
-			offset_from_left := q.x0 / camera_zoom
-			offset_from_top := q.y0 / camera_zoom
-			glyph_w := (q.x1 - q.x0) / camera_zoom
-			glyph_h := (q.y1 - q.y0) / camera_zoom
+			offset_from_left := placed.x * world_scale
+			offset_from_top := placed.y * world_scale
+			glyph_w := f32(g.width) * world_scale
+			glyph_h := f32(g.height) * world_scale
 
 			glyph_y := y_up ? block_top - offset_from_top - glyph_h : block_top + offset_from_top
 
@@ -1762,7 +1733,14 @@ draw_text :: proc(
 			dst := Rect { position.x, position.y, glyph_w, glyph_h }
 			char_origin := origin + position - { glyph_x, glyph_y }
 
-			draw_texture_fit(font_object.atlas, src, dst, char_origin, rotation, color)
+			draw_texture_fit(
+				font_object.dynamic_pages[g.page],
+				src,
+				dst,
+				char_origin,
+				rotation,
+				color,
+			)
 		}
 	}
 
@@ -4738,9 +4716,9 @@ load_static_font_from_bytes :: proc(
 	set_texture_filter(tex, options.filter)
 
 	font := Font_Data {
-		atlas = tex,
 		type = .Static,
 		options = options,
+		static_atlas = tex,
 		static_glyphs = slice.clone(glyphs[:], s.allocator),
 		static_glyph_ranges = slice.clone(glyph_ranges[:], s.allocator),
 		static_font_size = font_size,
@@ -4783,41 +4761,22 @@ load_dynamic_font_from_bytes :: proc(
 	data: []u8,
 	options: Font_Options = {},
 ) -> (Font, bool) #optional_ok {
-	font_info: stbtt.fontinfo
-	font_offset := stbtt.GetFontOffsetForIndex(raw_data(data), 0)
-	init_ok := stbtt.InitFont(&font_info, raw_data(data), font_offset)
+	cache: fc.Font_Cache
 
-	if !init_ok {
+	if !fc.init(&cache, data, s.allocator) {
 		log.error("Failed loading TTF/TTC font")
 		return FONT_NONE, false
 	}
 
-	fontstash_handle := fs.AddFontMem(&s.fs, "", slice.clone(data, s.allocator), false)
 	h := Font(len(s.fonts))
 
-	atlas_texture, atlas_texture_ok := rb.create_texture(
-		FONT_DEFAULT_ATLAS_SIZE,
-		FONT_DEFAULT_ATLAS_SIZE,
-		.RGBA_8_Norm,
-	)
-
-	if !atlas_texture_ok {
-		return FONT_NONE, false
-	}
-
-	data := Font_Data {
-		dynamic_fontstash_handle = fontstash_handle,
-		atlas = {
-			handle = atlas_texture,
-			width = FONT_DEFAULT_ATLAS_SIZE,
-			height = FONT_DEFAULT_ATLAS_SIZE,
-		},
+	append(&s.fonts, Font_Data {
 		type = .Dynamic,
 		options = options,
-	}
+		dynamic_cache = cache,
+		dynamic_pages = make([dynamic]Texture, s.allocator),
+	})
 
-	set_texture_filter(data.atlas, options.filter)
-	append(&s.fonts, data)
 	return h, true
 }
 
@@ -4842,24 +4801,24 @@ destroy_font :: proc(font: Font) {
 
 	f := &s.fonts[font]
 
-	// Recorded draw calls may still be waiting to sample this font's atlas.
-	_flush_if_batch_uses_texture(f.atlas.handle)
-	rb.destroy_texture(f.atlas.handle)
-
-	// So `_update_font_atlases` stops uploading glyphs to a texture that is gone.
-	f.atlas = {}
-
 	switch f.type {
 	case .Static:
+		// Recorded draw calls may still be waiting to sample this font's atlas.
+		_flush_if_batch_uses_texture(f.static_atlas.handle)
+		rb.destroy_texture(f.static_atlas.handle)
+		f.static_atlas = {}
 		delete(f.static_glyphs, s.allocator)
 		delete(f.static_glyph_ranges, s.allocator)
 	case .Dynamic:
-		// TODO fontstash has no "destroy font" proc... I should make my own version of fontstash
-		delete(s.fs.fonts[f.dynamic_fontstash_handle].glyphs)
-		delete(s.fs.fonts[f.dynamic_fontstash_handle].loadedData, s.allocator)
-		s.fs.fonts[f.dynamic_fontstash_handle].glyphs = {}
-	}
+		for page in f.dynamic_pages {
+			_flush_if_batch_uses_texture(page.handle)
+			rb.destroy_texture(page.handle)
+		}
 
+		delete(f.dynamic_pages)
+		f.dynamic_pages = {}
+		fc.destroy(&f.dynamic_cache)
+	}
 }
 
 @(deprecated="Use FONT_DEFAULT constant instead")
@@ -5895,6 +5854,8 @@ Font_Options :: struct {
 	filter: Texture_Filter,
 }
 
+// TODO-UPDATE-COMMENT dynamic fonts use the `font_cache` package, not fontstash.
+// ---
 // Supported font types:
 // - Static: A pre-baked font where you specify a range of characters that are baked into a texture.
 // - Dynamic: A font where an atlas is continuously updated as you need need new characters. This
@@ -5910,19 +5871,20 @@ Font_Type :: enum {
 }
 
 Font_Data :: struct {
-	atlas: Texture,
 	options: Font_Options,
 
 	type: Font_Type,
 
 	// type == .Static
+	static_atlas: Texture,
 	static_glyphs: []Font_Baked_Glyph,
 	static_glyph_ranges: []Font_Baked_Glyph_Range,
 	static_font_size: f32,
 	static_line_spacing: f32,
 
 	// type == .Dynamic
-	dynamic_fontstash_handle: int,
+	dynamic_cache: fc.Font_Cache,
+	dynamic_pages: [dynamic]Texture,
 }
 
 Handle :: hm.Handle64
@@ -6255,8 +6217,6 @@ State :: struct {
 	render_backend: Render_Backend_Interface,
 	render_backend_state: rawptr,
 
-	fs: fs.FontContext,
-	
 	close_window_requested: bool,
 
 	// All events for this frame. Cleared when `process_events` run
@@ -6292,7 +6252,6 @@ State :: struct {
 	shape_drawing_texture: Texture_Handle,
 	// The settings the next draw call will be recorded with. Changing one of these does not affect
 	// draw calls that are already recorded.
-	current_font: Font,
 	current_camera: Maybe(Camera),
 	current_shader: Shader,
 	current_scissor: Maybe(Rect),
@@ -7555,8 +7514,53 @@ _camera_flip_y :: proc() -> bool {
 	return false
 }
 
-FONT_DEFAULT_ATLAS_SIZE :: 2048
+_font_render_size :: proc(font_size: f32) -> int {
+	camera_zoom: f32 = 1
 
+	if cam, cam_ok := s.current_camera.?; cam_ok && cam.zoom > 0.001 {
+		camera_zoom = cam.zoom
+	}
+
+	return max(1, int(math.round(font_size * camera_zoom)))
+}
+
+_sync_font_pages :: proc(font: ^Font_Data) {
+	for page, page_idx in font.dynamic_cache.pages {
+		if page_idx == len(font.dynamic_pages) {
+			append(&font.dynamic_pages, Texture {})
+		}
+
+		texture := &font.dynamic_pages[page_idx]
+
+		if texture.width == page.width && texture.height == page.height {
+			continue
+		}
+
+		if texture.handle != TEXTURE_NONE {
+			rb.destroy_texture(texture.handle)
+		}
+
+		handle, handle_ok := rb.create_texture(page.width, page.height, .RGBA_8_Norm)
+
+		if !handle_ok {
+			log.errorf("Failed creating %vx%v font atlas texture", page.width, page.height)
+			texture^ = {}
+			continue
+		}
+
+		texture^ = {
+			handle = handle,
+			width = page.width,
+			height = page.height,
+		}
+
+		set_texture_filter(texture^, font.options.filter)
+	}
+}
+
+// TODO-UPDATE-COMMENT each dynamic font has its own cache with one or more pages, each page has a
+// texture and a dirty rect. A page is only ever wiped after the batch has been flushed.
+// ---
 // Gets glyphs that were baked since the last flush onto the GPU. Drawing text with a dynamic font
 // bakes the glyphs it needs into fontstash's atlas as it goes. This has to run before the draw
 // calls that use them. Fontstash only ever puts glyphs in unused parts of the atlas. Texture
@@ -7565,81 +7569,56 @@ FONT_DEFAULT_ATLAS_SIZE :: 2048
 // Every dynamic font shares one fontstash atlas. Each has its own GPU texture mirroring it. They
 // all get the same update.
 _update_font_atlases :: proc() {
-	font_dirty_rect: [4]f32
-
-	if !fs.ValidateTexture(&s.fs, &font_dirty_rect) {
-		return
-	}
-
-	for font in s.fonts {
-		// A static font has a finished atlas of its own, it is not part of fontstash's. A
-		// destroyed font has no atlas left at all.
-		if font.type == .Dynamic && font.atlas.handle != TEXTURE_NONE {
-			_update_font_atlas(font, font_dirty_rect)
+	for &font in s.fonts {
+		if font.type != .Dynamic {
+			continue
 		}
-	}
-}
 
-_update_font_atlas :: proc(font: Font_Data, font_dirty_rect: [4]f32) {
-	tw := FONT_DEFAULT_ATLAS_SIZE
-	fdr := font_dirty_rect
-
-	r := Rect {
-		fdr[0],
-		fdr[1],
-		fdr[2] - fdr[0],
-		fdr[3] - fdr[1],
-	}
-
-	x := int(r.x)
-	y := int(r.y)
-	w := int(fdr[2]) - int(fdr[0])
-	h := int(fdr[3]) - int(fdr[1])
-
-	expanded_pixels := make([]Color, w * h, frame_allocator)
-	start := x + tw * y
-
-	for i in 0..<w*h {
-		px := i%w
-		py := i/w
-
-		dst_pixel_idx := (px) + (py * w)
-		src_pixel_idx := start + (px) + (py * tw)
-
-		src := s.fs.textureData[src_pixel_idx]
-
-		if font.options.premultiply_alpha {
-			a := f32(src) / 255
-			expanded_pixels[dst_pixel_idx] = {
-				u8(f32(src) * a),
-				u8(f32(src) * a),
-				u8(f32(src) * a),
-				src,
+		for &page, page_idx in font.dynamic_cache.pages {
+			if page.dirty_max.x <= page.dirty_min.x || page.dirty_max.y <= page.dirty_min.y {
+				continue
 			}
-		} else {
-			expanded_pixels[dst_pixel_idx] = {255,255,255, src}
+
+			if page_idx >= len(font.dynamic_pages) {
+				continue
+			}
+
+			texture := font.dynamic_pages[page_idx]
+
+			if texture.handle == TEXTURE_NONE {
+				continue
+			}
+
+			x := page.dirty_min.x
+			y := page.dirty_min.y
+			w := page.dirty_max.x - x
+			h := page.dirty_max.y - y
+			pixels := make([]Color, w * h, frame_allocator)
+
+			for i in 0..<w*h {
+				px := i%w
+				py := i/w
+				alpha := page.pixels[(x + px) + (y + py) * page.width]
+
+				if font.options.premultiply_alpha {
+					pixels[i] = { alpha, alpha, alpha, alpha }
+				} else {
+					pixels[i] = { 255, 255, 255, alpha }
+				}
+			}
+
+			r := Rect {
+				f32(x),
+				f32(y),
+				f32(w),
+				f32(h),
+			}
+
+			rb.update_texture(texture.handle, slice.reinterpret([]u8, pixels), r)
+			page.dirty_min = { page.width, page.height }
+			page.dirty_max = {}
 		}
 	}
-
-	rb.update_texture(font.atlas.handle, slice.reinterpret([]u8, expanded_pixels), r)
-}
-
-// Not for direct use. Specify font to `draw_text_ex`
-_set_font :: proc(fh: Font) {
-	fh := fh
-
-	if s.current_font == fh {
-		return
-	}
-
-	s.current_font = fh
-
-	if fh == 0 {
-		fh = FONT_DEFAULT
-	}
-
-	font := &s.fonts[fh]
-	fs.SetFont(&s.fs, font.dynamic_fontstash_handle)
 }
 
 _ :: jpeg

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -258,13 +258,6 @@ update :: proc() -> bool {
 	calculate_frame_time()
 	update_audio()
 	process_events()
-
-	for &font in s.fonts {
-		if font.type == .Dynamic {
-			fc.new_frame(&font.dynamic_cache)
-		}
-	}
-
 	return !close_window_requested()
 }
 
@@ -1469,16 +1462,16 @@ measure_text :: proc(text: string, font_size: f32, font: Font = FONT_DEFAULT) ->
 		}
 
 		render_size := _font_render_size(font_size)
-		size, size_ok := fc.measure(&font_object.dynamic_cache, text, render_size)
+		size, size_ok := fc.measure(&font_object.dynamic_cache, text, render_size, s.time)
 
 		for !size_ok {
 			draw_current_batch()
 
-			if !fc.make_room(&font_object.dynamic_cache) {
+			if !fc.make_room(&font_object.dynamic_cache, s.time) {
 				break
 			}
 
-			size, size_ok = fc.measure(&font_object.dynamic_cache, text, render_size)
+			size, size_ok = fc.measure(&font_object.dynamic_cache, text, render_size, s.time)
 		}
 
 		return size * (font_size / f32(render_size))
@@ -1687,7 +1680,7 @@ draw_text :: proc(
 			block_top += f32(count_text_lines(text))*font_size
 		}
 
-		it := fc.text_iterator_init(text, render_size)
+		it := fc.text_iterator_init(text, render_size, s.time)
 
 		for {
 			placed, placed_res := fc.text_iterator_next(&font_object.dynamic_cache, &it)
@@ -1699,7 +1692,7 @@ draw_text :: proc(
 			if placed_res == .No_Room {
 				draw_current_batch()
 
-				if !fc.make_room(&font_object.dynamic_cache) {
+				if !fc.make_room(&font_object.dynamic_cache, s.time) {
 					break
 				}
 

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1658,27 +1658,22 @@ draw_text :: proc(
 			return
 		}
 
-		// TODO-UPDATE-COMMENT the size is rounded to whole pixels in `_font_render_size`, and the
-		// quads are scaled by `world_scale` instead of divided by the zoom.
-		// ---
-		// Bake the glyph at font_size*camera_zoom pixels so it is sharp at the current zoom level.
-		// We then divide quad positions back by camera_zoom to recover world-space coordinates.
+		// `_font_render_size` will scale the font size by the camera zoom and round it to nearest
+		// pixel size. We'll ue `inv_render_scale` further down to cancel out the scale, since the
+		// scaling happens in the camera.
 		render_size := _font_render_size(font_size)
-		world_scale := font_size / f32(render_size)
+		inv_render_scale := font_size / f32(render_size)
 		_sync_font_pages(font_object)
 
-		// TODO-UPDATE-COMMENT the layout comes from the font cache's text iterator.
-		// ---
-		// FontStash lays the text out top-down starting at (0, 0), so its quads come out as offsets
-		// from the top-left of the text block. This is where that corner goes. With flipped Y
-		// `position` is the bottom-left corner of the block, so the top is a whole block higher. The
-		// height must agree with what `measure_text_dynamic` reports, which is `lines * font_size`.
 		y_up := _camera_flip_y()
 		block_top := position.y
 
+		// In Y up mode the top of the text block is offset by its total height.
 		if y_up {
 			block_top += f32(count_text_lines(text))*font_size
 		}
+
+		// The font_cache iterator will go through the text and lay the letters out.
 
 		it := fc.place_text_iterator_init(text, render_size, s.time)
 
@@ -1712,10 +1707,10 @@ draw_text :: proc(
 			}
 
 			// Unscale quad positions from render-size space back to text-local world units.
-			offset_from_left := placed.x * world_scale
-			offset_from_top := placed.y * world_scale
-			glyph_w := f32(g.width) * world_scale
-			glyph_h := f32(g.height) * world_scale
+			offset_from_left := placed.x * inv_render_scale
+			offset_from_top := placed.y * inv_render_scale
+			glyph_w := f32(g.width) * inv_render_scale
+			glyph_h := f32(g.height) * inv_render_scale
 
 			glyph_y := y_up ? block_top - offset_from_top - glyph_h : block_top + offset_from_top
 
@@ -5847,12 +5842,10 @@ Font_Options :: struct {
 	filter: Texture_Filter,
 }
 
-// TODO-UPDATE-COMMENT dynamic fonts use the `font_cache` package, not fontstash.
-// ---
 // Supported font types:
 // - Static: A pre-baked font where you specify a range of characters that are baked into a texture.
-// - Dynamic: A font where an atlas is continuously updated as you need need new characters. This
-//            mode current uses fontstash.
+// - Dynamic: A font that is continuously updated as you need new characters. Each font can have up
+//            to four 2048x2048 textures (pages) filled with glyphs. Uses the `font_cache` package.
 //
 // Future types (TODO):
 // - Slug: Upload the character bezier curves to the GPU and render the text on the GPU without the
@@ -7541,16 +7534,15 @@ _sync_font_pages :: proc(font: ^Font_Data) {
 	}
 }
 
-// TODO-UPDATE-COMMENT each dynamic font has its own cache with one or more pages, each page has a
-// texture and a dirty rect. A page is only ever wiped after the batch has been flushed.
-// ---
-// Gets glyphs that were baked since the last flush onto the GPU. Drawing text with a dynamic font
-// bakes the glyphs it needs into fontstash's atlas as it goes. This has to run before the draw
-// calls that use them. Fontstash only ever puts glyphs in unused parts of the atlas. Texture
-// coordinates already recorded in the vertex buffer therefore stay valid.
+// For each dynamic font, this procedure updates the GPU-side atlases based on if the CPU-side
+// atlases have "dirty data". This means that there are areas on the CPU-side atlses that are not on
+// the GPU yet. This happens when `draw_text` uses previously unused glyphs.
+// 
+// Dynamic fonts use the font_cache. It maintains up to four 2048x2048 CPU-side atlases. This
+// procedure goes through the pages and checks if there are "dirty rects" set for any of them, which
+// means that that region of the GPU texture needs to be updated.
 //
-// Every dynamic font shares one fontstash atlas. Each has its own GPU texture mirroring it. They
-// all get the same update.
+// This is run before any draw call that depends on these glyphs is submitted.
 _update_font_atlases :: proc() {
 	for &font in s.fonts {
 		if font.type != .Dynamic {

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -4760,8 +4760,19 @@ load_dynamic_font_from_bytes :: proc(
 	options: Font_Options = {},
 ) -> (Font, bool) #optional_ok {
 	dynamic_font: fc.Font
+	init_err := fc.init(&dynamic_font, data, options.font_index, s.allocator)
 
-	if !fc.init(&dynamic_font, data, options.font_index, s.allocator) {
+	switch init_err {
+	case .None:
+	case .Font_Index_Out_Of_Range:
+		log.errorf(
+			"Cannot load font index %v, the font data contains %v fonts",
+			options.font_index,
+			stbtt.GetNumberOfFonts(raw_data(data)),
+		)
+		return FONT_NONE, false
+	case .Invalid_Font_Data:
+		log.error("Failed loading TTF/TTC font")
 		return FONT_NONE, false
 	}
 

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1680,10 +1680,10 @@ draw_text :: proc(
 			block_top += f32(count_text_lines(text))*font_size
 		}
 
-		it := fc.iterator_init(text, render_size, s.time)
+		it := fc.place_text_iterator_init(text, render_size, s.time)
 
 		for {
-			placed, placed_res := fc.iterate(&font_object.dynamic_font, &it)
+			placed, placed_res := fc.place_text_iterate(&font_object.dynamic_font, &it)
 
 			if placed_res == .Done {
 				break
@@ -7533,21 +7533,11 @@ _sync_font_pages :: proc(font: ^Font_Data) {
 			rb.destroy_texture(texture.handle)
 		}
 
-		handle, handle_ok := rb.create_texture(page.width, page.height, .RGBA_8_Norm)
+		texture^ = create_texture(page.width, page.height, .RGBA_8_Norm)
 
-		if !handle_ok {
-			log.errorf("Failed creating %vx%v font atlas texture", page.width, page.height)
-			texture^ = {}
-			continue
+		if texture.handle != TEXTURE_NONE {
+			set_texture_filter(texture^, font.options.filter)
 		}
-
-		texture^ = {
-			handle = handle,
-			width = page.width,
-			height = page.height,
-		}
-
-		set_texture_filter(texture^, font.options.filter)
 	}
 }
 

--- a/karl2d.odin
+++ b/karl2d.odin
@@ -1683,13 +1683,13 @@ draw_text :: proc(
 		it := fc.place_text_iterator_init(text, render_size, s.time)
 
 		for {
-			placed, placed_res := fc.place_text_iterate(&font_object.dynamic_font, &it)
+			placed, place_res := fc.place_text_iterate(&font_object.dynamic_font, &it)
 
-			if placed_res == .Done {
+			if place_res == .Done {
 				break
 			}
 
-			if placed_res == .No_Room {
+			if place_res == .No_Room {
 				draw_current_batch()
 
 				if !fc.make_room(&font_object.dynamic_font, s.time) {


### PR DESCRIPTION
Custom font cache instead of using fontstash. It supports multiple textures per font. Each font can have up to 8 1024x1024 textures. If it runs out of textures, then it clear the one that has least recently been used for drawing.

Also rounds scaled font size to nearest integer. This is actually the biggest win. It makes the system waste a lot less texture space.

The new code is about 1.5x faster than the old code.

Also fixes an old bug where the dynamic font atlas didn't grow properly, which was the original cause of the text breaking when the atlas got full.

Fixes #63 

## Testing and reviewing
- [x] Platform agnostic code reviewed

Tested on:
- [x] Windows
- [ ] Mac
- [x] Web
- [x] Linux